### PR TITLE
fix(hops-local-cli): add missing hops-config dependency

### DIFF
--- a/packages/local-cli/package.json
+++ b/packages/local-cli/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "hops-config": "7.2.0",
     "tar": "^4.0.1",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^9.0.1"


### PR DESCRIPTION
`hops-global-cli init` fails with `Error: Cannot find module 'hops-config'` due to missing `hops-config-dependency`

