### PR TITLE
Adds postinstall script

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const shell = require('shelljs');
+const normalizeData = require('normalize-package-data');
+
+const config = require('../lib/config');
+const pkgPath = path.join(config.appRoot, 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath));
+
+normalizeData(pkg);
+
+const scripts = Object.assign({}, { start: 'hops' }, pkg.scripts);
+const babel = Object.assign({}, { extends: 'hops/etc/babel' }, pkg.babel);
+const main = pkg.main || 'src/main.js';
+
+fs.writeFileSync(
+  pkgPath,
+  JSON.stringify(Object.assign({}, pkg, { main, scripts, babel }), null, 2)
+);
+
+const tryCopy = (file) => {
+  try {
+    fs.accessSync(file.path, fs.F_OK);
+  } catch (e) {
+    shell.cp('-R', file.origin, file.destination);
+  }
+};
+
+const projectPath = (pathname) => path.join(config.appRoot, pathname);
+
+const template = [
+  {
+    path: config.srcDir,
+    origin: path.join('app', 'src'),
+    destination: path.join('..', '..')
+  },
+  {
+    path: projectPath('.eslintrc.js'),
+    origin: path.join('app', '.eslintrc.js'),
+    destination: config.appRoot
+  },
+  {
+    path: projectPath('.stylelintrc.js'),
+    origin: path.join('app', '.stylelintrc.js'),
+    destination: config.appRoot
+  }
+];
+
+template.forEach(tryCopy);

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,14 @@ var ejs = require('ejs');
 var templatePath = path.resolve(__dirname, 'template.html');
 var templateString = fs.readFileSync(templatePath, 'utf8');
 
+var srcDir;
+
+try {
+  srcDir = path.dirname(require.resolve(appRoot.toString()));
+} catch (e) {
+  srcDir = path.join(appRoot.toString(), 'src');
+}
+
 module.exports = {
   appRoot: appRoot.toString(),
   cssFile: (process.env.NODE_ENV === 'production') ? 'bundle.css' : null,
@@ -21,7 +29,7 @@ module.exports = {
   require: appRoot.require,
   resolve: appRoot.resolve,
   shells: ['/'],
-  srcDir: path.dirname(require.resolve(appRoot.toString())),
+  srcDir: srcDir,
   webpackDev: path.resolve(__dirname, '..', 'etc', 'webpack.dev.js'),
   webpackBuild: path.resolve(__dirname, '..', 'etc', 'webpack.build.js')
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "files": [
     "bin",
     "etc",
-    "lib"
+    "lib",
+    "app"
   ],
   "bin": {
     "hops": "bin/hops.js"
@@ -24,12 +25,14 @@
     "pretest": "rm -rf app/{dist,node_modules/hops} && cd app && npm install",
     "test": "tape spec/**/*.js | tap-min",
     "preversion": "npm test",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "install": "node bin/setup.js"
   },
   "contributors": [
     "dmbch <daniel@dmbch.net> (https://www.xing.com/profile/Daniel_Dembach)",
     "TobiasKrogh <tobias@krogh.de> (https://www.xing.com/profile/Tobias_Krogh)",
-    "matthias-reis <mr@smartr.de> (https://www.xing.com/profile/Matthias_Reis3)"
+    "matthias-reis <mr@smartr.de> (https://www.xing.com/profile/Matthias_Reis3)",
+    "rcsole <ricardsolecasas@gmail.com> (https://www.xing.com/profile/Ricard_soleCasas)"
   ],
   "license": "MIT",
   "homepage": "https://github.com/xing/hops",
@@ -65,6 +68,7 @@
     "file-loader": "0.8.5",
     "json-loader": "0.5.4",
     "mkdirp": "0.5.1",
+    "normalize-package-data": "^2.3.5",
     "postcss": "5.0.19",
     "postcss-cssnext": "2.5.2",
     "postcss-loader": "0.8.2",

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,23 @@ a look at our [example app](https://github.com/xing/hops/tree/master/app).
 npm install -SE hops
 ```
 
+A postinstall script will try to create the following: `.eslintrc.js`,
+`.stylelintrc.js`. It will also try to find your _source directory_, which comes
+from trying to resolve where your _main_ file is in your `package.json`. If there
+is no _main_ it will add some defaults to your `package.json`:
+
+```json
+{
+  "main": "src/main.js"
+}
+```
+
+Your `scripts` and `babel` values will be merged with the examples in the
+[configure](https://github.com/rcsole/hops/tree/postinstall-scripts#configure)
+section, your prior settings will always take preference. Finally, if it couldn't
+match your _source directory_, it will copy a boilerplate example which you can find
+in this project under `app/src`.
+
 ### Configure
 
 **package.json**


### PR DESCRIPTION
Adds a postinstall script which will try to create some boilerplate, so you can easily
do something like:

```sh
mkdir my-app && cd my-app
npm init && npm i hops -SE
npm start
```

And just have it work.