### PR TITLE
(1/4) chore: semistandard uses parser "babel-eslint" to recognize flowtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     }
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.3",
+    "eslint-plugin-flowtype": "^2.35.0",
     "glob": "^7.1.2",
     "hops-cli": "file:./packages/cli",
     "hops-config": "file:./packages/config",

--- a/spec/codestyle.js
+++ b/spec/codestyle.js
@@ -3,11 +3,16 @@
 var semistandard = require('mocha-standard/semistandard');
 
 describe('code style', function () {
-  this.timeout(5000);
+  this.timeout(10000);
 
-  it('conforms to semistandard', semistandard.files([
-    'packages/**/*.js',
-    'demo/src/*.js',
-    'spec/**/*.js'
-  ]));
+  it('conforms to semistandard', semistandard.files(
+    [
+      'packages/**/*.js',
+      'demo/src/*.js',
+      'spec/**/*.js'
+    ], {
+      parser: 'babel-eslint',
+      plugins: ['flowtype']
+    }
+  ));
 });


### PR DESCRIPTION
This commit switches the parser of "semistandard" to "babel-eslint" in
order to enable semistandard to correctly parse files that contain flow
type annotations.
It also enables the "eslint-plugin-flowtype" as is recommened in the
semistandard documentation:
https://github.com/standard/standard#can-i-use-a-javascript-language-variant-like-flow-or-typescript