### PR TITLE
fix(build): log errors without "stack" instead of swallowing them

### DIFF
--- a/packages/build/build.js
+++ b/packages/build/build.js
@@ -22,7 +22,7 @@ var nodeConfig = injectProgressPlugin(require(hopsBuildConfig.nodeConfig));
 
 function defaultCallback(error, stats) {
   if (error) {
-    console.error(error.stack.toString());
+    console.error(error.stack ? error.stack.toString() : error.toString());
   } else {
     console.log(stats.toString({ chunks: false, modules: false }));
   }


### PR DESCRIPTION
Some errors don't have a "stack" property, which would lead to a
TypeError when trying to log the original error.

Now all errors are printed, with or without stack.