### PR TITLE
Improved renderer

### DIFF
--- a/packages/build/build.js
+++ b/packages/build/build.js
@@ -20,10 +20,11 @@ function getWebpackConfig (options) {
       buildConfig,
       {
         plugins: [
-          new HopsPlugin(
-            hopsConfig.locations,
-            nodeConfig
-          ),
+          new HopsPlugin({
+            locations: hopsConfig.locations,
+            webpackConfig: nodeConfig,
+            hopsConfig: hopsConfig
+          }),
           new webpack.ProgressPlugin()
         ]
       }

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -9,11 +9,11 @@ function getFileName (location) {
   return index(location).replace(/^\//, '');
 }
 
-module.exports = function Plugin (locations, webpackConfig, watchOptions) {
-  var render = createRenderer(webpackConfig, watchOptions);
+module.exports = function Plugin (options) {
+  var render = createRenderer(options);
   this.apply = function (compiler) {
     compiler.plugin('emit', function (compilation, callback) {
-      Promise.all((locations || []).map(function (location) {
+      Promise.all((options.locations || []).map(function (location) {
         return render(location).then(function (html) {
           if (html) {
             compilation.assets[getFileName(location)] = new RawSource(html);

--- a/packages/renderer/index.js
+++ b/packages/renderer/index.js
@@ -20,11 +20,12 @@ module.exports = function createRenderer (options) {
     options.watchOptions
   ));
 
-  return function (location) {
+  return function (options) {
+    if (typeof options === 'string') {
+      options = { url: options };
+    }
     return new Promise(function (resolve, reject) {
-      var req = mocks.createRequest({
-        url: location
-      });
+      var req = mocks.createRequest(options);
       var res = mocks.createResponse({
         eventEmitter: events.EventEmitter,
         request: req

--- a/packages/spec/plugin.js
+++ b/packages/spec/plugin.js
@@ -32,7 +32,10 @@ describe('plugin', function () {
         assert('index.html' in assets);
         done();
       });
-      var plugin = new Plugin(['/'], goodConfig);
+      var plugin = new Plugin({
+        locations: ['/'],
+        webpackConfig: goodConfig
+      });
       plugin.apply(compiler);
     });
 
@@ -43,7 +46,10 @@ describe('plugin', function () {
         assert.equal(result, 'Hello World!');
         done();
       });
-      var plugin = new Plugin(['/'], goodConfig);
+      var plugin = new Plugin({
+        locations: ['/'],
+        webpackConfig: goodConfig
+      });
       plugin.apply(compiler);
     });
 
@@ -52,7 +58,10 @@ describe('plugin', function () {
         assert(error instanceof Error);
         done();
       });
-      var plugin = new Plugin(['/'], badExportConfig);
+      var plugin = new Plugin({
+        locations: ['/'],
+        webpackConfig: badExportConfig
+      });
       plugin.apply(compiler);
     });
 
@@ -61,7 +70,10 @@ describe('plugin', function () {
         assert(error instanceof Error);
         done();
       });
-      var plugin = new Plugin(['/'], badHandlerConfig);
+      var plugin = new Plugin({
+        locations: ['/'],
+        webpackConfig: badHandlerConfig
+      });
       plugin.apply(compiler);
     });
   });

--- a/packages/spec/renderer.js
+++ b/packages/spec/renderer.js
@@ -27,6 +27,22 @@ describe('renderer', function () {
       assert(promise instanceof Promise);
     });
 
+    it('should call middleware', function () {
+      var render = createRenderer({
+        webpackConfig: goodConfig,
+        hopsConfig: {
+          bootstrapServer: function (app) {
+            assert(true);
+            app.use(function (req, res, next) {
+              assert(true);
+              next();
+            });
+          }
+        }
+      });
+      render('/');
+    });
+
     it('should render expected result', function (done) {
       var render = createRenderer({ webpackConfig: goodConfig });
       render('/')

--- a/packages/spec/renderer.js
+++ b/packages/spec/renderer.js
@@ -16,19 +16,19 @@ describe('renderer', function () {
   });
 
   it('should create a renderer function', function () {
-    var render = createRenderer(goodConfig);
+    var render = createRenderer({ webpackConfig: goodConfig });
     assert.equal(typeof render, 'function');
   });
 
   describe('function', function () {
     it('should return a promise', function () {
-      var render = createRenderer(goodConfig);
+      var render = createRenderer({ webpackConfig: goodConfig });
       var promise = render('/');
       assert(promise instanceof Promise);
     });
 
     it('should render expected result', function (done) {
-      var render = createRenderer(goodConfig);
+      var render = createRenderer({ webpackConfig: goodConfig });
       render('/')
         .then(function (result) {
           assert.equal(typeof result, 'string');
@@ -38,7 +38,7 @@ describe('renderer', function () {
     });
 
     it('should reject promise (bad export)', function (done) {
-      var render = createRenderer(badExportConfig);
+      var render = createRenderer({ webpackConfig: badExportConfig });
       render('/')
         .catch(function () {
           assert(true);
@@ -47,7 +47,7 @@ describe('renderer', function () {
     });
 
     it('should reject promise (bad handler)', function (done) {
-      var render = createRenderer(badHandlerConfig);
+      var render = createRenderer({ webpackConfig: badHandlerConfig });
       render('/')
         .catch(function () {
           assert(true);

--- a/packages/spec/renderer.js
+++ b/packages/spec/renderer.js
@@ -27,7 +27,7 @@ describe('renderer', function () {
       assert(promise instanceof Promise);
     });
 
-    it('should call middleware', function () {
+    it('should call middleware', function (done) {
       var render = createRenderer({
         webpackConfig: goodConfig,
         hopsConfig: {
@@ -36,6 +36,7 @@ describe('renderer', function () {
             app.use(function (req, res, next) {
               assert(true);
               next();
+              done();
             });
           }
         }


### PR DESCRIPTION
## Current state

Static renderer does not apply bootstrapServer function from hops-config. In this regard, its implementation differs from our servers.

## Changes introduced here

Renderer now applies the `bootstrapServer` function, aligning it with server behaviour. It does so by actually instantiating an [Express Router](http://expressjs.com/en/4x/api.html#router) and using it for rendering.

N.B.: I deliberately decided to not also apply `teardownServer`, because the primary use-case of that function is to set up error handling and logging. We are doing both ourselves in a static rendering context.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [x] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added