### PR TITLE
feat(express): statically serve app shells for dynamic path segments

### DIFF
--- a/packages/build/lib/generate.js
+++ b/packages/build/lib/generate.js
@@ -14,7 +14,9 @@ var createRenderer = require('./renderer');
 function getFileName(location) {
   return path.join.apply(
     path,
-    [hopsConfig.buildDir].concat(index(location).split(path.sep))
+    [hopsConfig.buildDir].concat(
+      index(location.replace(/:/g, '')).split(path.sep)
+    )
   );
 }
 

--- a/packages/express/lib/utils.js
+++ b/packages/express/lib/utils.js
@@ -6,6 +6,7 @@ var net = require('net');
 var path = require('path');
 var http = require('http');
 var https = require('https');
+var Router = require('react-router');
 
 var hopsConfig = require('hops-config');
 
@@ -94,14 +95,11 @@ exports.rewritePath = function rewritePath(req, res, next) {
     process.env.HOPS_MODE === 'static' &&
     Array.isArray(hopsConfig.locations)
   ) {
-    var location = hopsConfig.locations.find(function(location) {
-      return (
-        location !== hopsConfig.basePath + '/' &&
-        req.url.indexOf(location) === 0
-      );
-    });
+    var location = hopsConfig.locations.map(function(location) {
+      return Router.matchPath(req.url, { path: location, exact: true });
+    })[0];
     if (location) {
-      req.url = location.replace(/([^\\/])$/, '$1/');
+      req.url = location.path.replace(/([^\\/])$/, '$1/').replace(/:/g, '');
     }
   }
   next();

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -36,6 +36,7 @@
     "helmet": "^3.8.2",
     "hops-config": "10.4.0",
     "mime": "^2.2.0",
+    "react-router": "^4.2.0",
     "server-timings": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows us to define dynamic path segments in the `locations`
section of the `hops-config` the same way as in our route definitions.

**Example:**
for the following routes (defined in your application):
```javascript
<Switch>
  <Route exact path="/categories" component={Categories} />
  <Route exact path="/exercises/:category" component={Exercises} />
</Switch>
```
you can configure these locations to be pre-rendered as app shells:
```json
  "hops": {
    "locations": ["/categories", "/exercises/:category"]
  }
```

And when executing `hops build --static` the above defined route
component (`Exercises`) will receive:
`props.match.category = ':category'`
to enable you to decide whether to render an app shell or actual
content.

When using `hops-express` to serve static routes only
(`hops serve --static`) it will automatically find the matching
app shells for the requested route.