### PR TITLE
Improve CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,6 +48,8 @@ yarn add hops
 
 ## Usage
 
+### Bootstrapping a Project
+
 ```bash
 hops init my-new-hops-project [--verbose] [--npm] [--template hops-template-*]
 ```
@@ -67,48 +69,25 @@ Then `cd` into `my-new-hops-project` and execute `hops --help` again to see a li
 
 ### Available Commands
 
-* `hops build` - initiates a project build to generate browser and server JS bundles
-* `hops develop` - starts the webpack development server with hot code reloading for fast local iterations
-* `hops serve` - starts a production Node.js Express server using the generated JS bundle from `hops build`
-* `hops start` - if NODE_ENV is set to production, this runs `hops serve`. Otherwise `hops develop` gets executed
+* `hops build` (provided by [`hops-build`](https://www.npmjs.com/package/hops-build)) - initiates a project build to generate browser and server JS bundles
+* `hops develop` (provided by [`hops-build`](https://www.npmjs.com/package/hops-build)) - starts the webpack development server with hot code reloading for fast local iterations
+* `hops serve` (provided by [`hops-express`](https://www.npmjs.com/package/hops-express)) - starts a production Node.js Express server using the generated JS bundle from `hops build`
+* `hops start` - if NODE_ENV is set to production, this runs `hops build` and `hops serve`. Otherwise `hops develop` is executed.
 
-`hops build` accepts additional arguments: `--static` / `-s` to generate static HTML app shells for all configured hops locations.
+All commands accept additional arguments:
 
-hops only lists commands that are available through other hops packages.
+* `--production` / `-p` - equivalent to setting `NODE_ENV` to `production`
+* `--static` / `-s` - to generate static HTML app shells for all configured hops locations.
+* `--clean` / `-c` - defaults to `true`, removes the build directory before initiating a build (n/a for `hops serve`)
+
+`hops` only lists commands that are made available by other installed hops packages.
 
 So for example `hops build` and `hops develop` are only available if `hops-build` is installed as a dependency in your project ([`hops-template-react`](https://github.com/xing/hops/tree/master/packages/template-react) includes it by default).
 
 The command `hops serve` is only available if `hops-express` is installed as a dependency in your project (also included in the default react template).
 
-And the command `hops start` is only available if both `hops-build` and `hops-express` are installed as dependencies.
+And the command `hops start` is only available if `hops-build` and `hops-express` are installed as dependencies. To disable rebuilds in production mode, you must simply disable cleaning: `hops start -p --clean=false`.
 
 ## Configuration
 
-hops is being configured through `hops-config` which in turn uses the npm config mechanism (read more at [hops-config](https://github.com/xing/hops/tree/master/packages/config)).
-
-That means that while you can run `hops` commands independently and they will use the configuration from your package.json file, you cannot overwrite these values through `npm config set ...` in this mode. For that to work you need to run the hops through your package.json `scripts` fields.
-
-```JSON
-{
-  "name": "my-application",
-  "scripts": {
-    "start": "hops start"
-  },
-  "config": {
-    "hops:": {
-      "port": "3000"
-    }
-  }
-}
-```
-
-```bash
-npm config set my-application:hops:port 1337
-```
-
-And now you can execute the "start" command through npm or yarn:
-
-```bash
-npm start
-yarn start
-```
+`hops` is being configured through [`hops-config`](https://github.com/xing/hops/tree/master/packages/config).

--- a/packages/graphql/commands/graphql.js
+++ b/packages/graphql/commands/graphql.js
@@ -4,7 +4,11 @@
 module.exports = function defineGraphQLCommand(args) {
   args.command('graphql', 'Execute GraphQL specific tasks', function(yargs) {
     return yargs
-      .usage('Usage: hops-graphql <command>')
+      .usage(
+        'Usage: ' +
+          (require.main === module ? 'hops-graphql' : '$0 graphql') +
+          ' <command>'
+      )
       .command({
         command: 'introspect',
         describe: 'Fetches GraphQL schema information for introspection',


### PR DESCRIPTION
## Current state

Hops CLI's `start` command does not perform a build in production mode.

## Changes introduced here

In production mode, if hops-build is installed, a full build is executed when starting the server. This behaviour can be deactivated by passing '--clean=false'.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)