### PR TITLE
Fix Config Extension Mechanism

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -8,22 +8,25 @@ var root = require('pkg-dir').sync();
 
 var cosmiconfig = require('cosmiconfig');
 
-function getDefaultConfig() {
-  return {
-    https: false,
-    host: '0.0.0.0',
-    port: 8080,
-    locations: [],
-    basePath: '',
-    assetPath: '',
-    browsers: '> 1%, last 2 versions, Firefox ESR',
-    node: 'current',
-    envVars: { HOPS_MODE: 'dynamic' },
-    moduleDirs: [],
-    appDir: '.',
-    buildDir: 'build',
-    cacheDir: 'node_modules/.cache/hops',
-  };
+function applyDefaultConfig(config) {
+  return assign(
+    {
+      https: false,
+      host: '0.0.0.0',
+      port: 8080,
+      locations: [],
+      basePath: '',
+      assetPath: '',
+      browsers: '> 1%, last 2 versions, Firefox ESR',
+      node: 'current',
+      envVars: { HOPS_MODE: 'dynamic' },
+      moduleDirs: [],
+      appDir: '.',
+      buildDir: 'build',
+      cacheDir: 'node_modules/.cache/hops',
+    },
+    config
+  );
 }
 
 function applyUserConfig(config) {
@@ -53,7 +56,7 @@ function applyInheritedConfig(config) {
         sync: true,
       });
       var _result = loader.load();
-      assign(result, assign(_result ? _result.config : {}, result));
+      result = assign(_result ? _result.config : {}, result);
     } else {
       console.error('Failed to load inherited config', configName);
     }
@@ -126,13 +129,13 @@ function normalizeURLs(config) {
 }
 
 module.exports = [
-  getDefaultConfig,
   applyUserConfig,
   applyInheritedConfig,
   applyEnvironmentConfig,
+  applyDefaultConfig,
   resolvePlaceholders,
   resolvePaths,
   normalizeURLs,
 ].reduce(function(result, step) {
   return step(result);
-}, null);
+}, {});


### PR DESCRIPTION
## Current state

`extends` is currently completely broken, as the default values always take precedence.

## Changes introduced here

Default values are now mixed in after all other config override mechanisms habe been applied.

## Checklist

* [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [X] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
