### PR TITLE
Avoid BREAKING CHANGE by adding loader suffix

### DIFF
--- a/etc/webpack.test.js
+++ b/etc/webpack.test.js
@@ -7,7 +7,7 @@ module.exports = require('./webpack.node.js')
     rules: [{
       test: /\.test\.jsx?$/,
       use: {
-        loader: 'babel',
+        loader: 'babel-loader',
         options: {
           presets: ['es2015', 'stage-0', 'react'],
         }


### PR DESCRIPTION
Hi all,
Webpack doesn't allow omitting the '-loader' suffix any more:
https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.26
Line 4 is still ok, since the removeLoader function uses regex to regard the suffix if present