### PR TITLE
Disable GraphQL Data Fetching in Static Mode

### DIFF
--- a/packages/graphql/node.js
+++ b/packages/graphql/node.js
@@ -21,7 +21,7 @@ exports.GraphQLContext.prototype = Object.assign({}, common, {
     return introspectionResult;
   },
   getTemplateData: function(templateData, rootElement) {
-    return ReactApollo.getDataFromTree(rootElement).then(
+    return this.prefetchData(rootElement).then(
       function() {
         return Object.assign({}, templateData, {
           globals: (templateData.globals || []).concat([
@@ -37,6 +37,11 @@ exports.GraphQLContext.prototype = Object.assign({}, common, {
         });
       }.bind(this)
     );
+  },
+  prefetchData: function(rootElement) {
+    return process.env.HOPS_MODE !== 'static'
+      ? ReactApollo.getDataFromTree(rootElement)
+      : Promise.resolve();
   },
 });
 


### PR DESCRIPTION
This pull request closes issue #324 

## Current state

Currently, GraphQL data is always being prefetched, even in static rendering mode.

## Changes introduced here

In static mode, during server side rendering, GraphQL data is no longer being prefetched. That appears to be the sane default. The old behaviour can be restored by extending `GraphQLContext` and overriding its 'prefetchData' method.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)