### PR TITLE
Context constructors

### DIFF
--- a/packages/graphql/dom.js
+++ b/packages/graphql/dom.js
@@ -5,7 +5,11 @@ var hopsReact = require('hops-react');
 var common = require('./lib/common');
 var constants = require('./lib/constants');
 
-exports.contextDefinition = Object.assign({}, common, {
+exports.contextDefinition = function () {
+  return common.constructor.apply(this, arguments);
+};
+
+exports.contextDefinition.prototype = Object.assign({}, common, {
   createCache: function () {
     return common.createCache.call(this).restore(
       global[constants.APOLLO_STATE]

--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -8,7 +8,11 @@ var common = require('./lib/common');
 var constants = require('./lib/constants');
 var introspectionResult = require('./lib/util').getIntrospectionResult();
 
-exports.contextDefinition = Object.assign({}, common, {
+exports.contextDefinition = function () {
+  return common.constructor.apply(this, arguments);
+};
+
+exports.contextDefinition.prototype = Object.assign({}, common, {
   enhanceElement: function (reactElement) {
     var enhancedElement = common.enhanceElement.call(this, reactElement);
     return ReactApollo.getDataFromTree(enhancedElement).then(function () {

--- a/packages/react/dom.js
+++ b/packages/react/dom.js
@@ -8,25 +8,23 @@ var mixinable = require('mixinable');
 var hopsConfig = require('hops-config');
 
 exports.combineContexts = mixinable({
-  bootstrap: mixinable.parallel,
-  enhanceElement: mixinable.compose,
+  bootstrap: mixinable.async.parallel,
+  enhanceElement: mixinable.async.compose,
   getMountpoint: mixinable.override
 });
 
-exports.contextDefinition = {
-  constructor: function (options) {
-    if (!options) { options = {}; }
-    this.mountpoint = options.mountpoint || '#main';
-  },
-  bootstrap: function () {
-    return Promise.resolve();
-  },
+exports.contextDefinition = function (options) {
+  if (!options) { options = {}; }
+  this.mountpoint = options.mountpoint || '#main';
+};
+
+exports.contextDefinition.prototype = {
   enhanceElement: function (reactElement) {
-    return Promise.resolve(React.createElement(
+    return React.createElement(
       ReactRouterDOM.BrowserRouter,
       { basename: hopsConfig.basePath },
       reactElement
-    ));
+    );
   },
   getMountpoint: function () {
     return document.querySelector(this.mountpoint);

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -11,25 +11,23 @@ var hopsConfig = require('hops-config');
 var defaultTemplate = require('./lib/template');
 
 exports.combineContexts = mixinable({
-  bootstrap: mixinable.parallel,
-  enhanceElement: mixinable.compose,
-  getTemplateData: mixinable.pipe,
+  bootstrap: mixinable.async.parallel,
+  enhanceElement: mixinable.async.compose,
+  getTemplateData: mixinable.async.pipe,
   renderTemplate: mixinable.override
 });
 
-exports.contextDefinition = {
-  constructor: function () {
-    var args = Array.prototype.slice.call(arguments);
-    var options = Object.assign.apply(Object, [{}].concat(args));
-    this.template = options.template || defaultTemplate;
-    this.request = options.request;
-    this.routerContext = {};
-  },
-  bootstrap: function () {
-    return Promise.resolve();
-  },
+exports.contextDefinition = function () {
+  var args = Array.prototype.slice.call(arguments);
+  var options = Object.assign.apply(Object, [{}].concat(args));
+  this.template = options.template || defaultTemplate;
+  this.request = options.request;
+  this.routerContext = {};
+};
+
+exports.contextDefinition.prototype = {
   enhanceElement: function (reactElement) {
-    return Promise.resolve(React.createElement(
+    return React.createElement(
       ReactRouter.StaticRouter,
       {
         basename: hopsConfig.basePath,
@@ -37,17 +35,17 @@ exports.contextDefinition = {
         context: this.routerContext
       },
       reactElement
-    ));
+    );
   },
   getTemplateData: function (templateData) {
-    return Promise.resolve(Object.assign({}, templateData, {
+    return Object.assign({}, templateData, {
       routerContext: this.routerContext,
       options: this.options,
       helmet: Helmet.renderStatic(),
       assets: hopsConfig.assets,
       manifest: hopsConfig.manifest,
       globals: (templateData.globals || [])
-    }));
+    });
   },
   renderTemplate: function (templateData) {
     return this.template(templateData);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "hops-config": "8.0.0",
-    "mixinable": "1.1.0",
+    "mixinable": "1.2.0",
     "serialize-javascript": "^1.4.0"
   },
   "peerDependencies": {

--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -9,15 +9,16 @@ var hopsReact = require('hops-react');
 
 var REDUX_STATE = 'REDUX_STATE';
 
-exports.contextDefinition = {
-  constructor: function (options) {
-    this.reducers = {};
-    Object.keys((options && options.reducers) || {}).forEach(
-      function (key) {
-        this.registerReducer(key, options.reducers[key]);
-      }.bind(this)
-    );
-  },
+exports.contextDefinition = function (options) {
+  this.reducers = {};
+  Object.keys((options && options.reducers) || {}).forEach(
+    function (key) {
+      this.registerReducer(key, options.reducers[key]);
+    }.bind(this)
+  );
+};
+
+exports.contextDefinition.prototype = {
   registerReducer: function (namespace, reducer) {
     this.reducers[namespace] = reducer;
     if (this.store) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,8 +82,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.0.tgz#eb2840746e9dc48bd5e063a36e3fd400c5eab5a9"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -1264,12 +1264,12 @@ caniuse-api@^2.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000770"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000770.tgz#cf68ae1cb8a82f6d3c35df41c62dc6973e470244"
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000770:
-  version "1.0.30000770"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000770.tgz#bc8e7f50b073273390db6ab357378909a14e9bdb"
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000772.tgz#78129622cabfed7af1ff38b64ab680a6a0865420"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1305,8 +1305,8 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     supports-color "^4.0.0"
 
 chardet@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.0.tgz#0bbe1355ac44d7a3ed4a925707c4ef70f8190f6c"
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
@@ -1466,9 +1466,13 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@2.11.0, commander@~2.11.0:
+commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
+commander@~2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.1.tgz#468635c4168d06145b9323356d1da84d14ac4a7a"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2144,12 +2148,11 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+doctrine@^2.0.0, doctrine@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
     esutils "^2.0.2"
-    isarray "^1.0.0"
 
 domain-browser@^1.1.1:
   version "1.1.7"
@@ -2250,8 +2253,8 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -2418,8 +2421,8 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.10.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.11.0.tgz#39a8c82bc0a3783adf5a39fa27fdd9d36fac9a34"
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.0.tgz#a7ce78eba8cc8f2443acfbbc870cc31a65135884"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -2427,7 +2430,7 @@ eslint@^4.10.0:
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
     debug "^3.0.1"
-    doctrine "^2.0.0"
+    doctrine "^2.0.2"
     eslint-scope "^3.7.1"
     espree "^3.5.2"
     esquery "^1.0.0"
@@ -2436,7 +2439,7 @@ eslint@^4.10.0:
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^9.17.0"
+    globals "^11.0.1"
     ignore "^3.3.3"
     imurmurhash "^0.1.4"
     inquirer "^3.0.6"
@@ -3010,7 +3013,11 @@ glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.17.0, globals@^9.18.0:
+globals@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.0.1.tgz#12a87bb010e5154396acc535e1e43fc753b0e5e8"
+
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -4436,9 +4443,9 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.3.4, mime@^1.4.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.5.0.tgz#59c20e03ae116089edeb7d3b34a6788c5b3cccea"
+mime@^1.3.4, mime@^1.4.1, mime@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mime@^2.0.3:
   version "2.0.3"
@@ -4505,9 +4512,9 @@ mississippi@^1.3.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixinable@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mixinable/-/mixinable-1.1.0.tgz#919ecd8e5d8244df2940c479bb5dd2102ceafddb"
+mixinable@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mixinable/-/mixinable-1.2.0.tgz#d3b229da98d1155ee398ba03db3bdf40f1f22193"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4558,8 +4565,8 @@ multicast-dns-service-types@^1.1.0:
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
 
 multicast-dns@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.0.tgz#13f22d0c32dc5ee82a32878e3c380d875b3eab22"
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.1.tgz#c5035defa9219d30640558a49298067352098060"
   dependencies:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
@@ -5911,8 +5918,8 @@ reduce-css-calc@^1.2.6, reduce-css-calc@^1.2.7:
     reduce-function-call "^1.0.1"
 
 reduce-css-calc@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.1.tgz#f4ecd7a00ec3e5683773f208067ad7da117b9db0"
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.3.tgz#63c4c6325ffbbf4ea6c23f1d4deb47c3953f3b81"
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
@@ -6861,10 +6868,10 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-es@^3.1.3:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.1.10.tgz#f1840c3b52771d17555a02ce158cf46f689384bd"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.2.0.tgz#fbbfb9dc465ec7e5065701b9720d0de977d0bc24"
   dependencies:
-    commander "~2.11.0"
+    commander "~2.12.1"
     source-map "~0.6.1"
 
 uglify-js@^2.6, uglify-js@^2.8.29:
@@ -7097,11 +7104,11 @@ webidl-conversions@^4.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 webpack-dev-middleware@^1.11.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.1.tgz#338be3ca930973be1c2ce07d84d275e997e1a25a"
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e"
   dependencies:
     memory-fs "~0.4.1"
-    mime "^1.4.1"
+    mime "^1.5.0"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
@@ -7149,8 +7156,8 @@ webpack-node-externals@^1.6.0:
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz#232c62ec6092b100635a3d29d83c1747128df9bd"
 
 webpack-sources@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"


### PR DESCRIPTION
## Current state

We are using object literals (with constructor props) as context definitions.

## Changes introduced here

Context definitions are now constructor functions with prototypes, enabling us to leverage standard (`class`) inheritance.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
