### PR TITLE
docs(*): add npm version shields to READMEs

### DIFF
--- a/packages/build-config/README.md
+++ b/packages/build-config/README.md
@@ -1,5 +1,7 @@
 # Hops Build Config
 
+[![npm](https://img.shields.io/npm/v/hops-build-config.svg)](https://www.npmjs.com/package/hops-build-config)
+
 hops-build-config exposes webpack configurations for Node.js, browser and webpack-dev-server.
 
 # Installation

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -1,5 +1,6 @@
-
 # Hops Build
+
+[![npm](https://img.shields.io/npm/v/hops-build.svg)](https://www.npmjs.com/package/hops-build)
 
 hops-build is a wrapper around webpack and [hops-build-config](https://github.com/xing/hops/tree/master/packages/build-config) which exports functions to execute a single build or start a `webpack-dev-server`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,6 @@
-
 # Hops CLI
+
+[![npm](https://img.shields.io/npm/v/hops-cli.svg)](https://www.npmjs.com/package/hops-cli)
 
 hops-cli provides a `hops` binary that should be installed globally.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,5 +1,7 @@
 # Hops Config
 
+[![npm](https://img.shields.io/npm/v/hops-config.svg)](https://www.npmjs.com/package/hops-config)
+
 hops-config exposes options to configure the other Hops packages and your own application. It is quite flexible and highly extensible.
 
 # Installation

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,5 +1,6 @@
-
 # Hops Express
+
+[![npm](https://img.shields.io/npm/v/hops-express.svg)](https://www.npmjs.com/package/hops-express)
 
 hops-express creates a minimal [Express](https://expressjs.com/) server which takes care of serving static assets and registering a middleware built using [hops-build](https://github.com/xing/hops/tree/master/packages/build).
 

--- a/packages/jest-preset/README.md
+++ b/packages/jest-preset/README.md
@@ -1,5 +1,7 @@
 # Hops Jest Preset
 
+[![npm](https://img.shields.io/npm/v/jest-preset-hops.svg)](https://www.npmjs.com/package/jest-preset-hops)
+
 A [Jest preset](https://facebook.github.io/jest/docs/configuration.html#preset-string) that makes it easier for Hops powered apps to use Jest.
 
 It ensures that Babel works correctly out of the box and that requiring files such as images does not produce errors. [identity-obj-proxy](https://github.com/keyanzhang/identity-obj-proxy) is used to make working with CSS modules easier in tests.

--- a/packages/local-cli/README.md
+++ b/packages/local-cli/README.md
@@ -1,5 +1,7 @@
 # Hops Local CLI
 
+[![npm](https://img.shields.io/npm/v/hops-local-cli.svg)](https://www.npmjs.com/package/hops-local-cli)
+
 hops-local-cli provides a set of commands to manage your hops project.
 hops-local-cli will be automatically installed in projects created by calling [`hops init` (provided by hops-cli)](https://github.com/xing/hops/tree/master/packages/cli). In other projects it needs to be added as a dependency separately.
 

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -1,5 +1,6 @@
+# Hops Middleware 
 
-# Hops Middleware
+[![npm](https://img.shields.io/npm/v/hops-middleware.svg)](https://www.npmjs.com/package/hops-middleware)
 
 Hops assumes you will write an Express-style middleware, transpiles it using Webpack and makes it easy to use in non-transpiled and even non-server code. Hops' middleware is a simple helper to simplify using your custom middleware with an Express server.
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,5 +1,6 @@
-
 # Hops Plugin
+
+[![npm](https://img.shields.io/npm/v/hops-plugin.svg)](https://www.npmjs.com/package/hops-plugin)
 
 Hops assumes you will write an Express-style middleware, transpiles it and makes it easy to use in non-transpiled and even non-server code. Hops' plugin is a simple helper to simplify using your custom middleware in a Webpack build.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,7 @@
 # Hops React
 
+[![npm](https://img.shields.io/npm/v/hops-react.svg)](https://www.npmjs.com/package/hops-react)
+
 hops-react works in tandem with [hops-build](https://github.com/xing/hops/blob/master/packages/build) and [hops-config](https://github.com/xing/hops/blob/master/packages/redux) to make an integrated solution for universal ("isomorphic") rendering using React. It provides a minimal API and hides the tricky bits of setting up React for such use-cases.
 
 Out of the box, hops-react additionally supports [React Router](https://github.com/ReactTraining/react-router) and [React Helmet](https://github.com/nfl/react-helmet).

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -1,5 +1,7 @@
 # Hops Redux
 
+[![npm](https://img.shields.io/npm/v/hops-redux.svg)](https://www.npmjs.com/package/hops-redux)
+
 hops-redux extends [hops-react](https://github.com/xing/hops/tree/master/packages/react) by providing a rendering context injecting a [Redux](https://github.com/reactjs/redux) [`Provider`](https://github.com/reactjs/react-redux) and some helpers.
 
 Additionally, hops-redux registers the [Thunk](https://github.com/gaearon/redux-thunk) middleware and supports [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension) out of the box.

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,5 +1,6 @@
-
 # Hops Renderer
+
+[![npm](https://img.shields.io/npm/v/hops-renderer.svg)](https://www.npmjs.com/package/hops-renderer)
 
 Hops assumes you will write an Express-style middleware, transpiles it and makes it easy to use in non-transpiled and even non-server code. Hops' renderer is a simple helper to enable you to use your custom middleware outside of Express servers.
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,5 +1,6 @@
-
 # Hops Server
+
+[![npm](https://img.shields.io/npm/v/hops-server.svg)](https://www.npmjs.com/package/hops-server)
 
 Hops server is a small collection of shared functionality that can be used in express-like interfaces to register the hops-middleware.
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -1,4 +1,3 @@
-
 # Hops Spec
 
-Hops spec contains the integration test suites and mocks and is considered a "private" package that is only used during development to very that all modules work correctly.
+Hops spec contains the integration test suites and mocks and is considered a "private" package that is only used during development to verify that all modules work correctly.

--- a/packages/template-minimal/README.md
+++ b/packages/template-minimal/README.md
@@ -1,5 +1,7 @@
 # Hops Template Minimal
 
+[![npm](https://img.shields.io/npm/v/hops-template-minimal.svg)](https://www.npmjs.com/package/hops-template-minimal)
+
 This is a minimal example of how [hops](https://github.com/xing/hops) can be used without react.
 
 

--- a/packages/template-react/README.md
+++ b/packages/template-react/README.md
@@ -1,5 +1,7 @@
 # Hops Template React
 
+[![npm](https://img.shields.io/npm/v/hops-template-react.svg)](https://www.npmjs.com/package/hops-template-react)
+
 This is a small example application showing [hops](https://github.com/xing/hops) in action.
 It demonstrates how to use hops with React, Redux, Flow and Jest.
 

--- a/packages/transpiler/README.md
+++ b/packages/transpiler/README.md
@@ -1,5 +1,6 @@
-
 # Hops Transpiler
+
+[![npm](https://img.shields.io/npm/v/hops-transpiler.svg)](https://www.npmjs.com/package/hops-transpiler)
 
 Hops transpiler is a very simple wrapper around Webpack's compiler and it is its most bare-bones, lowest-level component. It exports a function creating an event emitter that is set up to emit three kinds of events: `start`, `success` and `error`.
 


### PR DESCRIPTION
## Current state

No nice blue badges (or npm links) are there in all those READMEs

## Changes introduced here

Use small badges or shields provided by https://shields.io to display npm versions in READMEs and link to the respective npm project page

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [X] Necessary unit tests are added in order to ensure correct behavior
- [X] Documentation has been added