### PR TITLE
feat(build-config): added mode as environment variable

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -55,7 +55,8 @@ module.exports = {
       ignoreOrder: true
     }),
     new webpack.EnvironmentPlugin({
-      'NODE_ENV': 'production'
+      NODE_ENV: 'production',
+      HOPS_MODE: 'dynamic'
     }),
     new webpack.LoaderOptionsPlugin({
       debug: false,

--- a/packages/build-config/configs/develop.js
+++ b/packages/build-config/configs/develop.js
@@ -37,7 +37,8 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
     new webpack.EnvironmentPlugin({
-      NODE_ENV: 'development'
+      NODE_ENV: 'development',
+      HOPS_MODE: 'dynamic'
     })
   ],
   performance: {

--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -46,7 +46,8 @@ module.exports = {
       maxChunks: 1
     }),
     new webpack.EnvironmentPlugin({
-      NODE_ENV: 'development'
+      NODE_ENV: 'development',
+      HOPS_MODE: 'dynamic'
     })
   ],
   performance: {

--- a/packages/express/app.js
+++ b/packages/express/app.js
@@ -31,12 +31,9 @@ function createApp () {
       require(filePath)
     );
   } else {
-    console.error(
-      'Could not find generated server middleware at',
-      '"' + filePath + '"'
+    console.log(
+      'No middleware found. Delivering only statically built routes.'
     );
-    console.error('Did you forget to run "hops build"?');
-    process.exit(1);
   }
   server.teardown(app, hopsConfig);
 

--- a/packages/local-cli/commands/build.js
+++ b/packages/local-cli/commands/build.js
@@ -32,6 +32,7 @@ module.exports = function buildCommand (callback) {
       if (argv.production) {
         process.env.NODE_ENV = 'production';
       }
+      process.env.HOPS_MODE = argv.static ? 'static' : 'dynamic';
       hopsBuild.runBuild(argv, callback);
     }
   };

--- a/packages/local-cli/commands/develop.js
+++ b/packages/local-cli/commands/develop.js
@@ -8,6 +8,12 @@ module.exports = function developCommand (callback) {
     describe: 'Starts a webpack-dev-server to enable local development with ' +
       'hot code reloading',
     builder: {
+      static: {
+        alias: 's',
+        default: false,
+        describe: 'Serve app in hot mode with static env variable turned on',
+        type: 'boolean'
+      },
       clean: {
         alias: 'c',
         default: true,
@@ -17,6 +23,8 @@ module.exports = function developCommand (callback) {
       }
     },
     handler: function developHandler (argv) {
+      process.env.HOPS_MODE = argv.static ? 'static' : 'dynamic';
+
       hopsBuild.runServer(argv, callback);
     }
   };

--- a/packages/local-cli/commands/serve.js
+++ b/packages/local-cli/commands/serve.js
@@ -9,6 +9,12 @@ module.exports = function serveCommand (callback) {
     'application',
     builder: {
       production: {
+        static: {
+          alias: 's',
+          default: false,
+          describe: 'Serve built app with static env variable turned on',
+          type: 'boolean'
+        },
         alias: 'p',
         default: false,
         describe: 'Minifies the output, generates source maps and removes ' +
@@ -20,6 +26,7 @@ module.exports = function serveCommand (callback) {
       if (argv.production) {
         process.env.NODE_ENV = 'production';
       }
+      process.env.HOPS_MODE = argv.static ? 'static' : 'dynamic';
       hopsExpress.startServer(callback);
     }
   };

--- a/packages/local-cli/commands/start.js
+++ b/packages/local-cli/commands/start.js
@@ -8,6 +8,12 @@ module.exports = function startCommand (callback) {
     command: 'start',
     describe: 'Starts a development or production server, based on NODE_ENV',
     builder: {
+      static: {
+        alias: 's',
+        default: false,
+        describe: 'Sets mode to static',
+        type: 'boolean'
+      },
       clean: {
         alias: 'c',
         default: true,
@@ -27,6 +33,7 @@ module.exports = function startCommand (callback) {
       if (argv.production) {
         process.env.NODE_ENV = 'production';
       }
+      process.env.HOPS_MODE = argv.static ? 'static' : 'dynamic';
       if (process.env.NODE_ENV === 'production') {
         hopsExpress.startServer(callback);
       } else {


### PR DESCRIPTION
## Current state

NODE_ENV is accepted as a global variable and therefore is used for code optimizations in the minifying step. But we also need it for a global variable called HOPS_MODE, which indicates whether the application runs in a `static` build environment or a `dynamic` middleware use case.

## Changes introduced here

Added the environment variable `HOPS_MODE` with a default of `dynamic` to all webpack configs.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
