### PR TITLE
fix(hops-redux): make options.reducers optional again

### DIFF
--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -13,9 +13,11 @@ exports.Context = exports.createContext = Context.extend({
   initialize: function (options) {
     Context.prototype.initialize.call(this, options);
     this.reducers = {};
-    Object.keys(options.reducers).forEach(function (key) {
-      this.registerReducer(key, options.reducers[key]);
-    }.bind(this));
+    Object.keys(options.reducers || {}).forEach(
+      function (key) {
+        this.registerReducer(key, options.reducers[key]);
+      }.bind(this)
+    );
   },
   registerReducer: function (namespace, reducer) {
     this.reducers[namespace] = reducer;


### PR DESCRIPTION
not passing options.reducers causes an error, [which it did not before](https://github.com/xing/hops/commit/f11cac86c9f98733588482053c26d0d2ab8e1c46#diff-6163e5b6f61632ddf858987872971110L15).

## Current state

<!-- explanation of the current state -->

## Changes introduced here

<!-- explanation of the changes you did in this pull request -->

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
