### PR TITLE
chore: specify npm registry in lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,6 @@
   "lerna": "2.4.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "7.3.1"
+  "version": "7.3.1",
+  "registry": "https://registry.npmjs.org/"
 }


### PR DESCRIPTION
Because of a bug in lerna the registry environment variable will be set
to yarnpkg in certain cases, therefore we specify the registry manually
in the lerna config.

Related: https://github.com/lerna/lerna/issues/896