### PR TITLE
Output which location rendering failed

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -53,17 +53,21 @@ function fetch(options) {
 
 /** @ignore */
 function render(options) {
-  return {
-    state: JSON.stringify(Object.assign(
-      options.store.getState(),
-      { routing: {}}
-    )),
-    dom: ReactDOM.renderToString(
-      React.createElement(ReactRedux.Provider, { store: options.store },
-        React.createElement(ReactRouter.RouterContext, options.renderProps)
+  try {
+    return {
+      state: JSON.stringify(Object.assign(
+        options.store.getState(),
+        { routing: {}}
+      )),
+      dom: ReactDOM.renderToString(
+        React.createElement(ReactRedux.Provider, { store: options.store },
+          React.createElement(ReactRouter.RouterContext, options.renderProps)
+        )
       )
-    )
-  };
+    };
+  } catch (error) {
+    console.log('[HOPS PLUGIN ERROR] - rendering ' + options.location + ' failed:', error);
+  }
 }
 
 /**


### PR DESCRIPTION
We just spend an hour search for the any hint where the build fails. This console.log statement will at least show the "location" which failed. 

Note, that the stacktrace by itself is not really helpful:
HOPS PLUGIN ERROR - rendering location /xing/malt-svg failed: 
TypeError: Cannot read property 'hash' of undefined
    at Constructor.getInitialState (/Users/frederik.dietz/git/malt/public/bundle.js:14383:37)
    at new Constructor (/Users/frederik.dietz/git/malt/node_modules/react/lib/ReactClass.js:668:54)