### PR TITLE
fix(express): fix startServer method signature

### DIFF
--- a/packages/express/index.js
+++ b/packages/express/index.js
@@ -10,5 +10,7 @@ function runServer (options, callback) {
 module.exports = {
   createApp: createApp,
   runServer: runServer,
-  startServer: runServer // added for backwards compat - remove a.s.a.p.
+  startServer: function (callback) {
+    runServer({}, callback);
+  }
 };


### PR DESCRIPTION
## Current state

`runServer` added a new `options` argument startServer didn't require.

## Changes introduced here

Make `runServer` compatible again.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
