### PR TITLE
chore: make sure eslint is executed on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ install:
 before_script:
   - yarn run bootstrap
 
+script:
+  - yarn test
+  - yarn lint
+
 node_js:
 - '6'
 - '7'

--- a/package.json
+++ b/package.json
@@ -63,9 +63,7 @@
     "extends": ["semistandard", "prettier"],
     "plugins": ["react", "prettier"],
     "rules": {
-      "prettier/prettier": "error",
-      "indent": ["warn", 2],
-      "max-len": ["warn", 80]
+      "prettier/prettier": "error"
     },
     "parserOptions": {
       "ecmaVersion": 5,

--- a/packages/spec/redux.js
+++ b/packages/spec/redux.js
@@ -6,7 +6,7 @@ var hopsRedux = require('hops-redux');
 describe('redux', function() {
   it('allows to set middlewares via option', function() {
     var middleware = function() {};
-    var context = new hopsRedux.contextDefinition({
+    var context = new hopsRedux.ReduxContext({
       middlewares: [middleware],
     });
     assert.equal(context.getMiddlewares()[0], middleware);
@@ -14,7 +14,8 @@ describe('redux', function() {
 
   it('throws error when middlewares is not an array', function() {
     assert.throws(function() {
-      new hopsRedux.contextDefinition({
+      // eslint-disable-next-line no-new
+      new hopsRedux.ReduxContext({
         middlewares: function() {},
       });
     });


### PR DESCRIPTION
Before:
eslint had to be executed manually via (`yarn lint`) and PRs with
linting issues were shown as "passing" - where they should have
failed.

After:
eslint is executed after the tests on every travis run.