### PR TITLE
Fix Readmes

### DIFF
--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -54,7 +54,9 @@ export default (req, res) => {
 ```javascript
 const express = require('express');
 const createMiddleware = require('hops-middleware');
-const webpackConfig = require('hops-build-config').nodeConfig;
+
+const hopsBuildConfig = require('hops-build-config');
+const webpackConfig = require(hopsBuildConfig.nodeConfig);
 
 const app = express();
 

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -54,7 +54,9 @@ export default (req, res) => {
 
 ```javascript
 const createRenderer = require('hops-renderer');
-const webpackConfig = require('hops-build-config').nodeConfig;
+
+const hopsBuildConfig = require('hops-build-config');
+const webpackConfig = require(hopsBuildConfig.nodeConfig);
 
 const render = createRenderer(webpackConfig /*, watchOptions */);
 


### PR DESCRIPTION
## Current state

Currently, the example code on some READMEs use previous API versions and are therefore broken.

## Changes introduced here

Example code is fixed.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] Documentation has been added