### PR TITLE
Deprecate plugin, refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^3.0.1",
     "husky": "^0.14.3",
     "lerna": "^2.5.1",

--- a/packages/build/lib/generate.js
+++ b/packages/build/lib/generate.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var index = require('directory-index');
+var mkdirp = require('mkdirp');
+
+var hopsConfig = require('hops-config');
+var createRenderer = require('hops-renderer');
+
+function getFileName(location) {
+  return path.join.apply(
+    path,
+    [hopsConfig.buildDir].concat(index(location).split(path.sep))
+  );
+}
+
+function getKBs(s) {
+  return ((encodeURI(s).split(/%..|./).length - 1) / 1024).toFixed(2);
+}
+
+function writeFile(location, html) {
+  return new Promise(function(resolve, reject) {
+    var filename = getFileName(location);
+    console.log(filename.replace(hopsConfig.buildDir, ''), getKBs(html), 'kB');
+    mkdirp(path.dirname(filename), function(err) {
+      if (err) {
+        reject(err);
+      } else {
+        fs.writeFile(filename, html, function(err) {
+          err ? reject(err) : resolve();
+        });
+      }
+    });
+  });
+}
+
+module.exports = function(webpackConfig) {
+  var render = createRenderer(webpackConfig);
+  return Promise.all(
+    (hopsConfig.locations || []).map(function(location) {
+      return render(location).then(function(html) {
+        if (html) {
+          return writeFile(location, html);
+        }
+      });
+    })
+  ).then(function() {
+    console.log();
+  });
+};

--- a/packages/build/lib/generate.js
+++ b/packages/build/lib/generate.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 
 var index = require('directory-index');
+var filesize = require('filesize');
 var mkdirp = require('mkdirp');
 
 var hopsConfig = require('hops-config');
@@ -16,14 +17,13 @@ function getFileName(location) {
   );
 }
 
-function getKBs(s) {
-  return ((encodeURI(s).split(/%..|./).length - 1) / 1024).toFixed(2);
-}
-
 function writeFile(location, html) {
   return new Promise(function(resolve, reject) {
     var filename = getFileName(location);
-    console.log(filename.replace(hopsConfig.buildDir, ''), getKBs(html), 'kB');
+    console.log(
+      filename.replace(hopsConfig.buildDir, ''),
+      filesize(Buffer.byteLength(html))
+    );
     mkdirp(path.dirname(filename), function(err) {
       if (err) {
         reject(err);
@@ -47,6 +47,6 @@ module.exports = function(webpackConfig) {
       });
     })
   ).then(function() {
-    console.log();
+    console.log(/* empty line */);
   });
 };

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "directory-index": "^0.1.0",
+    "filesize": "^3.5.11",
     "hops-build-config": "9.1.1",
     "hops-config": "9.1.1",
     "hops-middleware": "9.1.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -15,11 +15,12 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "directory-index": "^0.1.0",
     "hops-build-config": "9.1.1",
     "hops-config": "9.1.1",
     "hops-middleware": "9.1.1",
-    "hops-plugin": "9.1.1",
     "hops-server": "9.1.1",
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.4",

--- a/packages/express/app.js
+++ b/packages/express/app.js
@@ -10,7 +10,7 @@ var helmet = require('helmet');
 var hopsConfig = require('hops-config');
 var server = require('hops-server');
 
-function createApp() {
+function createApp(options) {
   var app = express();
   app.use(helmet());
   app.use(server.rewritePath);
@@ -26,16 +26,17 @@ function createApp() {
     })
   );
   server.bootstrap(app, hopsConfig);
-  var filePath = path.join(hopsConfig.cacheDir, 'server.js');
-  if (fs.existsSync(filePath)) {
-    server.registerMiddleware(app.use(helmet.noCache()), require(filePath));
-  } else {
-    console.log(
-      'No middleware found. Delivering only statically built routes.'
-    );
+  if (!options.static) {
+    var filePath = path.join(hopsConfig.cacheDir, 'server.js');
+    if (fs.existsSync(filePath)) {
+      server.registerMiddleware(app.use(helmet.noCache()), require(filePath));
+    } else {
+      console.log(
+        'No middleware found. Delivering only statically built routes.'
+      );
+    }
   }
   server.teardown(app, hopsConfig);
-
   return app;
 }
 

--- a/packages/express/commands/serve.js
+++ b/packages/express/commands/serve.js
@@ -27,7 +27,7 @@ module.exports = function defineServeCommand(args) {
         process.env.NODE_ENV = 'production';
       }
       process.env.HOPS_MODE = argv.static ? 'static' : 'dynamic';
-      require('..').runServer();
+      require('..').runServer(argv);
     },
   });
 };

