### PR TITLE
feat(hops-config): use faster source map strategy

### DIFF
--- a/packages/config/configs/develop.js
+++ b/packages/config/configs/develop.js
@@ -43,7 +43,7 @@ module.exports = {
   performance: {
     hints: false
   },
-  devtool: '#source-map',
+  devtool: 'cheap-module-eval-source-map',
   watchOptions: {
     aggregateTimeout: 300,
     ignored: /node_modules/


### PR DESCRIPTION
In two demo projects, I was able to cut incremental build time in half.

It's also the setting, the [webpack docs recommend](https://webpack.js.org/guides/build-performance/#devtool) and is used by [preact-cli](https://github.com/developit/preact-cli/blob/8a2dfffa832c1ac6c7ca535baf0a2500a7799448/src/lib/webpack/webpack-base-config.js#L228).
