### PR TITLE
Fix express export

### DIFF
--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -12,8 +12,8 @@ hops-express doesn't generate the middleware itself but assumes that it is named
 ## `createApp()`
 `createApp()` creates an Express app, applies all the middleware configuration and returns the app object ready to call `app.listen(host, port)` on it.
 
-## `startServer(callback)`
-`startServer()` is a small wrapper around `createApp()` and executes `app.listen()` with the values provided through hops-config.
+## `runServer(callback)`
+`runServer()` is a small wrapper around `createApp()` and executes `app.listen()` with the values provided through hops-config.
 
 
 ### Target Audience
@@ -29,7 +29,7 @@ The server contained in this app is meant for production usage. During developme
 ```javascript
 var hopsExpress = require('hops-express');
 
-hopsExpress.startServer(function (error) {
+hopsExpress.runServer(function (error) {
   if (error) {
     console.error(error);
   } else {

--- a/packages/express/index.js
+++ b/packages/express/index.js
@@ -10,5 +10,5 @@ function runServer (options, callback) {
 module.exports = {
   createApp: createApp,
   runServer: runServer,
-  startServer: runServer
+  startServer: runServer // added for backwards compat - remove a.s.a.p.
 };

--- a/packages/express/index.js
+++ b/packages/express/index.js
@@ -3,9 +3,12 @@
 var server = require('hops-server');
 var createApp = require('./app');
 
+function runServer (options, callback) {
+  server.run(createApp(), callback);
+}
+
 module.exports = {
   createApp: createApp,
-  runServer: function runServer (options, callback) {
-    server.run(createApp(), callback);
-  }
+  runServer: runServer,
+  startServer: runServer
 };


### PR DESCRIPTION
## Current state

`startServer` was renamed to `runServer` without flagging a breaking change.

## Changes introduced here

Re-introduce `startServer` export.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [x] Documentation has been added