### PR TITLE
feat(jest-preset-hops): add jest 22 to peerDependency range

### DIFF
--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "babel-core": "^6.26.0",
-    "babel-jest": "21",
+    "babel-jest": "^22.0.4",
     "hops-build-config": "9.3.2",
     "identity-obj-proxy": "^3.0.0"
   },
   "peerDependencies": {
-    "jest": "^21.0.0 || ^22.0.0"
+    "jest": ">= 21.0.0 < 23.0.0"
   }
 }

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -16,6 +16,6 @@
     "identity-obj-proxy": "^3.0.0"
   },
   "peerDependencies": {
-    "jest": "21"
+    "jest": "^21.0.0 || ^22.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,7 +568,14 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@21, babel-jest@^21.2.0:
+babel-jest@22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.0.4.tgz#533c46de37d7c9d7612f408c76314be9277e0c26"
+  dependencies:
+    babel-plugin-istanbul "^4.1.5"
+    babel-preset-jest "^22.0.3"
+
+babel-jest@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
   dependencies:
@@ -601,7 +608,7 @@ babel-plugin-dynamic-import-node@^1.1.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
-babel-plugin-istanbul@^4.0.0:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
@@ -612,6 +619,10 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
+babel-plugin-jest-hoist@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.3.tgz#62cde5fe962fd41ae89c119f481ca5cd7dd48bb4"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -951,6 +962,13 @@ babel-preset-jest@^21.2.0:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
   dependencies:
     babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.0.3.tgz#e2bb6f6b4a509d3ea0931f013db78c5a84856693"
+  dependencies:
+    babel-plugin-jest-hoist "^22.0.3"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-react@^6.24.1:


### PR DESCRIPTION
[jest 22 has been released](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2200). Tested jest@22 with the hops default template. `jest-preset-hops` still seems to work, so I'd like to increase the range of supported jest versions. :)

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
