### PR TITLE
output.publicPath set to http://localhost:8080/

### DIFF
--- a/etc/webpack.watch.js
+++ b/etc/webpack.watch.js
@@ -12,6 +12,9 @@ module.exports = helpers.extend(
  'webpack.base.js',
   {
     entry: require.resolve('../lib/shim'),
+    output: {
+      publicPath: 'http://0.0.0.0:8080/'
+    },
     cache: {},
     devtool: '#eval-source-map',
     devServer: {


### PR DESCRIPTION
see http://webpack.github.io/docs/webpack-dev-server.html#combining-with-an-existing-server docs 

This enables the use of another backend server (for example Ruby on Rails) to serve the Webpack generated index.html template which itself references assets from http://localhost:8080.