### PR TITLE
show actual error with stack trace

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -53,17 +53,21 @@ function fetch(options) {
 
 /** @ignore */
 function render(options) {
-  return {
-    state: JSON.stringify(Object.assign(
-      options.store.getState(),
-      { routing: {}}
-    )),
-    dom: ReactDOM.renderToString(
-      React.createElement(ReactRedux.Provider, { store: options.store },
-        React.createElement(ReactRouter.RouterContext, options.renderProps)
+  try {
+    return {
+      state: JSON.stringify(Object.assign(
+        options.store.getState(),
+        { routing: {}}
+      )),
+      dom: ReactDOM.renderToString(
+        React.createElement(ReactRedux.Provider, { store: options.store },
+          React.createElement(ReactRouter.RouterContext, options.renderProps)
+        )
       )
-    )
-  };
+    };
+  } catch (error) {
+    console.log('[HOPS PLUGIN ERROR] - rendering ' + options.location + ' failed:', error);
+  }
 }
 
 /**

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -120,8 +120,12 @@ Plugin.prototype.apply = function(compiler) {
       return Promise.all(options.locations.map(function (location) {
         return renderReact(location, options)
         .then(function (result) {
-          var html = renderEJS(Object.assign({}, options, result, assets));
-          compilation.assets[getFileName(location)] = getAssetObject(html);
+          try {
+            var html = renderEJS(Object.assign({}, options, result, assets));
+            compilation.assets[getFileName(location)] = getAssetObject(html);
+          } catch (error) { // eslint-disable-next-line no-console
+            console.log('[HOPS PLUGIN ERROR]:', error);
+          }
         });
       }));
     })


### PR DESCRIPTION
Before the actual error was swallowed!

Example output:

[HOPS PLUGIN ERROR]: { ReferenceError: ejs:15
    13|     <div id="__ROOT"><%- dom %></div>
    14|     <script>
 >> 15|       API_CACHE = <%- JSON.stringify(initialData) %>;
    16|       MALT_CONFIG = <%- JSON.stringify(maltConfig) %>;
    17|     </script>
    18|     <%-js.map(function (path) {

initialData is not defined
    at eval (eval at compile (/Users/frederik.dietz/git/test/malt-test/node_modules/ejs/lib/ejs.js:491:12), <anonymous>:20:31)
    at returnedFn (/Users/frederik.dietz/git/test/malt-test/node_modules/ejs/lib/ejs.js:520:17)
    at /Users/frederik.dietz/git/test/malt-test/node_modules/hops/plugin/index.js:126:24