### PR TITLE
Fix CSS Imports

### DIFF
--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -28,7 +28,7 @@ function shouldIncludeExternalModuleInBundle(module) {
     module.indexOf('babel-polyfill') === 0 ||
     // bundle everything the native require implementation can not handle
     // see: https://nodejs.org/api/modules.html#modules_all_together
-    /^.*\.(?!(?:js|json|mjs|node)$)/.test(module) ||
+    !/\.(?:js|json|mjs|node)$/.test(require.resolve(module)) ||
     checkEsnext(module)
   );
 }

--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -26,7 +26,9 @@ function shouldIncludeExternalModuleInBundle(module) {
     module.indexOf('hops') === 0 ||
     module.indexOf('core-js') === 0 ||
     module.indexOf('babel-polyfill') === 0 ||
-    /^.*\.(?!js(?:on)?$)/.test(module) ||
+    // bundle everything the native require implementation can not handle
+    // see: https://nodejs.org/api/modules.html#modules_all_together
+    /^.*\.(?!(?:js|json|mjs|node)$)/.test(module) ||
     checkEsnext(module)
   );
 }

--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -23,9 +23,10 @@ function findNodeModules(start) {
 
 function shouldIncludeExternalModuleInBundle(module) {
   return (
+    module.indexOf('hops') === 0 ||
     module.indexOf('core-js') === 0 ||
     module.indexOf('babel-polyfill') === 0 ||
-    module.indexOf('hops') === 0 ||
+    /^.*\.(?!js(?:on)?$)/.test(module) ||
     checkEsnext(module)
   );
 }


### PR DESCRIPTION
This pull request closes issue #342

## Current state

Previously, most of `node_modules` was excluded from bundling in Node.js builds. Unfortunately, this also prevented CSS files (and other file types) from being imported.

## Changes introduced here

This commit adds an RegExp check to make sure we bundle all file types except JSON and JS.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)