### PR TITLE
fix(hops-config): use hops relative loader packages

### DIFF
--- a/packages/config/sections/module-rules/babel.js
+++ b/packages/config/sections/module-rules/babel.js
@@ -14,7 +14,7 @@ function getBabelLoader (targets, plugins) {
   return {
     test: /\.m?jsx?$/,
     use: {
-      loader: 'babel-loader',
+      loader: require.resolve('babel-loader'),
       options: {
         cacheDirectory: true,
         cacheIdentifier: createIdentifier(targets),

--- a/packages/config/sections/module-rules/file.js
+++ b/packages/config/sections/module-rules/file.js
@@ -7,7 +7,7 @@ var hopsConfig = require('../..');
 exports.default = {
   test: /\.(html|svg|((o|t)tf)|woff2?|ico)$/,
   use: {
-    loader: 'file-loader',
+    loader: require.resolve('file-loader'),
     options: {
       name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]')
     }

--- a/packages/config/sections/module-rules/json.js
+++ b/packages/config/sections/module-rules/json.js
@@ -3,6 +3,6 @@
 exports.default = {
   test: /\.json$/,
   use: {
-    loader: 'json-loader'
+    loader: require.resolve('json-loader')
   }
 };

--- a/packages/config/sections/module-rules/postcss.js
+++ b/packages/config/sections/module-rules/postcss.js
@@ -29,11 +29,11 @@ exports.build = {
     fallback: 'style-loader',
     use: [
       {
-        loader: 'css-loader',
+        loader: require.resolve('css-loader'),
         options: cssLoaderOptions
       },
       {
-        loader: 'postcss-loader',
+        loader: require.resolve('postcss-loader'),
         options: postcssLoaderOptions
       }
     ]
@@ -45,11 +45,11 @@ exports.develop = {
   use: [
     'style-loader',
     {
-      loader: 'css-loader',
+      loader: require.resolve('css-loader'),
       options: Object.assign({}, cssLoaderOptions, { sourceMap: true })
     },
     {
-      loader: 'postcss-loader',
+      loader: require.resolve('postcss-loader'),
       options: postcssLoaderOptions
     }
   ]
@@ -58,7 +58,7 @@ exports.develop = {
 exports.node = {
   test: /\.css$/,
   use: {
-    loader: 'css-loader/locals',
+    loader: require.resolve('css-loader/locals'),
     options: Object.assign({}, cssLoaderOptions, { importLoaders: 0 })
   }
 };

--- a/packages/config/sections/module-rules/url.js
+++ b/packages/config/sections/module-rules/url.js
@@ -7,7 +7,7 @@ var hopsConfig = require('../..');
 exports.default = {
   test: /\.(png|gif|jpe?g|webp)$/,
   use: {
-    loader: 'url-loader',
+    loader: require.resolve('url-loader'),
     options: {
       limit: 10000,
       name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]')


### PR DESCRIPTION
to fix the issue with packages not being installed in root node_modules in newer yarn versions.

https://github.com/yarnpkg/yarn/issues/4394

Got this error in a hops-powered project.
```
hops server listening at http://0.0.0.0:8080

ERROR in multi webpack-dev-server/client?http://0.0.0.0:8080 webpack/hot/dev-server ./node_modules/hops-config/shims/develop.js
Module not found: Error: Can't resolve 'babel-loader' in '/Users/robin.drexler/Development/malt'
 @ multi webpack-dev-server/client?http://0.0.0.0:8080 webpack/hot/dev-server ./node_modules/hops-config/shims/develop.js
```

create-react-app also does this: https://github.com/facebookincubator/create-react-app/blob/6644054fc3f64533dd1b9469baa2fab94e44b721/packages/react-scripts/config/webpack.config.dev.js