### PR TITLE
docs: add missing peerDependencies to hops-react/redux readme example

### DIFF
--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -6,7 +6,7 @@ Out of the box, hops-react additionally supports [React Router](https://github.c
 
 # Installation
 ``` bash
-npm install --save react react-dom react-helmet react-router react-router-dom hops-react
+npm install --save react react-dom react-helmet react-router react-router-dom hops-react hops-config
 ```
 
 # API

--- a/packages/redux/readme.md
+++ b/packages/redux/readme.md
@@ -8,7 +8,7 @@ Additionally, hops-redux registers the [Thunk](https://github.com/gaearon/redux-
 To use hops-redux, you need to add it and its dependencies to an existing project that already has [hops-react](https://github.com/xing/hops/tree/master/packages/react) installed.
 
 ``` bash
-npm install --save hops-redux react-redux redux redux-thunk
+npm install --save hops-redux react react-redux redux redux-thunk
 ```
 
 # API


### PR DESCRIPTION
The package `hops-react` has a peerDependency to `hops-config` but it
isn't specified in the package's `readme.md` installation instructions.

The package `hops-redux` has a peerDependency to `react` but it isn't
specified in the package's `readme.md` installation instructions.

This PR adds the missing peerDependencies to the installation
instructions in both readme files.