### PR TITLE
Add jsdoc & documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 tmp
 .tmp
 coverage
+docs
 node_modules
 npm-debug.log
 .DS_Store

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,5 +1,6 @@
 .tmp
 dist
+docs
 node_modules
 npm-debug.log
 .DS_Store

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,1 @@
+# Hello hops

--- a/app/jsdoc.json
+++ b/app/jsdoc.json
@@ -1,0 +1,25 @@
+{
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": ["jsdoc"]
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
+  "templates": {
+    "cleverLinks": true,
+    "monospaceLinks": true
+  },
+  "source": {
+    "include": ["src", "README.md", "package.json"],
+    "includePattern": "\\.js$",
+    "excludePattern": "(node_modules/|docs)"
+  },
+  "opts": {
+    "encoding": "utf8",
+    "destination": "docs/",
+    "private": true,
+    "recurse": true,
+    "template": "node_modules/hopsdoc"
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,8 @@
     "start": "[ \"$NODE_ENV\" != \"production\" ] && npm run watch || npm run build",
     "watch": "webpack-dev-server --hot --config webpack.config.js",
     "build": "webpack --progress --config webpack.config.js",
-    "test": "mocha-webpack --reporter hops/reporter --webpack-config webpack.config.js \"src/**/*.test.js\""
+    "test": "mocha-webpack --reporter hops/reporter --webpack-config webpack.config.js \"src/**/*.test.js\"",
+    "docs": "rm -rf docs; jsdoc -c jsdoc.json"
   },
   "dependencies": {
     "hops": "file:.."

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,3 +1,20 @@
+/**
+ * @module Main module
+ * @file demo file with default hops app
+ * @summary hops demo app
+ * @description 
+ *   Very simple example app for hops.
+ *   The app folder acts as template root for new hops apps
+ * @name src/main
+ * @exports Home
+ * @exports select
+ * @exports update
+ * @exports routes
+ * @exports render
+ * @author Daniel Dembach <daniel@dmbch.net>
+ * @author Gregor Adams <greg@pixelass.com>
+ */
+
 
 import React, { createClass, PropTypes } from 'react';
 import { Route } from 'react-router';
@@ -12,18 +29,46 @@ const select = register('home', (state = {}, action) => (
     {}, state, { greeting: action.payload }
   )
 ));
+/**
+ * @const select
+ * @const update
+ */
 const update = (payload) => ({ type: 'updateGreeting', payload });
-
+/**
+ * simple hello hops
+ * @const Home
+ */
 const Home = connect(select, { update })(
+
+  // create a React class with display name and propTypes
   createClass({
     displayName: 'Home',
     propTypes: {
       greeting: PropTypes.string,
       update: PropTypes.func
     },
+    /**
+     * @summary React.js internal method
+     * @description 
+     *    method is executed when component has been mounted
+     *    when mounted set the greeting to "Hello World"
+     *    uses redux's immutability helpers
+     * @method Home/componentDidMount
+     * @name componentDidMount
+     * @alias Home/componentDidMount
+     * @private
+     */
     componentDidMount() {
       this.props.update('Hello World!');
     },
+    /**
+     * render the view
+     * @method render
+     * @private
+     * @return {HTMLElement}         returns an h1 with the headline styles.
+     *                               the geeting is internaly set when the component
+     *                               is mounted {@link module:src/main~componentDidMount}
+     */
     render() {
       return (
         <h1 className={ headline }>{ this.props.greeting }</h1>
@@ -32,9 +77,14 @@ const Home = connect(select, { update })(
   })
 );
 
+/**
+ * global routes
+ * @const routes
+ */
 const routes = (
   <Route path='/' component={ Home }/>
 );
+
 
 export default render({ routes });
 export { Home };

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -36,7 +36,7 @@ const select = register('home', (state = {}, action) => (
 const update = (payload) => ({ type: 'updateGreeting', payload });
 /**
  * simple hello hops
- * @const Home
+ * @class Home
  */
 const Home = connect(select, { update })(
 
@@ -56,6 +56,7 @@ const Home = connect(select, { update })(
      * @method Home/componentDidMount
      * @name componentDidMount
      * @alias Home/componentDidMount
+     * @memberof module:src/main~Home
      * @private
      */
     componentDidMount() {
@@ -65,9 +66,10 @@ const Home = connect(select, { update })(
      * render the view
      * @method render
      * @private
+     * @memberof module:src/main~Home
      * @return {HTMLElement}         returns an h1 with the headline styles.
      *                               the geeting is internaly set when the component
-     *                               is mounted {@link module:src/main~componentDidMount}
+     *                               is mounted {@link module:src/main~Home.componentDidMount}
      */
     render() {
       return (

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * @module setup
+ * @author Somebody <somebody@foo.bar>
+ */
 
 var fs = require('fs');
 var path = require('path');
@@ -9,7 +13,15 @@ var root = require('app-root-path').toString();
 var pkgPath = path.resolve(root, 'package.json');
 var pkg = require(pkgPath);
 
+/**
+ * default test string for comparison
+ * @type {String}
+ */
 var defaultTest = 'echo "Error: no test specified" && exit 1';
+/**
+ * hops test is used if no test is specified
+ * @type {String}
+ */
 var hopsTest = 'mocha-webpack --reporter hops/reporter --webpack-config webpack.config.js "src/**/*.test.js"';
 
 Object.assign(pkg, {
@@ -18,14 +30,17 @@ Object.assign(pkg, {
     {
       start: '[ "$NODE_ENV" != "production" ] && npm run watch || npm run build',
       watch: 'webpack-dev-server --hot --config webpack.config.js',
-      build: 'webpack --progress --config webpack.config.js'
+      build: 'webpack --progress --config webpack.config.js',
+      docs: 'rm -rf docs; jsdoc -c jsdoc.json'
     },
     pkg.scripts,
     {
       test: (pkg.scripts.test === defaultTest) ? hopsTest : pkg.scripts.test
     }
   ),
-  babel: Object.assign({ extends: 'hops/etc/babel' }, pkg.babel)
+  babel: Object.assign({
+    extends: 'hops/etc/babel'
+  }, pkg.babel)
 });
 
 var srcDir = path.resolve(__dirname, '..', 'app');
@@ -39,6 +54,9 @@ var template = [{
   source: path.join(srcDir, '.stylelintrc.js'),
   destination: path.join(root, '.stylelintrc.js')
 }, {
+  origin: path.join(srcDir, 'jsdoc.json'),
+  destination: path.join(root, 'jsdoc.json')
+}, {
   source: path.join(srcDir, 'webpack.config.js'),
   destination: path.join(root, 'webpack.config.js')
 }];
@@ -49,7 +67,7 @@ function configure() {
 }
 
 function bootstrap() {
-  template.forEach(function (file) {
+  template.forEach(function(file) {
     if (!shell.test('-e', file.destination)) {
       var destDir = path.dirname(file.destination);
       shell.mkdir('-p', destDir);
@@ -60,7 +78,7 @@ function bootstrap() {
 }
 
 function isBootstrapped() {
-  var index = template.findIndex(function (file) {
+  var index = template.findIndex(function(file) {
     return shell.test('-e', file.destination);
   });
   return index >= 0;

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,26 @@
+{
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": ["jsdoc"]
+  },
+  "plugins": [
+    "plugins/markdown",
+    "plugins/summarize"
+  ],
+  "templates": {
+    "cleverLinks": true,
+    "monospaceLinks": true
+  },
+  "source": {
+    "include": ["lib", "bin", "plugin", "package.json", "README.md"],
+    "includePattern": "\\.js$",
+    "excludePattern": "(node_modules/|docs)"
+  },
+  "opts": {
+    "encoding": "utf8",
+    "destination": "./docs/",
+    "private": true,
+    "recurse": true,
+    "template": "node_modules/hopsdoc"
+  }
+}

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,8 +4,7 @@
     "dictionaries": ["jsdoc"]
   },
   "plugins": [
-    "plugins/markdown",
-    "plugins/summarize"
+    "plugins/markdown"
   ],
   "templates": {
     "cleverLinks": true,

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,3 +1,13 @@
+/**
+ * @module lib/browser
+ * @file lib/browser
+ * @name lib/browser
+ * @exports render
+ * @exports register
+ * @author Daniel Dembach <daniel@dmbch.net>
+ * @author Gregor Adams <greg@pixelass.com>
+ */
+
 /* istanbul ignore if */
 if (!global.Object.assign) {
   global.Object.assign = require('babel-runtime/core-js/object/assign').default;
@@ -14,14 +24,49 @@ var ReactRedux = require('react-redux');
 
 var defaults = require('./defaults');
 
-exports.render = function (overrides) {
+/**
+ * hops' main function:
+ *
+ * * creates a [Redux](https://github.com/reactjs/redux) store
+ * * sets up [React Router](https://github.com/reactjs/react-router)
+ * * handles rendering both in the browser and in node.
+ *
+ * Using it is mandatory and its output must be the default export of
+ * your main module. And it's a little magic.
+ * In addition to `routes` and `reducers`, an html `mountPoint`
+ * selector and some othes may be passed as options.
+ *
+ * @public
+ * @type Function
+ * @param  {Object} overrides - overrides something
+ * @param  {String} [overrides.mountPoint] - querySelector of mount point
+ * @param  {String} [overrides.title] - title of app
+ * @param  {Route} [overrides.routes] - routes of app
+ * @param  {Object} [overrides.initialState] - global initial state
+ * @param  {History} [overrides.history] - browser history
+ * @return {Function} returns a function to render the app
+ *                            inside the hops wrapper if not `module.hot` execute
+ * @example
+ * import { render } from 'hops';
+ * import { routes } from './routes';
+ * export default render({ routes });
+ */
+exports.render = function(overrides) {
+  /**
+   * return function
+   * @return {HTMLElement} the mount point
+   */
   function render() {
     var options = Object.assign({}, defaults, overrides);
     var store = options.createStore(options);
     var mountPoint = document.querySelector(options.mountPoint);
     ReactDOM.render(
-      React.createElement(ReactRedux.Provider, { store: store },
-        React.createElement(ReactRouter.Router, { history: store.history },
+      React.createElement(ReactRedux.Provider, {
+        store: store
+      },
+        React.createElement(ReactRouter.Router, {
+          history: store.history
+        },
           options.routes
         )
       ),
@@ -32,4 +77,12 @@ exports.render = function (overrides) {
   return (module.hot) ? render : render();
 };
 
+/**
+ * register namespaces see {@link module:lib/store~register}
+ * @type {Function|module:lib/store~register}
+ * @public
+ * @example
+ * import { register } from 'hops';
+ * export const { select, update } = register('foo');
+ */
 exports.register = require('./store').register;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,4 +1,22 @@
+/**
+ * @module defaults
+ * @exports mountPoint
+ * @exports title
+ * @exports routes
+ * @exports initialState
+ * @exports createStore
+ * @exports history
+ * @author Somebody <somebody@foo.bar>
+ */
 
+/**
+ * assign defaults to exports
+ * @property  {String} [mountPoint] - querySelector of mount point
+ * @property  {String} [title] - title of app
+ * @property  {Route} [routes] - routes of app
+ * @property  {Object} [initialState] - global initial state
+ * @property  {History} [history] - browser history
+ */
 Object.assign(exports, {
   mountPoint: 'main',
   routes: null,

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,3 +1,9 @@
+/**
+ * @module node
+ * @exports render
+ * @exports register
+ * @author Somebody <somebody@foo.bar>
+ */
 
 var React = require('react');
 var ReactDOM = require('react-dom/server');
@@ -6,6 +12,12 @@ var ReactRedux = require('react-redux');
 
 var defaults = require('./defaults');
 
+/**
+ * match options via router
+ * @private
+ * @param  {Object} options options to match
+ * @return {Promise} returns a promise
+ */
 function match(options) {
   return new Promise(function(resolve, reject) {
     ReactRouter.match(
@@ -26,6 +38,12 @@ function match(options) {
   });
 }
 
+/**
+ * fetch options from store
+ * @private
+ * @param  {Object} options options
+ * @return {Promise} returns a promise
+ */
 function fetch(options) {
   var store = options.createStore(options);
   var dispatch = store.dispatch.bind(store);
@@ -38,6 +56,12 @@ function fetch(options) {
   });
 }
 
+/**
+ * server render function
+ * @private
+ * @param  {Object} options options
+ * @return {Object} returns render object
+ */
 function render(options) {
   return {
     state: JSON.stringify(Object.assign(
@@ -51,6 +75,7 @@ function render(options) {
     )
   };
 }
+
 
 exports.render = function (overrides) {
   return function (location, tweaks) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,8 +1,21 @@
+/**
+ * @module lib/store
+ * @exports createContext
+ * @author Daniel Dembach <daniel@dmbch.net>
+ * @author Gregor Adams <greg@pixelass.com>
+ */
+
 
 var ReactRouterRedux = require('react-router-redux');
 var Redux = require('redux');
 var ReduxThunkMiddleware = require('redux-thunk').default;
 
+/**
+ * create a global store
+ * @param  {Array} reducers - list of reducers
+ * @param  {Object} options  custom options
+ * @return {Object}          history merged with store
+ */
 function createStore(reducers, options) {
   var store = Redux.createStore(
     Redux.combineReducers(reducers),
@@ -12,7 +25,7 @@ function createStore(reducers, options) {
         ReduxThunkMiddleware,
         ReactRouterRedux.routerMiddleware(options.history)
       ),
-      global.devToolsExtension ? global.devToolsExtension() : function (f) {
+      global.devToolsExtension ? global.devToolsExtension() : function(f) {
         return f;
       }
     )
@@ -25,22 +38,59 @@ function createStore(reducers, options) {
   });
 }
 
+/**
+ * create a context for a reducer
+ * @type {Function}
+ * @name createContext
+ * @namespace createContext
+ * @param  {Function} reducers - the reducer function
+ * @return {Object}          returns the methods
+ */
 function createContext(reducers) {
   reducers = reducers || {
     routing: ReactRouterRedux.routerReducer
   };
   var store;
   return {
-    register: function (namespace, reducer) {
+    /**
+     * `register()` is a helper to streamline store/state interactions in hops
+     * based projects. If passed only a `namespace` string, a generic reducer
+     * using React's [immutability helpers](https://facebook.github.io/react/docs/update.html)
+     * is created for that namespace. It's return value is an object containing
+     * a selector function for use in ReactRedux' `connect()` and a generic action
+     * creator (`update()`) working with the update reducer.
+     * @typedef {Function} module:lib/store~register
+     * @param  {String} namespace - namespace for the reducer
+     * @param  {Function} reducer - the reducer function to register in hops
+     * @return {Function}           returns a function to return the state of the current namespace
+     */
+    register: function(namespace, reducer) {
       reducers[namespace] = reducer;
       if (store) {
         store.replaceReducer(Redux.combineReducers(reducers));
       }
-      return function (state) { return state[namespace]; };
+      return function(state) {
+        return state[namespace];
+      };
+
     },
-    createStore: function (options) {
+    /**
+     * return the current store otherwise return a new one
+     * @memberof {module:lib/store~createStore}
+     * @param  {Object} [options] - options for store registration
+     *                            this param is only needed for creating a new store
+     * @return {Object}         returns the global store
+     */
+    createStore: function(options) {
       return store || (store = createStore(reducers, options));
     },
+    /**
+     * mainly a debugging feature that could be 
+     * used advanced operations {@link module:lib/store~createContext}
+     * @memberof {module:lib/store~createContext}
+     * @type {module:lib/store~createContext}
+     * 
+    */
     createContext: createContext
   };
 }

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,7 @@
 /**
  * @module lib/store
+ * @file lib/store
+ * @name lib/store
  * @exports createContext
  * @author Daniel Dembach <daniel@dmbch.net>
  * @author Gregor Adams <greg@pixelass.com>
@@ -9,6 +11,7 @@
 var ReactRouterRedux = require('react-router-redux');
 var Redux = require('redux');
 var ReduxThunkMiddleware = require('redux-thunk').default;
+
 
 /**
  * create a global store
@@ -42,7 +45,6 @@ function createStore(reducers, options) {
  * create a context for a reducer
  * @type {Function}
  * @name createContext
- * @namespace createContext
  * @param  {Function} reducers - the reducer function
  * @return {Object}          returns the methods
  */
@@ -50,6 +52,10 @@ function createContext(reducers) {
   reducers = reducers || {
     routing: ReactRouterRedux.routerReducer
   };
+  /**
+   * global store is initially undefined
+   * @type undefined
+   */
   var store;
   return {
     /**

--- a/lib/store.js
+++ b/lib/store.js
@@ -78,7 +78,6 @@ function createContext(reducers) {
       return function(state) {
         return state[namespace];
       };
-
     },
     /**
      * return the current store otherwise return a new one

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "istanbul test -x \"spec/**/*.js\" --root . --dir .tmp/coverage _mocha \"spec/**/*.js\"",
     "pretest": "npm run cleanup; mkdir -p .tmp/test; cd .tmp/test; npm init -y; npm install file:../../",
     "cleanup": "rm -rf coverage .tmp/test/{.eslintrc.js,.stylelintrc.js,webpack.config.js,src,dist,node_modules/hops}",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "docs": "rm -rf docs; jsdoc -c jsdoc.json"
   },
   "contributors": [
     "dmbch <daniel@dmbch.net> (https://www.xing.com/profile/Daniel_Dembach)",
@@ -62,6 +63,8 @@
     "fake-style-loader": "1.0.1",
     "file-loader": "0.8.5",
     "istanbul": "0.4.3",
+    "hopsdoc": "git+https://github.com/xing/hopsdoc.git",
+    "jsdoc": "git+https://github.com/pixelass/jsdoc.git",
     "json-loader": "0.5.4",
     "memory-fs": "0.3.0",
     "mocha": "2.5.3",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,3 +1,7 @@
+/**
+ * @module Plugin
+ * @author Somebody <somebody@foo.bar>
+ */
 
 var fs = require('fs');
 var path = require('path');

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Hops is not yet another boilerplate. Hops is a self-contained but highly extensi
 
 Besides recent versions of [Node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com), hops has no global dependencies. If you need those, we recommend using [nvm](https://github.com/creationix/nvm) or similar.
 
-```
+```shell
 mkdir foo && cd foo
 npm init -y
 npm install -SE hops
@@ -39,7 +39,7 @@ A postinstall script will attempt to bootstrap and configure the project hops is
 
 For developing with hops, you can use any decent editor with up-to-date language support. Those without a favorite we recommend [Atom](https://atom.io) with the [linter](https://atom.io/packages/linter), [linter-eslint](https://atom.io/packages/linter-eslint) and [linter-stylelint](https://atom.io/packages/linter-stylelint) plugins.
 
-```
+```shell
 npm start (--production)
 ```
 


### PR DESCRIPTION
rebased version of `feature/documentation`
adds dependencies

* jsdoc (forked version by @pixelass )
* hopsdoc (jsdoc theme)

adds documentation for the main app and defines documentation format.

The documentation needs to be reviewed.

When merged this can merged to `gh-pages` to update the online documentation