### PR TITLE
perf(graphql): remove fs.existsSync() check from context

### DIFF
--- a/packages/graphql/lib/util.js
+++ b/packages/graphql/lib/util.js
@@ -7,3 +7,11 @@ var hopsConfig = require('hops-config');
 exports.getFragmentsFile = function getFragmentsFile () {
   return path.join(hopsConfig.appDir, 'fragmentTypes.json');
 };
+
+exports.getIntrospectionResult = function getIntrospectionResult () {
+  var file = exports.getFragmentsFile();
+  try {
+    require.resolve(file);
+    return require(file);
+  } catch (_) {}
+};

--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var fs = require('fs');
-
 var ReactApollo = require('react-apollo');
 
 var common = require('./lib/common');
-var fragmentsFile = require('./lib/util').getFragmentsFile();
+var introspectionResult = require('./lib/util').getIntrospectionResult();
 
 exports.Context = exports.createContext = common.Context.extend({
   prepareRender: function (enhancedElement) {
@@ -16,9 +14,7 @@ exports.Context = exports.createContext = common.Context.extend({
     return common.Context.prototype.createClient.call(this, options);
   },
   getIntrospectionResult: function () {
-    if (fs.existsSync(fragmentsFile)) {
-      return require(fragmentsFile);
-    }
+    return introspectionResult;
   },
   getTemplateData: function () {
     var templateData = common.Context.prototype.getTemplateData.call(this);


### PR DESCRIPTION
## Current state

`fs.existsSync` checks on every request.

## Changes introduced here

Check on server startup.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
