### PR TITLE
Tweak manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "start": "cd packages/template-react; yarn start",
+    "start:minimal": "cd packages/template-minimal; yarn start",
+    "start:graphql": "cd packages/template-graphql; yarn start",
     "test": "lerna run test --stream",
     "lint": "eslint \"packages/**/*.js\"",
     "release": "lerna publish --exact --conventional-commits",
+    "release:major": "lerna publish --force-publish=* --cd-version major",
     "update": "yarn upgrade-interactive --latest && rm yarn.lock && yarn",
     "postupdate": "lerna clean --yes && lerna bootstrap",
     "reset": "git clean -dfx && yarn && yarn bootstrap",
@@ -55,13 +58,12 @@
   },
   "prettier": {
     "trailingComma": "es5",
-    "jsxBracketSameLine": true,
     "proseWrap": "never",
     "singleQuote": true
   },
   "eslintConfig": {
     "extends": ["semistandard", "prettier"],
-    "plugins": ["react", "prettier"],
+    "plugins": ["prettier"],
     "rules": {
       "prettier/prettier": "error"
     },
@@ -84,7 +86,6 @@
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^3.0.1",
     "husky": "^0.14.3",
     "lerna": "^2.5.1",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -12,7 +12,6 @@
     "hops-config": "9.5.0",
     "hops-express": "9.6.0",
     "hops-middleware": "9.4.2",
-    "hops-plugin": "9.5.0",
     "hops-react": "9.5.0",
     "hops-redux": "9.5.0",
     "hops-renderer": "9.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,7 +2448,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.0.2:
+doctrine@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -2726,15 +2726,6 @@ eslint-plugin-prettier@^2.4.0:
 eslint-plugin-promise@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
-
-eslint-plugin-react@^7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
-  dependencies:
-    doctrine "^2.0.0"
-    has "^1.0.1"
-    jsx-ast-utils "^2.0.0"
-    prop-types "^15.6.0"
 
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
@@ -4728,12 +4719,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-jsx-ast-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
-  dependencies:
-    array-includes "^3.0.3"
 
 killable@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Current state

There is no automated way to publish major releases, as we need to force publishing to ensure the major version of all packages is consistent. Also, some `package.json`s need cleanup.

## Changes introduced here

We now have a `release:major` script.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release