### PR TITLE
Redux middleware option

### DIFF
--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -2,30 +2,46 @@
 
 [![npm](https://img.shields.io/npm/v/hops-redux.svg)](https://www.npmjs.com/package/hops-redux)
 
-hops-redux extends [hops-react](https://github.com/xing/hops/tree/master/packages/react) by providing a rendering context injecting a [Redux](https://github.com/reactjs/redux) [`Provider`](https://github.com/reactjs/react-redux) and some helpers.
+hops-redux extends
+[hops-react](https://github.com/xing/hops/tree/master/packages/react) by
+providing a rendering context injecting a
+[Redux](https://github.com/reactjs/redux)
+[`Provider`](https://github.com/reactjs/react-redux) and some helpers.
 
-Additionally, hops-redux registers the [Thunk](https://github.com/gaearon/redux-thunk) middleware and supports [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension) out of the box.
+Additionally, hops-redux registers the
+[Thunk](https://github.com/gaearon/redux-thunk) middleware and supports
+[Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension) out of
+the box.
 
 # Installation
-To use hops-redux, you need to add it and its dependencies to an existing project that already has [hops-react](https://github.com/xing/hops/tree/master/packages/react) installed.
 
-``` bash
+To use hops-redux, you need to add it and its dependencies to an existing
+project that already has
+[hops-react](https://github.com/xing/hops/tree/master/packages/react) installed.
+
+```bash
 npm install --save hops-redux react react-redux redux redux-thunk
 ```
 
 # API
-## `createContext(options)`
-`createContext()` is hops-redux's main export. Of course, it is based on the implementation in [hops-react](https://github.com/xing/hops/tree/master/packages/react#createcontextoptions), but takes an additional `reducers` option.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| mountpoint | String | `'#main'` | querySelector identifying the root DOM node |
-| template | Function | `defaultTemplate` | template function supporting all React Helmet and hops-react features |
-| reducers | Object | `{}` | object literal containing reducers to be passed to Redux's [`combineReducers()`](http://redux.js.org/docs/api/combineReducers.html) |
+## `createContext(options)`
+
+`createContext()` is hops-redux's main export. Of course, it is based on the
+implementation in
+[hops-react](https://github.com/xing/hops/tree/master/packages/react#createcontextoptions),
+but takes an additional `reducers` option.
+
+| Field       | Type     | Default                  | Description                                                                                                                                                                                                                                |
+| ----------- | -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| mountpoint  | String   | `'#main'`                | querySelector identifying the root DOM node                                                                                                                                                                                                |
+| template    | Function | `defaultTemplate`        | template function supporting all React Helmet and hops-react features                                                                                                                                                                      |
+| reducers    | Object   | `{}`                     | object literal containing reducers to be passed to Redux's [`combineReducers()`](http://redux.js.org/docs/api/combineReducers.html)                                                                                                        |
+| middlewares | Array    | `[ReduxThunkMiddleware]` | array specifying the redux middlewares to apply. Uses [redux-thunk](https://github.com/gaearon/redux-thunk) as default. When middlewares is specified redux-thunk will not be included by default and needs to be added as well if needed. |
 
 # Example
 
-``` js
+```js
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -36,11 +52,14 @@ const namespace = 'foo';
 
 const withMessage = connect(state => state[namespace]);
 
-const App = withMessage(props => (<h1>{ props.message }</h1>));
+const App = withMessage(props => <h1>{props.message}</h1>);
 
-export default render(<App />, createContext({
-  reducers: {
-    [namespace]: (state = { message: 'Hello World!' }) => state
-  }
-}));
+export default render(
+  <App />,
+  createContext({
+    reducers: {
+      [namespace]: (state = { message: 'Hello World!' }) => state
+    }
+  })
+);
 ```

--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -11,7 +11,14 @@ var REDUX_STATE = 'REDUX_STATE';
 
 exports.contextDefinition = function (options) {
   this.reducers = {};
-  Object.keys((options && options.reducers) || {}).forEach(
+  options = options || {};
+  this.middlewares = options.middlewares || [ReduxThunkMiddleware];
+
+  if (!Array.isArray(this.middlewares)) {
+    throw new Error('middlewares needs to be an array');
+  }
+
+  Object.keys(options.reducers || {}).forEach(
     function (key) {
       this.registerReducer(key, options.reducers[key]);
     }.bind(this)
@@ -54,7 +61,7 @@ exports.contextDefinition.prototype = {
     });
   },
   getMiddlewares: function () {
-    return [ReduxThunkMiddleware];
+    return this.middlewares;
   },
   enhanceElement: function (reactElement) {
     return React.createElement(
@@ -67,10 +74,12 @@ exports.contextDefinition.prototype = {
   },
   getTemplateData: function (templateData) {
     return Object.assign({}, templateData, {
-      globals: (templateData.globals || []).concat([{
-        name: REDUX_STATE,
-        value: this.getStore().getState()
-      }])
+      globals: (templateData.globals || []).concat([
+        {
+          name: REDUX_STATE,
+          value: this.getStore().getState()
+        }
+      ])
     });
   }
 };

--- a/packages/spec/redux.js
+++ b/packages/spec/redux.js
@@ -1,48 +1,20 @@
 /* eslint-env node, mocha */
 var assert = require('assert');
-var React = require('react');
 
-var redux = require('hops-redux');
-var hopsReact = require('hops-react');
+var hopsRedux = require('hops-redux');
 
 describe('redux', function () {
-  var defaultOptions = {
-    someSlice: function () {
-      return null;
-    }
-  };
-
-  function setupContext (options) {
-    return hopsReact.combineContexts(redux.contextDefinition)(
-      Object.assign({}, defaultOptions, options || {})
-    );
-  }
-
   it('allows to set middlewares via option', function () {
-    var called = false;
-    var context = setupContext({
-      middlewares: [
-        function () {
-          return function () {
-            return function () {
-              called = true;
-            };
-          };
-        }
-      ]
+    var middleware = function () {};
+    var context = new hopsRedux.contextDefinition({
+      middlewares: [middleware]
     });
-
-    return context
-      .enhanceElement(React.createElement('span'))
-      .then(function (element) {
-        element.props.store.dispatch({ type: '' });
-        assert.ok(called);
-      });
+    assert.equal(context.getMiddlewares()[0], middleware);
   });
 
-  it('throws an error, when middlewares is provided but not an array', function () {
+  it('throws array when middlewares is not an array', function () {
     assert.throws(function () {
-      setupContext({
+      new hopsRedux.contextDefinition({
         middlewares: function () {}
       });
     });

--- a/packages/spec/redux.js
+++ b/packages/spec/redux.js
@@ -39,4 +39,12 @@ describe('redux', function () {
         assert.ok(called);
       });
   });
+
+  it('throws an error, when middlewares is provided but not an array', function () {
+    assert.throws(function () {
+      setupContext({
+        middlewares: function () {}
+      });
+    });
+  });
 });

--- a/packages/spec/redux.js
+++ b/packages/spec/redux.js
@@ -1,0 +1,42 @@
+/* eslint-env node, mocha */
+var assert = require('assert');
+var React = require('react');
+
+var redux = require('hops-redux');
+var hopsReact = require('hops-react');
+
+describe('redux', function () {
+  var defaultOptions = {
+    someSlice: function () {
+      return null;
+    }
+  };
+
+  function setupContext (options) {
+    return hopsReact.combineContexts(redux.contextDefinition)(
+      Object.assign({}, defaultOptions, options || {})
+    );
+  }
+
+  it('allows to set middlewares via option', function () {
+    var called = false;
+    var context = setupContext({
+      middlewares: [
+        function () {
+          return function () {
+            return function () {
+              called = true;
+            };
+          };
+        }
+      ]
+    });
+
+    return context
+      .enhanceElement(React.createElement('span'))
+      .then(function (element) {
+        element.props.store.dispatch({ type: '' });
+        assert.ok(called);
+      });
+  });
+});

--- a/packages/spec/redux.js
+++ b/packages/spec/redux.js
@@ -12,7 +12,7 @@ describe('redux', function () {
     assert.equal(context.getMiddlewares()[0], middleware);
   });
 
-  it('throws array when middlewares is not an array', function () {
+  it('throws error when middlewares is not an array', function () {
     assert.throws(function () {
       new hopsRedux.contextDefinition({
         middlewares: function () {}


### PR DESCRIPTION

## Current state
In order to set redux middlewares a consumer needs to create a new context that mixes with the redux context and override `getMiddlewares`.


## Changes introduced here

Since it's a pretty common use case to set middlewares, make it easier to do so by adding it as a context option. 


## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [x] Necessary unit tests are added in order to ensure correct behavior
- [x] Documentation has been added
