### PR TITLE
docs(build-config): fix wrong import in example

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "systemboogie <marcus@marcusnoll.de> (https://www.xing.com/profile/Marcus_Noll3)",
     "KingHenne <mail@hendrik-liebau.de> (https://www.xing.com/profile/Hendrik_Liebau2)",
     "ZauberNerd <zaubernerd@zaubernerd.de> (https://www.xing.com/profile/Bjoern_Brauer5)",
-    "ghost23 <mail@ghost23.de> (https://www.xing.com/profile/Sven_Busse)"
+    "ghost23 <mail@ghost23.de> (https://www.xing.com/profile/Sven_Busse)",
+    "jhiode <mail@jhio.de> (https://www.xing.com/profile/Jonas_Holland)"
   ],
   "scripts": {
     "bootstrap": "lerna bootstrap",

--- a/packages/build-config/README.md
+++ b/packages/build-config/README.md
@@ -50,7 +50,7 @@ The following example shows how to overwrite / extend the webpack configurations
 
 ```javascript
 var webpack = require('webpack');
-var hopsBuildConfig = require('hops-build-config');
+var hopsBuildConfig = require('hops-build-config/configs/build');
 var merge = require('webpack-merge');
 
 var myCustomBuildConfig = {
@@ -63,7 +63,7 @@ var myCustomBuildConfig = {
 
 module.exports = merge.strategy(
   { plugins: 'append' },
-  hopsBuildConfig.buildConfig,
+  hopsBuildConfig,
   myCustomBuildConfig
 );
 ```


### PR DESCRIPTION
## Current state

The example in the build-config readme is wrong. 

## Changes introduced here

The example in the readme is updated. 

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