--- a/packages/express/index.js
+++ b/packages/express/index.js
@@ -4,7 +4,7 @@ var server = require('hops-server');
 var createApp = require('./app');
 
 function runServer(options, callback) {
-  server.run(createApp(), callback);
+  server.run(createApp(options), callback);
 }
 
 module.exports = {

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,6 +1,8 @@
 # Hops Plugin
 
-[![npm](https://img.shields.io/npm/v/hops-plugin.svg)](https://www.npmjs.com/package/hops-plugin)
+![deprecated](https://img.shields.io/badge/status-deprecated-red.svg)
+
+**This package is deprecated. Please use [hops-local-cli](https://www.npmjs.com/package/hops-local-cli) and [hops-build](https://www.npmjs.com/package/hops-build) instead.**
 
 Hops assumes you will write an Express-style middleware, transpiles it and makes it easy to use in non-transpiled and even non-server code. Hops' plugin is a simple helper to simplify using your custom middleware in a Webpack build.
 

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -10,7 +10,7 @@ function getFileName(location) {
 }
 
 module.exports = function Plugin(options) {
-  var render = createRenderer(options);
+  var render = createRenderer(options.webpackConfig, options.watchOptions);
   this.apply = function(compiler) {
     compiler.plugin('emit', function(compilation, callback) {
       Promise.all(

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -6,7 +6,7 @@ Hops assumes you will write an Express-style middleware, transpiles it and makes
 
 Its export, `createRenderer`, creates a `render` function that, if called with a `location` string, returns a promise that resolves to the full body of your middleware's response.
 
-You can override hops' default Webpack configuration by passing a config object to the `createRenderer` function. You can also enable watch mode by passing a `watchOptions` object.
+`createRenderer` expects to be passed a `webpackConfig` as first argument. You can also pass `watchOptions` as its second.
 
 ### Target Audience
 
@@ -66,5 +66,3 @@ render('/baz').catch(function(error) {
   // error === new Error('invalid status code: 404')
 });
 ```
-
-Hops' own [Webpack plugin](https://github.com/xing/hops/blob/master/packages/plugin/index.js) is another example of its renderer in action.

--- a/packages/renderer/index.js
+++ b/packages/renderer/index.js
@@ -5,18 +5,24 @@ var events = require('events');
 var express = require('express');
 var mocks = require('node-mocks-http');
 
+var hopsConfig = require('hops-config');
 var createMiddleware = require('hops-middleware');
 
-module.exports = function createRenderer(options) {
-  var hopsConfig = options.hopsConfig || {};
+module.exports = function createRenderer(webpackConfig, watchOptions) {
+  if (arguments.length === 1 && 'webpackConfig' in webpackConfig) {
+    webpackConfig = webpackConfig.webpackConfig;
+    watchOptions = webpackConfig.watchOptions;
+    console.warn(
+      'Calling createRenderer() with just an options hash is deprecated.',
+      'Please refer to the latest docs:',
+      'https://github.com/xing/hops/blob/master/packages/renderer/README.md'
+    );
+  }
   var router = new express.Router();
-
   if (hopsConfig.bootstrapServer) {
     hopsConfig.bootstrapServer(router, hopsConfig);
   }
-
-  router.use(createMiddleware(options.webpackConfig, options.watchOptions));
-
+  router.use(createMiddleware(webpackConfig, watchOptions));
   return function(options) {
     if (typeof options === 'string') {
       options = { url: options };

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "files": ["index.js"],
   "dependencies": {
+    "hops-config": "9.1.1",
     "hops-middleware": "9.1.1",
     "node-mocks-http": "^1.6.6"
   }

--- a/packages/spec/renderer.js
+++ b/packages/spec/renderer.js
@@ -16,36 +16,19 @@ describe('renderer', function() {
   });
 
   it('should create a renderer function', function() {
-    var render = createRenderer({ webpackConfig: goodConfig });
+    var render = createRenderer(goodConfig);
     assert.equal(typeof render, 'function');
   });
 
   describe('function', function() {
     it('should return a promise', function() {
-      var render = createRenderer({ webpackConfig: goodConfig });
+      var render = createRenderer(goodConfig);
       var promise = render('/');
       assert(promise instanceof Promise);
     });
 
-    it('should call middleware', function(done) {
-      var render = createRenderer({
-        webpackConfig: goodConfig,
-        hopsConfig: {
-          bootstrapServer: function(app) {
-            assert(true);
-            app.use(function(req, res, next) {
-              assert(true);
-              next();
-              done();
-            });
-          },
-        },
-      });
-      render('/');
-    });
-
     it('should render expected result', function(done) {
-      var render = createRenderer({ webpackConfig: goodConfig });
+      var render = createRenderer(goodConfig);
       render('/').then(function(result) {
         assert.equal(typeof result, 'string');
         assert.equal(result, 'Hello World!');
@@ -54,7 +37,7 @@ describe('renderer', function() {
     });
 
     it('should reject promise (bad export)', function(done) {
-      var render = createRenderer({ webpackConfig: badExportConfig });
+      var render = createRenderer(badExportConfig);
       render('/').catch(function() {
         assert(true);
         done();
@@ -62,7 +45,7 @@ describe('renderer', function() {
     });
 
     it('should reject promise (bad handler)', function(done) {
-      var render = createRenderer({ webpackConfig: badHandlerConfig });
+      var render = createRenderer(badHandlerConfig);
       render('/').catch(function() {
         assert(true);
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,6 +2924,10 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
+filesize@^3.5.11:
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.2:
+doctrine@^2.0.0, doctrine@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
@@ -2562,6 +2562,15 @@ eslint-plugin-prettier@^2.3.1:
 eslint-plugin-promise@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
+
+eslint-plugin-react@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^2.0.0"
+    prop-types "^15.6.0"
 
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
@@ -4356,6 +4365,12 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  dependencies:
+    array-includes "^3.0.3"
 
 killable@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Current state

Using our custom Webpack plugin, we are currently running Webpack within Webpack. That's probably not the simplest way to achieve what we want.

## Changes introduced here

Get rid of custom Webpack plugin.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [X] Necessary unit tests are added in order to ensure correct behavior
* [X] Documentation has been added
