### PR TITLE
feat(hops-config): disable host check

### DIFF
--- a/packages/config/configs/develop.js
+++ b/packages/config/configs/develop.js
@@ -53,6 +53,7 @@ module.exports = {
   devServer: {
     contentBase: hopsConfig.buildDir,
     hot: true,
+    disableHostCheck: true,
     overlay: {
       warnings: true,
       errors: true


### PR DESCRIPTION
This PR introduces a flag to webpack-dev-server which disables host checks and therefore allows running the server on 0.0.0.0 and bein reachable under localhost or other synonyms.

This is needed to open pages in a vm. 