### PR TITLE
chore: fail install when npm is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "DJCordhose <oliver@zeigermann.de> (https://www.xing.com/profile/Oliver_Zeigermann)"
   ],
   "scripts": {
+    "preinstall":
+      "/usr/bin/env bash -c \"[[ $npm_execpath = *'yarn'* ]] || (echo 'hops uses yarn workspaces to manage packages.\nPlease use yarn to install dependencies: https://yarnpkg.com/' && exit 1)\"",
+
     "bootstrap": "lerna bootstrap",
     "start": "cd packages/template-react; yarn start",
     "start:minimal": "cd packages/template-minimal; yarn start",


### PR DESCRIPTION
## Current state

Developers try to install packages using npm, running into all sorts of issues since we are using yarn workspaces which are not supported by npm.

## Changes introduced here
Added hook to ensure installation fails when trying to use npm

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
