### PR TITLE
[WIP] fix(demo): add missing babel-core dependency needed by babel-jest

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -20,6 +20,7 @@
     "pretest": "flow"
   },
   "dependencies": {
+    "babel-core": "^6.26.0",
     "hops-cli": "file:../packages/cli",
     "hops-config": "file:../packages/config",
     "hops-middleware": "file:../packages/middleware",


### PR DESCRIPTION
```
npm WARN babel-jest@21.0.2 requires a peer of babel-core@^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0 but none is installed. You must install peer dependencies yourself.
```
`babel-jest` itself is a dependency of `jest-preset-hops`.

