### PR TITLE
feat(lambda): include entire project dir in zip file (minus dev deps)

### DIFF
--- a/packages/lambda/deploy.js
+++ b/packages/lambda/deploy.js
@@ -180,8 +180,8 @@ module.exports = function deploy(options, parametersOverrides) {
         createLambdaBundle(
           projectDirectory,
           zippedBundleLocation,
-          [hopsConfig.buildDir, hopsConfig.cacheDir],
-          null,
+          awsConfig.include,
+          awsConfig.exclude,
           onProgress
         ),
         createBucketIfNotExists(s3, awsConfig.bucketName),

--- a/packages/lambda/lib/aws-config.js
+++ b/packages/lambda/lib/aws-config.js
@@ -7,6 +7,8 @@ var DEFAULT_REGION = 'us-east-1';
 var DEFAULT_MEMORY_SIZE = 128;
 var DEFAULT_STAGE_NAME = 'prod';
 var DEFAULT_CF_TEMPLATE = path.resolve(__dirname, '..', 'cloudformation.yaml');
+var DEFAULT_INCLUDE = [hopsConfig.cacheDir + '/**'];
+var DEFAULT_EXCLUDE = ['flow-typed/**', 'typings/**'];
 
 module.exports = function getAWSConfig() {
   var awsConfig = hopsConfig.aws || {};
@@ -30,6 +32,8 @@ module.exports = function getAWSConfig() {
     basePath: hopsConfig.basePath.slice(1) || '(none)',
     cloudformationTemplateFile:
       awsConfig.cloudformationTemplateFile || DEFAULT_CF_TEMPLATE,
+    include: awsConfig.include || DEFAULT_INCLUDE,
+    exclude: awsConfig.exclude || DEFAULT_EXCLUDE,
   };
 
   if (!region) {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "archiver": "^2.1.0",
     "aws-sdk": "^2.135.0",
+    "globby": "^7.1.1",
     "hops-config": "9.1.1",
     "prompt": "^1.0.0",
     "resolve-tree": "^0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2253,6 +2253,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 directory-index@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/directory-index/-/directory-index-0.1.0.tgz#307ce6b20af35fe861af9d876bc6d076787baadb"
@@ -3234,6 +3241,17 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -3580,7 +3598,7 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -5349,6 +5367,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.14"


### PR DESCRIPTION
This commit changes the way we zip the lambda bundle.
Before: We were only zipping the production dependencies,
build artifacts and package.json file.
After: Now we zip the entire project directory (excluding node_modules)
and then selectively adding production dependencies.

We now also have configurable include/exclude glob patterns.