### PR TITLE
Adds the .pcss extension to the CSS loader test

### DIFF
--- a/etc/webpack.build.js
+++ b/etc/webpack.build.js
@@ -11,7 +11,7 @@ var baseConfig = path.join(__dirname, 'webpack.base');
 module.exports = new WebpackConfig().extend(baseConfig).merge({
   module: {
     loaders: [{
-      test: /\.css$/,
+      test: /\.(css|pcss)$/,
       loader: ExtractTextPlugin.extract(
         'style',
         'css?modules&localIdentName=' + config.cssName + '&importLoaders=1!postcss'

--- a/etc/webpack.dev.js
+++ b/etc/webpack.dev.js
@@ -9,7 +9,7 @@ var baseConfig = path.join(__dirname, 'webpack.base');
 module.exports = new WebpackConfig().extend(baseConfig).merge({
   module: {
     loaders: [{
-      test: /\.css$/,
+      test: /\.(css|pcss)$/,
       loaders: [
         'style',
         'css?sourceMap&modules&localIdentName=' + config.cssName + '&importLoaders=1',


### PR DESCRIPTION
I personally prefer `.pcss` extension ever since @rudeworks showed it to
me, as it gives me cool syntax highlighting in some editors (eg. VS Code).