### PR TITLE
make css entries configurable

### DIFF
--- a/etc/webpack.base.js
+++ b/etc/webpack.base.js
@@ -5,7 +5,7 @@ var config = require('../lib/config');
 
 module.exports = new WebpackConfig().merge({
   entry: [
-    'normalize.css',
+    ...config.cssAdditionalEntry,
     config.appRoot
   ],
   output: {
@@ -35,3 +35,4 @@ module.exports = new WebpackConfig().merge({
     packageMains: ['webpack', 'browser', 'web', 'browserify', 'style', 'main']
   }
 });
+

--- a/etc/webpack.base.js
+++ b/etc/webpack.base.js
@@ -4,10 +4,9 @@ var WebpackConfig = require('webpack-config');
 var config = require('../lib/config');
 
 module.exports = new WebpackConfig().merge({
-  entry: [
-    ...config.cssAdditionalEntry,
+  entry: config.cssShared.concat([
     config.appRoot
-  ],
+  ]),
   output: {
     path: config.distDir,
     publicPath: '/',

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,7 +12,7 @@ module.exports = {
   appRoot: appRoot.toString(),
   cssFile: (process.env.NODE_ENV === 'production') ? 'bundle.css' : null,
   cssName: '[name]-[local]-[hash:base64:5]',
-  cssAdditionalEntry: [],
+  cssShared: [],
   distDir: appRoot.resolve('dist'),
   jsFile: 'bundle.js',
   noBabel: /node_modules\/(?!es-)/,

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ module.exports = {
   appRoot: appRoot.toString(),
   cssFile: (process.env.NODE_ENV === 'production') ? 'bundle.css' : null,
   cssName: '[name]-[local]-[hash:base64:5]',
+  cssAdditionalEntry: [],
   distDir: appRoot.resolve('dist'),
   jsFile: 'bundle.js',
   noBabel: /node_modules\/(?!es-)/,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "postversion": "git push && git push --tags"
   },
   "contributors": [
-    "dmbch <daniel@dmbch.net> (https://www.xing.com/profile/Daniel_Dembach)"
+    "dmbch <daniel@dmbch.net> (https://www.xing.com/profile/Daniel_Dembach)",
+    "TobiasKrogh <tobias@krogh.de> (https://www.xing.com/profile/Tobias_Krogh)",
+    "matthias-reis <mr@smartr.de> (https://www.xing.com/profile/Matthias_Reis3)"
   ],
   "license": "MIT",
   "homepage": "https://github.com/xing/hops",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "file-loader": "0.8.5",
     "json-loader": "0.5.4",
     "mkdirp": "0.5.1",
-    "normalize.css": "4.0.0",
     "postcss": "5.0.19",
     "postcss-cssnext": "2.5.2",
     "postcss-loader": "0.8.2",


### PR DESCRIPTION
This pr gets rid of the direct dependency to "normalize.css" and instead makes this part configurable by the application.

Simply pass the dependencies as an array in `.hopsrc.js`, key: `cssAdditionalEntry`, default: `[]`