### PR TITLE
docs(jest-preset-hops): fixed README.md jest docs url and example

### DIFF
--- a/packages/jest-preset/README.md
+++ b/packages/jest-preset/README.md
@@ -8,13 +8,13 @@ It ensures that Babel works correctly out of the box and that requiring files su
 
 ## Usage
 
-Add `hops-jest-preset` as [preset](https://facebook.github.io/jest/docs/configuration.html#preset-string) to your Jest config.
+Add `hops-jest-preset` as [preset](https://facebook.github.io/jest/docs/en/configuration.html#preset-string) to your Jest config.
 This can for example be done by adding it to your package.json.
 
 ```json
 {
   "jest": {
-    "preset": "hops-jest-preset"
+    "preset": "jest-preset-hops"
   }
 }
 ```


### PR DESCRIPTION
## Current state

 - Url to jest docs is broken  (404)
 - Preset name in the example is wrong.

## Changes introduced here

 - fixed url
 - fixed preset name

## Checklist

- [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [ ] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
