### PR TITLE
Additional context exports

### DIFF
--- a/packages/graphql/dom.js
+++ b/packages/graphql/dom.js
@@ -5,22 +5,23 @@ var hopsReact = require('hops-react');
 var common = require('./lib/common');
 var constants = require('./lib/constants');
 
-exports.contextDefinition = function() {
+exports.GraphQLContext = function () {
   return common.constructor.apply(this, arguments);
 };
-
-exports.contextDefinition.prototype = Object.assign({}, common, {
-  createCache: function() {
-    return common.createCache
-      .call(this)
-      .restore(global[constants.APOLLO_STATE]);
+exports.GraphQLContext.prototype = Object.assign({}, common, {
+  createCache: function () {
+    return common.createCache.call(this).restore(
+      global[constants.APOLLO_STATE]
+    );
   },
   getIntrospectionResult: function() {
     return global[constants.APOLLO_IQRD];
   },
 });
 
+exports.contextDefinition = exports.GraphQLContext;
+
 exports.createContext = hopsReact.combineContexts(
-  hopsReact.contextDefinition,
-  exports.contextDefinition
+  hopsReact.ReactContext,
+  exports.GraphQLContext
 );

--- a/packages/graphql/dom.js
+++ b/packages/graphql/dom.js
@@ -5,14 +5,14 @@ var hopsReact = require('hops-react');
 var common = require('./lib/common');
 var constants = require('./lib/constants');
 
-exports.GraphQLContext = function () {
+exports.GraphQLContext = function() {
   return common.constructor.apply(this, arguments);
 };
 exports.GraphQLContext.prototype = Object.assign({}, common, {
-  createCache: function () {
-    return common.createCache.call(this).restore(
-      global[constants.APOLLO_STATE]
-    );
+  createCache: function() {
+    return common.createCache
+      .call(this)
+      .restore(global[constants.APOLLO_STATE]);
   },
   getIntrospectionResult: function() {
     return global[constants.APOLLO_IQRD];

--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -8,12 +8,11 @@ var common = require('./lib/common');
 var constants = require('./lib/constants');
 var introspectionResult = require('./lib/util').getIntrospectionResult();
 
-exports.contextDefinition = function() {
+exports.GraphQLContext = function () {
   return common.constructor.apply(this, arguments);
 };
-
-exports.contextDefinition.prototype = Object.assign({}, common, {
-  enhanceElement: function(reactElement) {
+exports.GraphQLContext.prototype = Object.assign({}, common, {
+  enhanceElement: function (reactElement) {
     var enhancedElement = common.enhanceElement.call(this, reactElement);
     return ReactApollo.getDataFromTree(enhancedElement).then(function() {
       return enhancedElement;
@@ -43,7 +42,9 @@ exports.contextDefinition.prototype = Object.assign({}, common, {
   },
 });
 
+exports.contextDefinition = exports.GraphQLContext;
+
 exports.createContext = hopsReact.combineContexts(
-  hopsReact.contextDefinition,
-  exports.contextDefinition
+  hopsReact.ReactContext,
+  exports.GraphQLContext
 );

--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -8,11 +8,11 @@ var common = require('./lib/common');
 var constants = require('./lib/constants');
 var introspectionResult = require('./lib/util').getIntrospectionResult();
 
-exports.GraphQLContext = function () {
+exports.GraphQLContext = function() {
   return common.constructor.apply(this, arguments);
 };
 exports.GraphQLContext.prototype = Object.assign({}, common, {
-  enhanceElement: function (reactElement) {
+  enhanceElement: function(reactElement) {
     var enhancedElement = common.enhanceElement.call(this, reactElement);
     return ReactApollo.getDataFromTree(enhancedElement).then(function() {
       return enhancedElement;

--- a/packages/react/dom.js
+++ b/packages/react/dom.js
@@ -20,7 +20,7 @@ exports.ReactContext = function(options) {
   this.mountpoint = options.mountpoint || '#main';
 };
 exports.ReactContext.prototype = {
-  enhanceElement: function (reactElement) {
+  enhanceElement: function(reactElement) {
     return React.createElement(
       ReactRouterDOM.BrowserRouter,
       { basename: hopsConfig.basePath },
@@ -29,7 +29,7 @@ exports.ReactContext.prototype = {
   },
   getMountpoint: function() {
     return document.querySelector(this.mountpoint);
-  }
+  },
 };
 
 exports.contextDefinition = exports.ReactContext;

--- a/packages/react/dom.js
+++ b/packages/react/dom.js
@@ -13,15 +13,14 @@ exports.combineContexts = mixinable({
   getMountpoint: mixinable.override,
 });
 
-exports.contextDefinition = function(options) {
+exports.ReactContext = function(options) {
   if (!options) {
     options = {};
   }
   this.mountpoint = options.mountpoint || '#main';
 };
-
-exports.contextDefinition.prototype = {
-  enhanceElement: function(reactElement) {
+exports.ReactContext.prototype = {
+  enhanceElement: function (reactElement) {
     return React.createElement(
       ReactRouterDOM.BrowserRouter,
       { basename: hopsConfig.basePath },
@@ -30,10 +29,12 @@ exports.contextDefinition.prototype = {
   },
   getMountpoint: function() {
     return document.querySelector(this.mountpoint);
-  },
+  }
 };
 
-exports.createContext = exports.combineContexts(exports.contextDefinition);
+exports.contextDefinition = exports.ReactContext;
+
+exports.createContext = exports.combineContexts(exports.ReactContext);
 
 exports.render = function(reactElement, context) {
   return function() {

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -17,16 +17,15 @@ exports.combineContexts = mixinable({
   renderTemplate: mixinable.override,
 });
 
-exports.contextDefinition = function() {
+exports.ReactContext = function () {
   var args = Array.prototype.slice.call(arguments);
   var options = Object.assign.apply(Object, [{}].concat(args));
   this.template = options.template || defaultTemplate;
   this.request = options.request;
   this.routerContext = {};
 };
-
-exports.contextDefinition.prototype = {
-  enhanceElement: function(reactElement) {
+exports.ReactContext.prototype = {
+  enhanceElement: function (reactElement) {
     return React.createElement(
       ReactRouter.StaticRouter,
       {
@@ -52,7 +51,9 @@ exports.contextDefinition.prototype = {
   },
 };
 
-exports.createContext = exports.combineContexts(exports.contextDefinition);
+exports.contextDefinition = exports.ReactContext;
+
+exports.createContext = exports.combineContexts(exports.ReactContext);
 
 exports.render = function(reactElement, _context) {
   return function(req, res, next) {

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -17,7 +17,7 @@ exports.combineContexts = mixinable({
   renderTemplate: mixinable.override,
 });
 
-exports.ReactContext = function () {
+exports.ReactContext = function() {
   var args = Array.prototype.slice.call(arguments);
   var options = Object.assign.apply(Object, [{}].concat(args));
   this.template = options.template || defaultTemplate;
@@ -25,7 +25,7 @@ exports.ReactContext = function () {
   this.routerContext = {};
 };
 exports.ReactContext.prototype = {
-  enhanceElement: function (reactElement) {
+  enhanceElement: function(reactElement) {
     return React.createElement(
       ReactRouter.StaticRouter,
       {

--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -9,24 +9,21 @@ var hopsReact = require('hops-react');
 
 var REDUX_STATE = 'REDUX_STATE';
 
-exports.contextDefinition = function(options) {
+exports.ReduxContext = function (options) {
   this.reducers = {};
   options = options || {};
   this.middlewares = options.middlewares || [ReduxThunkMiddleware];
-
   if (!Array.isArray(this.middlewares)) {
     throw new Error('middlewares needs to be an array');
   }
-
   Object.keys(options.reducers || {}).forEach(
     function(key) {
       this.registerReducer(key, options.reducers[key]);
     }.bind(this)
   );
 };
-
-exports.contextDefinition.prototype = {
-  registerReducer: function(namespace, reducer) {
+exports.ReduxContext.prototype = {
+  registerReducer: function (namespace, reducer) {
     this.reducers[namespace] = reducer;
     if (this.store) {
       this.store.replaceReducer(Redux.combineReducers(this.reducers));
@@ -84,7 +81,9 @@ exports.contextDefinition.prototype = {
   },
 };
 
+exports.contextDefinition = exports.ReduxContext;
+
 exports.createContext = hopsReact.combineContexts(
-  hopsReact.contextDefinition,
-  exports.contextDefinition
+  hopsReact.ReactContext,
+  exports.ReduxContext
 );

--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -9,7 +9,7 @@ var hopsReact = require('hops-react');
 
 var REDUX_STATE = 'REDUX_STATE';
 
-exports.ReduxContext = function (options) {
+exports.ReduxContext = function(options) {
   this.reducers = {};
   options = options || {};
   this.middlewares = options.middlewares || [ReduxThunkMiddleware];
@@ -23,7 +23,7 @@ exports.ReduxContext = function (options) {
   );
 };
 exports.ReduxContext.prototype = {
-  registerReducer: function (namespace, reducer) {
+  registerReducer: function(namespace, reducer) {
     this.reducers[namespace] = reducer;
     if (this.store) {
       this.store.replaceReducer(Redux.combineReducers(this.reducers));


### PR DESCRIPTION
## Current state

Currently, hops-{react,redux,graphql} export their respective context definitions as `contextDefinition`. As these exports tend to be extended by downstream projects, they provide a somewhat un-idiomatic usage:

```javascript
import { contextDefinition } from 'hops-react'
class MyContext extends contextDefinition {...}
```

## Changes introduced here

We now also have a proper constructor export:

```javascript
import { ReactContext } from 'hops-react'
class MyContext extends ReactContext {...}
```

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in plain ECMAScript v5 and adheres to the [semistandard format](https://github.com/Flet/semistandard)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added