### PR TITLE
Include external serviceworker

### DIFF
--- a/etc/webpack.base.js
+++ b/etc/webpack.base.js
@@ -1,12 +1,12 @@
+
 var WebpackConfig = require('webpack-config');
 
 var config = require('../lib/config');
 
 module.exports = new WebpackConfig().merge({
-  entry: [
-    ...config.cssShared,
+  entry: config.cssShared.concat([
     config.appRoot
-  ],
+  ]),
   output: {
     path: config.distDir,
     publicPath: '/',

--- a/etc/webpack.base.js
+++ b/etc/webpack.base.js
@@ -1,12 +1,12 @@
-
 var WebpackConfig = require('webpack-config');
 
 var config = require('../lib/config');
 
 module.exports = new WebpackConfig().merge({
-  entry: config.cssShared.concat([
+  entry: [
+    ...config.cssShared,
     config.appRoot
-  ]),
+  ],
   output: {
     path: config.distDir,
     publicPath: '/',

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,4 @@
+
 var fs = require('fs');
 var path = require('path');
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs');
 var path = require('path');
 
@@ -20,6 +19,8 @@ module.exports = {
   render: ejs.compile(templateString),
   require: appRoot.require,
   resolve: appRoot.resolve,
+  serviceWorker: null,
+  serviceWorkerFile: null,
   shells: ['/'],
   srcDir: path.dirname(require.resolve(appRoot.toString())),
   webpackDev: path.resolve(__dirname, '..', 'etc', 'webpack.dev.js'),

--- a/lib/node.js
+++ b/lib/node.js
@@ -43,6 +43,7 @@ function render(options) {
   return config.render(Object.assign({}, options, {
     css: config.cssFile,
     js: config.jsFile,
+    sw: config.serviceWorker,
     state: options.store.getState(),
     body: ReactDOM.renderToString(
       React.createElement(ReactRedux.Provider, { store: options.store },

--- a/lib/node.js
+++ b/lib/node.js
@@ -43,7 +43,7 @@ function render(options) {
   return config.render(Object.assign({}, options, {
     css: config.cssFile,
     js: config.jsFile,
-    sw: config.serviceWorker,
+    sw: config.serviceWorker && process.env.NODE_ENV === 'production',
     state: options.store.getState(),
     body: ReactDOM.renderToString(
       React.createElement(ReactRedux.Provider, { store: options.store },

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -20,7 +20,7 @@ if (render.__esModule) { // eslint-disable-line no-underscore-dangle
 }
 
 function getFileName(url, distDir) {
-  var segments = url.split('/').filter(function (segment) {
+  var segments = url.split('/').filter(function(segment) {
     return segment.length;
   });
   if (!segments.length || segments[segments.length - 1].indexOf('.') === -1) {
@@ -30,18 +30,34 @@ function getFileName(url, distDir) {
   return path.join.apply(path, segments);
 }
 
+function copyServiceWorkerToDist() {
+  if (config.serviceWorkerFile) {
+
+    const source = path.resolve(config.appRoot, config.serviceWorkerFile);
+    const dest = path.resolve(config.distDir, config.serviceWorker);
+    mkdirp(path.dirname(dest), function(err) {
+      if (err) {
+        throw err;
+      }
+      else {
+        fs.createReadStream(source).pipe(fs.createWriteStream(dest));
+      }
+    });
+  }
+}
+
 function renderShells() {
-  config.shells.forEach(function (url) {
+  config.shells.forEach(function(url) {
     var fileName = getFileName(url, config.distDir);
-    render(url).then(function (body) {
-      mkdirp(path.dirname(fileName), function (err) {
+    render(url).then(function(body) {
+      mkdirp(path.dirname(fileName), function(err) {
         if (err) { throw err; }
         else {
           fs.writeFile(fileName, body);
         }
       });
     })
-    .catch(function (err) {
+    .catch(function(err) {
        /* eslint-disable no-console */
       console.error(err);
       console.trace();
@@ -50,8 +66,13 @@ function renderShells() {
   });
 }
 
-module.exports = renderShells;
+function runTask() {
+  copyServiceWorkerToDist();
+  renderShells();
+}
+
+module.exports = runTask;
 
 if (require.main === module) {
-  renderShells();
+  runTask();
 }

--- a/lib/template.html
+++ b/lib/template.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <% if (css) { %><link rel="stylesheet" href="/<%= css %>" /><% } %>
+    <% if (sw) { %>
+      <script>
+        if ('serviceWorker' in navigator) {
+          navigator.serviceWorker.register('/<%= sw %>');
+        }
+      </script>
+    <% } %>
+
   </head>
   <body>
     <main><% if (body) { %><%- body %><% } %></main>


### PR DESCRIPTION
This pr enables the hops config to hand over an external service worker to the hops app.

Config values:
`serviceWorker`: Url to use (e.g. `/my-shared-assets/sw.js`) = possibly not part of the project (centralized asset server path) - if `null` (default), no serviceworker is included
`serviceWorkerFile`: Optional - a service worker can be part of the project. In this case, you can point this config to a js file, which is copied to `/dist/{serviceWorker}` in the prerender step. (So this config depends on the serviceWorker config)

Addition:
We restricted the delivery of a service worker to production mode (see https://github.com/xing/hops/pull/6/commits/77e7333c1a5f123d4dfa4e17f2f20fc67a86ff75). Service Workers are not really suitable for HMR and other dev features.