### PR TITLE
fix(lambda): specify peerDependencies also in devDependencies

### DIFF
--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -27,6 +27,9 @@
     "serverless-http": "^1.5.2"
   },
   "peerDependencies": {
-    "hops-express": "9.1.1"
+    "hops-express": "9.5.0"
+  },
+  "devDependencies": {
+    "hops-express": "9.5.0"
   }
 }


### PR DESCRIPTION
Specify peerDependencies also in devDependencies in order to have lerna
take care of updating the version numbers.