### PR TITLE
fix(graphql): add lib folder to package

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -16,7 +16,9 @@
   "browser": "dom.js",
   "files": [
     "node.js",
-    "dom.js"
+    "dom.js",
+    "commands",
+    "lib"
   ],
   "dependencies": {
     "apollo-cache-inmemory": "^1.0.0",


### PR DESCRIPTION
## Current state

hops-graphql is currently completely broken because its `lib` folder is missing.

## Changes introduced here

`lib` folder is included in npm package.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
