### PR TITLE
feat(config): read hops user config from package.json if not in env

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -4,8 +4,22 @@ var path = require('path');
 
 var root = require('pkg-dir').sync(process.cwd());
 
-var npmConfig = require('./lib/parse-env')('hops');
 var manifestUtil = require('./lib/manifest-util');
+
+var npmConfig = require('./lib/parse-env')('hops');
+try {
+  require.resolve(path.join(root, 'package.json'));
+  var packageJson = require(path.join(root, 'package.json'));
+  if (packageJson.config.hops && isEmptyObject(npmConfig)) {
+    npmConfig = packageJson.config.hops;
+  }
+} catch (error) {}
+
+function isEmptyObject (input) {
+  return typeof input === 'object' &&
+    input !== null &&
+    Object.keys(input).length === 0;
+}
 
 function extendConfig (config) {
   if (npmConfig.extends) {


### PR DESCRIPTION
In case that the hops user configuration is not set in the npm
environment (for example by starting a service without npm script).
`hops-config` will try to read the config section of the package.json
to read the config.