### PR TITLE
Fix stats.json including manifest chunk, which does not exist 

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -28,9 +28,9 @@ module.exports = {
   },
   devtool: 'source-map',
   plugins: [
-    new StatsWriterPlugin({ fields: null }),
     new WriteFilePlugin(/^manifest\.js(\.map)?$/),
     new WriteManifestPlugin(),
+    new StatsWriterPlugin({ fields: null }),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       minChunks: function(module) {

--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -29,7 +29,7 @@ module.exports = {
   devtool: 'source-map',
   plugins: [
     new StatsWriterPlugin({ fields: null }),
-    new WriteFilePlugin(/^manifest\.js?$/),
+    new WriteFilePlugin(/^manifest\.js(\.map)?$/),
     new WriteManifestPlugin(),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',


### PR DESCRIPTION
## Current state
Generated stats.json includes manifest chunk, which does not exist, because the write-file plugin removes it. (while writing its content into the hops cache folder).

Tools, such as `webpack-bundle-analyzer` had issues parsing the stats.json file
```
Couldn't parse bundle asset "/Users/robin/beep/boop/manifest-test/build/manifest.js".
Analyzer will use module sizes from stats file.
```

## Changes introduced here

- Remove superflous `manifest.js.map` file
- Register `StatsWriterPlugin` after `WriteFilePlugin`

<!-- explanation of the changes you did in this pull request -->

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
