### PR TITLE
fix(graphql): get rid of webpack warning

### DIFF
--- a/packages/graphql/lib/util.js
+++ b/packages/graphql/lib/util.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 
 var hopsConfig = require('hops-config');
@@ -10,8 +11,7 @@ exports.getFragmentsFile = function getFragmentsFile() {
 
 exports.getIntrospectionResult = function getIntrospectionResult() {
   var file = exports.getFragmentsFile();
-  try {
-    require.resolve(file);
-    return require(file);
-  } catch (_) {}
+  if (fs.existsSync(file)) {
+    return JSON.parse(fs.readFileSync(file));
+  }
 };


### PR DESCRIPTION
Work around Webpack dynamic import warning.

## Current state

Since d7e5aa0f1693b719b9ed06d6f02b4c5dde027905, `hops-grapqhl` is quite broken, because all hops packages are now being bundled.

https://github.com/xing/hops/blob/d7e5aa0f1693b719b9ed06d6f02b4c5dde027905/packages/build-config/configs/node.js#L24-L31

## Changes introduced here

With this PR, we make sure Webpack's `require` implementation does not have to deal with dynamic imports.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)