### PR TITLE
feat(hops-react): Improve template data injection

### DIFF
--- a/packages/react/lib/template.js
+++ b/packages/react/lib/template.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function esc (data) {
-  return JSON.stringify(data).replace(/</g, '\\u003c');
+  return JSON.stringify(data).replace(/<\//g, '\\u003c');
 }
 
 module.exports = function (data) {


### PR DESCRIPTION
Small change to hops-react package regarding template data escaping

Currently for all injected globals we are escaping `<` sign.
According to doc I found it's better to escape `</`

> To prevent against this hole, you should replace every occurrence of </ in your JSON with <\/ so that the <script> tag remains open. (The characters < and / are valid only within a string literal so the replacement can’t affect anything else.)

This also allows me to inject data on rails based backend. Example:
```js
const ctx = Context.extend({
  getTemplateData () {
    const templateData = Context.prototype.getTemplateData.call(this);
    return Object.assign(templateData, {
      globals: templateData.globals.concat([{
        name: 'MY_NAME',
        value: '<%= @my_rails_data.html_safe %>'
      }])
    });
  }
});
```