### PR TITLE
chore: add no-only lint rule for mocha to avoid false positive ci runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "scripts": {
     "preinstall":
       "/usr/bin/env bash -c \"[[ $npm_execpath = *'yarn'* ]] || (echo 'hops uses yarn workspaces to manage packages.\nPlease use yarn to install dependencies: https://yarnpkg.com/' && exit 1)\"",
-
     "bootstrap": "lerna bootstrap",
     "start": "cd packages/template-react; yarn start",
     "start:minimal": "cd packages/template-minimal; yarn start",
@@ -74,9 +73,10 @@
   },
   "eslintConfig": {
     "extends": ["semistandard", "prettier"],
-    "plugins": ["prettier"],
+    "plugins": ["prettier", "mocha-no-only"],
     "rules": {
-      "prettier/prettier": "error"
+      "prettier/prettier": "error",
+      "mocha-no-only/mocha-no-only": "error"
     },
     "parserOptions": {
       "ecmaVersion": 5,
@@ -94,6 +94,7 @@
     "eslint-config-semistandard": "^12.0.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-mocha-no-only": "^0.0.5",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-promise": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,6 +2708,12 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-mocha-no-only@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha-no-only/-/eslint-plugin-mocha-no-only-0.0.5.tgz#f990702b1ddbd255c214d91cf7dc67fb3cfe28a7"
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-node@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
@@ -7096,6 +7102,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
We recently accidentally added a `.only` to a mocha describe block, potentially causing false positive ci runs.

To avoid that in the future this PR adds a linting rule that fails when a .only is found in a test.

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
