### PR TITLE
fix(cli): do not require local packages in global context

### DIFF
--- a/packages/cli/hops.js
+++ b/packages/cli/hops.js
@@ -124,7 +124,7 @@ var localCliPath = getLocalCliPath();
 
 var isInsideHopsProject = false;
 try {
-  var hopsRoot = require('hops-config').appDir;
+  var hopsRoot = require('pkg-dir').sync();
   var manifest = require(path.join(hopsRoot, 'package.json'));
   var dependencies = Object.keys(manifest.dependencies || {}).concat(
     Object.keys(manifest.devDependencies || {})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "hops-config": "9.3.0",
     "pkg-dir": "^2.0.0",
     "resolve-cwd": "^2.0.0",
     "tar": "^4.0.1",


### PR DESCRIPTION
Requiring a local package in a global scope (CLI) might break, if that
local package requires other local packages, because then
`require.resolve` will try to resolve against the global scope.
In this case we needed `hops-config` only to get the application root,
which we now find ourselves by using `pkg-dir`.