### PR TITLE
(1/2) Deprecate hops-middleware and hops-renderer

### DIFF
--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -1,5 +1,9 @@
 # Hops Middleware
 
+![deprecated](https://img.shields.io/badge/status-deprecated-red.svg)
+
+**This package is deprecated and has been moved into the [hops-build](https://www.npmjs.com/package/hops-build) package.**
+
 [![npm](https://img.shields.io/npm/v/hops-middleware.svg)](https://www.npmjs.com/package/hops-middleware)
 
 Hops assumes you will write an Express-style middleware, transpiles it using Webpack and makes it easy to use in non-transpiled and even non-server code. Hops' middleware is a simple helper to simplify using your custom middleware with an Express server.

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,5 +1,9 @@
 # Hops Renderer
 
+![deprecated](https://img.shields.io/badge/status-deprecated-red.svg)
+
+**This package is deprecated and has been moved into the [hops-build](https://www.npmjs.com/package/hops-build) package.**
+
 [![npm](https://img.shields.io/npm/v/hops-renderer.svg)](https://www.npmjs.com/package/hops-renderer)
 
 Hops assumes you will write an Express-style middleware, transpiles it and makes it easy to use in non-transpiled and even non-server code. Hops' renderer is a simple helper to enable you to use your custom middleware outside of Express servers.


### PR DESCRIPTION
This PR adds deprecation notices to the READMEs of
hops-middleware and hops-renderer and should be merged and released
separately of the actual removal PR.