### PR TITLE
fix(config): incorrect detection of empty objects as being an array

### DIFF
--- a/packages/config/lib/parse-env.js
+++ b/packages/config/lib/parse-env.js
@@ -10,7 +10,8 @@ function isNumberIsh (object) {
 }
 
 function isArrayIsh (object) {
-  return !Object.keys(object).filter(function (key) {
+  var keys = Object.keys(object);
+  return keys.length > 0 && !keys.filter(function (key) {
     return !/^\d+$/.test(key);
   }).length;
 }


### PR DESCRIPTION
`isArrayIsh` incorrectly detected empty objects `{}` as being an array.
With this fix it will no longer return true for these cases.