### PR TITLE
Introduce new lifecycle method: "prepareRender"

### DIFF
--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -12,11 +12,8 @@ exports.GraphQLContext = function() {
   return common.constructor.apply(this, arguments);
 };
 exports.GraphQLContext.prototype = Object.assign({}, common, {
-  enhanceElement: function(reactElement) {
-    var enhancedElement = common.enhanceElement.call(this, reactElement);
-    return ReactApollo.getDataFromTree(enhancedElement).then(function() {
-      return enhancedElement;
-    });
+  prepareRender: function(elementTree) {
+    return ReactApollo.getDataFromTree(elementTree);
   },
   enhanceClientOptions: function(options) {
     return Object.assign(common.enhanceClientOptions.call(this, options), {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -105,6 +105,10 @@ The `bootstrap` lifecyle hook allows you to set up your application and perform 
 
 By implementing `enhanceElement`, you can wrap your application's root element in additional, usually purely functional components such as Redux's or React-Intl's `Provider`s. This way, you can keep the low-level (plumbing) parts of your application nicely separated from the high-level (porcellain) parts.
 
+### `prepareRender(elementTree)` (Node.js only)
+
+This method is executed before gathering the template data / rendering the application. It gets passed in the element tree of the entire application that will be rendered (the result of all applied `enhanceElement` methods). You can use this method for example to analyze the component tree and do additional data fetching.
+
 ### `getTemplateData(templateData)` (Node.js only)
 
 `getTemplateData` is supposed to return an object that is being passed to the server-side template function. Please check out hops-react's default template to get an idea on what keys are supported.

--- a/packages/react/dom.js
+++ b/packages/react/dom.js
@@ -49,17 +49,21 @@ exports.render = function(reactElement, context) {
     } else {
       mountpoint.setAttribute('data-hopsroot', '');
     }
-    return context.bootstrap().then(function() {
-      return context
-        .enhanceElement(reactElement)
-        .then(function(enhancedElement) {
-          if (ReactDOM.hydrate && !isMounted) {
-            ReactDOM.hydrate(enhancedElement, mountpoint);
-          } else {
-            ReactDOM.render(enhancedElement, mountpoint);
-          }
-        });
-    });
+    return context
+      .bootstrap()
+      .then(function() {
+        return context.enhanceElement(reactElement);
+      })
+      .then(function(enhancedElement) {
+        if (ReactDOM.hydrate && !isMounted) {
+          ReactDOM.hydrate(enhancedElement, mountpoint);
+        } else {
+          ReactDOM.render(enhancedElement, mountpoint);
+        }
+      })
+      .catch(function(error) {
+        console.error('Error while rendering:', error);
+      });
   };
 };
 

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -67,28 +67,27 @@ exports.render = function(reactElement, _context) {
     renderContext
       .bootstrap()
       .then(function() {
-        return renderContext
-          .enhanceElement(reactElement)
-          .then(function(enhancedElement) {
-            return renderContext
-              .getTemplateData({
-                markup: ReactDOM.renderToString(enhancedElement),
-              })
-              .then(function(templateData) {
-                var routerContext = templateData.routerContext;
-                if (routerContext.miss) {
-                  next();
-                } else if (routerContext.url) {
-                  res.status(routerContext.status || 301);
-                  res.set('Location', routerContext.url);
-                  res.end();
-                } else {
-                  res.status(routerContext.status || 200);
-                  res.type('html');
-                  res.send(renderContext.renderTemplate(templateData));
-                }
-              });
-          });
+        return renderContext.enhanceElement(reactElement);
+      })
+      .then(function(elementTree) {
+        return renderContext.getTemplateData({
+          markup: ReactDOM.renderToString(elementTree),
+        });
+      })
+      .then(function(templateData) {
+        var routerContext = templateData.routerContext;
+
+        if (routerContext.miss) {
+          next();
+        } else if (routerContext.url) {
+          res.status(routerContext.status || 301);
+          res.set('Location', routerContext.url);
+          res.end();
+        } else {
+          res.status(routerContext.status || 200);
+          res.type('html');
+          res.send(renderContext.renderTemplate(templateData));
+        }
       })
       .catch(next);
   };


### PR DESCRIPTION
This PR introduces a new lifecycle method to the hops-react context,
called `prepareRender`.
It is being called after the element tree has been constructed (through
the `enhanceElement` methods).