### PR TITLE
Enables Redux DevTools Chrome extension

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -9,6 +9,15 @@ function isFunc(object) {
   return (typeof object === 'function');
 }
 
+function devTools () {
+  if (typeof window === 'object'
+      && typeof window.devToolsExtension !== 'undefined') {
+    return window.devToolsExtension();
+  } else {
+    return function (f) { return f; };
+  }
+}
+
 module.exports = {
   createReducer: function (key) {
     var type = 'update' + key.charAt(0).toUpperCase() + key.slice(1);
@@ -41,9 +50,12 @@ module.exports = {
     reducer = isFunc(reducer) ? reducer : Redux.combineReducers(
       Object.assign({}, reducer, { routing: ReactRouterRedux.routerReducer })
     );
-    enhancer = isFunc(enhancer) ? enhancer : Redux.applyMiddleware(
-      ReduxThunkMiddleware,
-      ReactRouterRedux.routerMiddleware(history)
+    enhancer = isFunc(enhancer) ? enhancer : Redux.compose(
+      Redux.applyMiddleware(
+        ReduxThunkMiddleware,
+        ReactRouterRedux.routerMiddleware(history)
+      ),
+      devTools()
     );
     var store = Redux.createStore(reducer, initialState, enhancer);
     return Object.assign(store, {


### PR DESCRIPTION
Redux DevTools was not being able to access the store because we needed
to set it up. This closes #7.