### PR TITLE
Add sourcemap and build stats

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -5,7 +5,7 @@ var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var UglifyPlugin = require('uglifyjs-webpack-plugin');
-
+var StatsWriterPlugin = require('webpack-stats-plugin').StatsWriterPlugin;
 var WriteManifestPlugin = require('../plugins/write-manifest');
 var WriteFilePlugin = require('../plugins/write-file');
 
@@ -28,6 +28,7 @@ module.exports = {
   },
   devtool: 'source-map',
   plugins: [
+    new StatsWriterPlugin({ fields: null }),
     new WriteFilePlugin(/^manifest\.js?$/),
     new WriteManifestPlugin(),
     new webpack.optimize.CommonsChunkPlugin({

--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -26,6 +26,7 @@ module.exports = {
   module: {
     rules: require('../sections/module-rules')('build')
   },
+  devtool: 'source-map',
   plugins: [
     new WriteFilePlugin(/^manifest\.js?$/),
     new WriteManifestPlugin(),
@@ -61,9 +62,9 @@ module.exports = {
     new webpack.LoaderOptionsPlugin({
       debug: false,
       minimize: true,
-      sourceMap: false
+      sourceMap: true
     }),
     new webpack.optimize.ModuleConcatenationPlugin(),
-    new UglifyPlugin()
+    new UglifyPlugin({ sourceMap: true })
   ]
 };

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -54,6 +54,7 @@
     "url-loader": "^0.6.2",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.4",
-    "webpack-node-externals": "^1.6.0"
+    "webpack-node-externals": "^1.6.0",
+    "webpack-stats-plugin": "^0.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7376,6 +7376,10 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-stats-plugin@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.1.5.tgz#29e5f12ebfd53158d31d656a113ac1f7b86179d9"
+
 webpack@^3.6.0:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.8.1.tgz#b16968a81100abe61608b0153c9159ef8bb2bd83"


### PR DESCRIPTION

## Current state
No sourcemaps and stats written.
 
## Changes introduced here

Sourcemaps and stats are written in order to allow consumers to analyze their bundles. 
Sourcemaps also allow for debugging in production.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
