### PR TITLE
fix(server): only rewrite path if run in static mode

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -27,19 +27,28 @@ exports.run = function run(app, callback) {
 };
 
 exports.rewritePath = function rewritePath(req, res, next) {
-  var location = hopsConfig.locations.find(function(location) {
-    return (
-      location !== hopsConfig.basePath + '/' && req.url.indexOf(location) === 0
-    );
-  });
-  if (location) {
-    req.url = location.replace(/([^\\/])$/, '$1/');
+  if (
+    process.env.HOPS_MODE === 'static' &&
+    Array.isArray(hopsConfig.locations)
+  ) {
+    var location = hopsConfig.locations.find(function(location) {
+      return (
+        location !== hopsConfig.basePath + '/' &&
+        req.url.indexOf(location) === 0
+      );
+    });
+    if (location) {
+      req.url = location.replace(/([^\\/])$/, '$1/');
+    }
   }
   next();
 };
 
 exports.registerMiddleware = function registerMiddleware(app, middleware) {
-  if (hopsConfig.locations.length) {
+  if (
+    process.env.HOPS_MODE === 'static' &&
+    Array.isArray(hopsConfig.locations)
+  ) {
     hopsConfig.locations.forEach(function(location) {
       app.get(location === '/' ? location : location + '*', middleware);
     });


### PR DESCRIPTION
This commit ensures that the path rewrite mechanism `rewritePath` is
only executed when a hops build happens in static mode (app shells).