### PR TITLE
feat(lambda): hide aws configuration from browser by prefixing with _

### DIFF
--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -13,16 +13,12 @@ This is the minimal configuration required to get started with hops-lambda:
 ```diff
 --- a/package.json
 +++ b/package.json
-@@ -6,5 +6,8 @@
-   "config": {
-     "hops": {
-+      "assetPath": "prod",
-+      "basePath": "prod",
-       "browsers": "last 1 Chrome versions",
-+      "node": "6.10.3",
-       "locations": [
-         "/",
-@@ -22,4 +25,5 @@
+   "hops": {
++    "assetPath": "prod",
++    "basePath": "prod",
+     "browsers": "last 1 Chrome versions",
++    "node": "6.10.3"
+   },
    "dependencies": {
      "hops-express": "^9.0.0",
 +    "hops-lambda": "^9.0.0",
@@ -68,27 +64,23 @@ In order to use hops-lambda you need to define the Node.js target version for wh
 
 ```json
 {
-  "config": {
-    "hops": {
-      "node": "6.10.3"
-    }
+  "hops": {
+    "node": "6.10.3"
   }
 }
 ```
 
 ### Available options through Hops npm config
 
-The following options are supported in a [hops-config](https://github.com/xing/hops/tree/master/packages/config) `aws` object.
+The following options are supported in a [hops-config](https://github.com/xing/hops/tree/master/packages/config) `_aws` object.
 
 ```json
 {
   "name": "foo",
   "version": "1.0.0",
-  "config": {
-    "hops": {
-      "aws": {
-        ...
-      }
+  "hops": {
+    "_aws": {
+      ...
     }
   }
 }

--- a/packages/lambda/lib/aws-config.js
+++ b/packages/lambda/lib/aws-config.js
@@ -12,7 +12,7 @@ var DEFAULT_EXCLUDE = ['flow-typed/**', 'typings/**'];
 var AVAILABLE_NODE_RUNTIME = ['6.10.3'];
 
 module.exports = function getAWSConfig() {
-  var awsConfig = hopsConfig.aws || {};
+  var awsConfig = hopsConfig._aws || hopsConfig.aws || {};
   var manifest = require(path.join(hopsConfig.appDir, 'package.json'));
 
   var region =


### PR DESCRIPTION
This commit changes the lambda configuration to use the key `_aws`
instead of `aws` which means the aws config will not be included in
the client-side JS bundle.

If `hopsConfig._aws` is not found it falls back to `hopsConfig.aws` to
ensure that this is a non-breaking backwards-compatible change.

Fixes: #319