### PR TITLE
fix(cli): re-add accidentally removed hops-config dependency

### DIFF
--- a/packages/cli/lib/commands.js
+++ b/packages/cli/lib/commands.js
@@ -3,9 +3,9 @@
 var fs = require('fs');
 var path = require('path');
 
-var hopsConfig = require('hops-config');
+var root = require('pkg-dir').sync();
 
-var binDir = path.join(hopsConfig.appDir, 'node_modules', '.bin');
+var binDir = path.join(root, 'node_modules', '.bin');
 
 module.exports = function findCommands() {
   if (fs.existsSync(binDir)) {


### PR DESCRIPTION
The CLI package still needed `hops-config` (which has been removed in a previous commit.
This PR fixes that by replacing `hopsConfig.appDir` with `pkg-dir` in the `lib/commands.js` script.