### PR TITLE
Configurable router

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,10 +33,11 @@ export default render(<App />, createContext());
 
 `createContext()` generates a rendering context containing most of the actual implementation used by `render`. It takes a couple of options:
 
-| Field      | Type     | Default                                                                                    | Description                                                                    |
-| ---------- | -------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| mountpoint | String   | '#main'                                                                                    | querySelector identifying the root DOM node                                    |
-| template   | Function | [defaultTemplate](https://github.com/xing/hops/blob/master/packages/react/lib/template.js) | template function supporting all relevant React Helmet and hops-react features |
+| Field      | Type     | Default                                                                                    | Description                                                                                                                                                                                                                                     |
+| ---------- | -------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mountpoint | String   | '#main'                                                                                    | querySelector identifying the root DOM node                                                                                                                                                                                                     |
+| template   | Function | [defaultTemplate](https://github.com/xing/hops/blob/master/packages/react/lib/template.js) | template function supporting all relevant React Helmet and hops-react features                                                                                                                                                                  |
+| router     | Object   | {}                                                                                         | props to be passed to one of the relevant ReactRouter implementations: [`<StaticRouter />`](https://reacttraining.com/react-router/web/api/StaticRouter) or [`<BrowserRouter />`](https://reacttraining.com/react-router/web/api/BrowserRouter) |
 
 ## `<Miss />` and `<Status code={200} />`
 

--- a/packages/react/dom.js
+++ b/packages/react/dom.js
@@ -17,13 +17,17 @@ exports.ReactContext = function(options) {
   if (!options) {
     options = {};
   }
+  this.routerOptions = Object.assign(
+    { basename: hopsConfig.basePath },
+    options.router
+  );
   this.mountpoint = options.mountpoint || '#main';
 };
 exports.ReactContext.prototype = {
   enhanceElement: function(reactElement) {
     return React.createElement(
       ReactRouterDOM.BrowserRouter,
-      { basename: hopsConfig.basePath },
+      this.routerOptions,
       reactElement
     );
   },

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -21,26 +21,27 @@ exports.ReactContext = function(options) {
   if (!options) {
     options = {};
   }
+  this.routerOptions = Object.assign(
+    {
+      location: options.request && options.request.path,
+      basename: hopsConfig.basePath,
+      context: {},
+    },
+    options.router
+  );
   this.template = options.template || defaultTemplate;
-  this.request = options.request;
-  this.routerContext = {};
 };
 exports.ReactContext.prototype = {
   enhanceElement: function(reactElement) {
     return React.createElement(
       ReactRouter.StaticRouter,
-      {
-        basename: hopsConfig.basePath,
-        location: this.request.path,
-        context: this.routerContext,
-      },
+      this.routerOptions,
       reactElement
     );
   },
   getTemplateData: function(templateData) {
     return Object.assign({}, templateData, {
-      routerContext: this.routerContext,
-      options: this.options,
+      routerContext: this.routerOptions.context,
       helmet: Helmet.renderStatic(),
       assets: hopsConfig.assets,
       manifest: hopsConfig.manifest,


### PR DESCRIPTION
## Current state

Currently, users have to provide their own (derived) `ReactContext` implementation if they want to pass props to ReactRouter instances.

## Changes introduced here

With this PR, we introduce a router config option allowing users to pass in ReactRouter props. Primary use-case is implementing a custom [`getUserConfirmation` function](https://reacttraining.com/react-router/web/api/BrowserRouter/getUserConfirmation-func).

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [X] Documentation has been added