### PR TITLE
Add Header component to allow setting http headers declaratively

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -39,11 +39,13 @@ export default render(<App />, createContext());
 | template   | Function | [defaultTemplate](https://github.com/xing/hops/blob/master/packages/react/lib/template.js) | template function supporting all relevant React Helmet and hops-react features                                                                                                                                                                  |
 | router     | Object   | {}                                                                                         | props to be passed to one of the relevant ReactRouter implementations: [`<StaticRouter />`](https://reacttraining.com/react-router/web/api/StaticRouter) or [`<BrowserRouter />`](https://reacttraining.com/react-router/web/api/BrowserRouter) |
 
-## `<Miss />` and `<Status code={200} />`
+## `<Miss />`, `<Status code={200} />` and `<Header name="x-foo" value="bar" />`
 
-To declaratively control server behavior from your application, you can use two React components provided by hops-react. Neither of these components produces any html output, both are effectively no-ops if used in the browser.
+To declaratively control server behavior from your application, you can use the React components provided by hops-react. Neither of these components produces any html output, they are effectively no-ops if used in the browser.
 
 On the server, however, `<Miss />` makes sure Express' `next()` middleware function is being called, signalling Express that your application is not responsible for handling the current request. `<Status />`, however controls the HTTP status code returned by the server.
+
+`<Header />` allows to set abritraty http headers for each request. Elements rendered more deeply will override those included higher up in the rendered tree. Adding the same header (such as `Set-Cookie`) multiple times can be achieved by providing an array as value. `<Header name="x-foo" value={['bar', 'baz']}/>`
 
 # Basic Example
 

--- a/packages/react/lib/components.js
+++ b/packages/react/lib/components.js
@@ -15,3 +15,11 @@ exports.Status = ReactRouter.withRouter(function Status(props) {
   }
   return null;
 });
+
+exports.Header = ReactRouter.withRouter(function Header(props) {
+  if (props.staticContext) {
+    props.staticContext.headers = props.staticContext.headers || {};
+    props.staticContext.headers[props.name] = props.value;
+  }
+  return null;
+});

--- a/packages/react/node.js
+++ b/packages/react/node.js
@@ -95,9 +95,12 @@ exports.render = function(reactElement, _context) {
         } else if (routerContext.url) {
           res.status(routerContext.status || 301);
           res.set('Location', routerContext.url);
+          routerContext.headers && res.set(routerContext.headers);
           res.end();
         } else {
           res.status(routerContext.status || 200);
+          routerContext.headers && res.set(routerContext.headers);
+
           res.type('html');
           res.send(markup);
         }


### PR DESCRIPTION
## Current state
No way to set http headers from inside the application.
This is useful for example to set (surrogate) cache headers or to set cookies. 

## Changes introduced here
Header component is added to allow setting http headers

**Needs tests.**

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [x] Documentation has been added
