### PR TITLE
fix(hops-cli): allow to add .npmrc in templates

### DIFF
--- a/packages/cli/init.js
+++ b/packages/cli/init.js
@@ -81,12 +81,17 @@ function init(root, appName, options) {
       })
       .then(function() {
         fs.unlinkSync(tarball);
-        if (fs.existsSync(path.join(appRoot, '_gitignore'))) {
-          fs.renameSync(
-            path.join(appRoot, '_gitignore'),
-            path.join(appRoot, '.gitignore')
-          );
-        }
+
+        // allow templates to provide files that are ignored by npm pack such as .gitignore
+        ['_gitignore', '_npmrc'].forEach(function(ignoredFile) {
+          if (fs.existsSync(path.join(appRoot, ignoredFile))) {
+            fs.renameSync(
+              path.join(appRoot, ignoredFile),
+              path.join(appRoot, '.' + ignoredFile.slice(1))
+            );
+          }
+        });
+
         var newPackageManifest = readPackageManifest(pathToPackageManifest);
         writePackageManifest(
           pathToPackageManifest,


### PR DESCRIPTION
## Current state

Templates can't provide .npmrc file, because they're ignored by `npm pack`.

## Changes introduced here
Templates can provide a .npmrc file by adding a _npmrc file.
This works identically to what we are [already doing for .gitignore files](https://github.com/xing/hops/blob/master/packages/cli/init.js#L84).

[There are plenty of other files that are ignored by default when publishing a package](https://github.com/npm/npm/blob/219589aa4e5f8cac6d42c09311857440a0c18651/doc/misc/npm-developers.md#keeping-files-out-of-your-package), but I'm certain we don't need any more of them. Hence I went with an additional if instead of adding a more generic solution.


## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
