### PR TITLE
fix(react): re-enable Miss/Status components

### DIFF
--- a/packages/spec/serve.js
+++ b/packages/spec/serve.js
@@ -102,4 +102,12 @@ describe('production server', function () {
       })
     );
   });
+
+  it('should deliver 404 when route does not match', function () {
+    return fetch('http://localhost:8080/thisdoesnotexist').then(function (
+      response
+    ) {
+      assert(response.status === 404);
+    });
+  });
 });


### PR DESCRIPTION
## Current state

Miss/Status components in hops-react are broken.

## Changes introduced here

Due to the recent changes, the router's static context was lost - this is now fixed: routerContext is now returned as a part of templateData.

With this PR, we also make sure Helmet.renderStatic() is being called for every request, preventing an eventual memleak.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
