### PR TITLE
refactor(cli): allow cli to be executed anywhere inside hops project

### DIFF
--- a/packages/cli/hops.js
+++ b/packages/cli/hops.js
@@ -159,11 +159,14 @@ var localCliPath = getLocalCliPath();
 
 var isInsideHopsProject = false;
 try {
-  var manifest = require(path.resolve(process.cwd(), 'package.json'));
+  var hopsRoot = require('pkg-dir').sync(process.cwd());
+  var manifest = require(path.join(hopsRoot, 'package.json'));
   var dependencies = Object.keys(manifest.dependencies || {}).concat(
     Object.keys(manifest.devDependencies || {})
   );
-  isInsideHopsProject = dependencies.indexOf('hops-local-cli') > -1;
+  isInsideHopsProject = PACKAGES_TO_INSTALL.every(function(dependency) {
+    return dependencies.indexOf(dependency) > -1;
+  });
 } catch (error) {
   isInsideHopsProject = false;
 }
@@ -189,9 +192,9 @@ if (isInsideHopsProject) {
   });
 
   validateName(name);
-  createDirectory(path.resolve(root, name));
-  writePackageManifest(path.resolve(root, name));
-  process.chdir(path.resolve(root, name));
+  createDirectory(path.join(root, name));
+  writePackageManifest(path.join(root, name));
+  process.chdir(path.join(root, name));
   installPackages(versionedPackages, options);
   require(getLocalCliPath()).init(root, name, options);
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "pkg-dir": "^2.0.0",
     "resolve-cwd": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
     "yargs": "^10.0.3"


### PR DESCRIPTION
Previously the `hops-cli` package could only be executed in the root
directory of a hops project.
With this change it will be possible to execute the hops cli from any
folder inside a hops project.