### PR TITLE
Placeholders Everywhere

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -43,7 +43,7 @@ Please find a list of the default options below. They can be set in your project
 
 All keys matching `/(config|file|dir)s?$/i` will be treated as a filesystem path (or array thereof) and resolved relative to your app's root folder. This only applies if the respective value is not an absolute path already.
 
-Additionally, you can use placeholders within such filesystem configs to reference others. For example, by configuring `"fooDir": "<cacheDir>/foo"`, you can specify a subfolder of cache directory.
+Additionally, you can use placeholders within config properties to reference others. For example, by configuring `"fooDir": "<cacheDir>/foo"`, you can specify a subfolder of cache directory.
 
 ## Configure via `package.json`
 


### PR DESCRIPTION
## Current state

Placeholders (`<placeholder>`) can only be used in filesystem related config properties.

## Changes introduced here

Placeholders can be used in all kinds of config properties to reference other values. For example, assuming your `basePath` is `/`, `<basePath>/foo` will be resolved to `/foo`.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [X] Documentation has been added