### PR TITLE
Give devServer config higher priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "BlakeSimpson <blakersim@gmail.com> (https://www.xing.com/profile/Blake_Simpson)",
     "systemboogie <marcus@marcusnoll.de> (https://www.xing.com/profile/Marcus_Noll3)",
     "KingHenne <mail@hendrik-liebau.de> (https://www.xing.com/profile/Hendrik_Liebau2)",
-    "ZauberNerd <zaubernerd@zaubernerd.de> (https://www.xing.com/profile/Bjoern_Brauer5)"
+    "ZauberNerd <zaubernerd@zaubernerd.de> (https://www.xing.com/profile/Bjoern_Brauer5)",
+    "ghost23 <mail@ghost23.de> (https://www.xing.com/profile/Sven_Busse)"
   ],
   "private": true,
   "license": "MIT",

--- a/packages/build/server.js
+++ b/packages/build/server.js
@@ -19,7 +19,7 @@ function runDevelop (options, callback) {
   var watchOptions = config.devServer.watchOptions || config.watchOptions;
   var app = new WebpackServer(
     webpack(config),
-    Object.assign({}, config.devServer, {
+    Object.assign({}, {
       after: function (app) {
         app.use(server.rewritePath);
         server.bootstrap(app, hopsConfig);
@@ -30,7 +30,7 @@ function runDevelop (options, callback) {
         server.teardown(app, hopsConfig);
       },
       watchOptions: watchOptions
-    })
+    }, config.devServer)
   );
   server.run(app, callback);
 }


### PR DESCRIPTION
This pull request closes issue #266 

## Current state

In the server.js:

https://github.com/xing/hops/blob/v7.4.0/packages/build/server.js#L22

currently, after the devServer config options there is an additional object (the one with the after function and the watchOptions). This way, it is impossible to override that functionality. For example, you are always stuck with the rewrite:

https://github.com/xing/hops/blob/v7.4.0/packages/build/server.js#L24

even if you don't want to use that.

## Changes introduced here

This change simply changes the order here:

https://github.com/xing/hops/blob/v7.4.0/packages/build/server.js#L22

from:
Object.assign({}, config.devServer, { after: .... })
to:
Object.assign({}, { after: .... }, config.devServer)

So now the devServer configs can override even the 'after' function and the watchOptions, if it so wishes.

## Checklist

- [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
