### PR TITLE
fix(jest-preset-hops): add babel-core to satisfy peer dependencies

### DIFF
--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "babel-core": "^6.26.0",
     "babel-jest": "21",
     "identity-obj-proxy": "^3.0.0"
   },


### PR DESCRIPTION
In favor of #227 

Thanks @dmbch :)