### PR TITLE
 Fix extends overriding previous values instead of extending

### DIFF
--- a/packages/build-config/README.md
+++ b/packages/build-config/README.md
@@ -37,13 +37,11 @@ The following example shows how to overwrite / extend the webpack configurations
 ```JSON
 "name": "my-application",
 "version": "1.0.0",
-"config": {
-    "hops": {
-      "buildConfig": "./path-to-my-custom-webpack-config/build.js",
-      "developConfig": "./path-to-my-custom-webpack-config/develop.js",
-      "nodeConfig": "./path-to-my-custom-webpack-config/node.js"
-    }
-  }
+"hops": {
+  "buildConfig": "./path-to-my-custom-webpack-config/build.js",
+  "developConfig": "./path-to-my-custom-webpack-config/develop.js",
+  "nodeConfig": "./path-to-my-custom-webpack-config/node.js"
+}
 ```
 
 #### `./path-to-my-custom-webpack-config/build.js`

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -53,7 +53,7 @@ function applyInheritedConfig(config) {
         sync: true,
       });
       var _result = loader.load();
-      assign(result, _result ? _result.config : {});
+      assign(result, assign(_result ? _result.config : {}, result));
     } else {
       console.error('Failed to load inherited config', configName);
     }


### PR DESCRIPTION
## Current state

Given the following package.json

```json
"hops": {
"extends": "./hops.js",
"value": true
}
```

and hops.js

```js
module.exports = {
  value: false
}
```

Expected value: true
Actual value: false

## Changes introduced here

Earlier values take precedence


## Checklist

* [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [ ] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
