### PR TITLE
feat(express): enable gzip compression

### DIFF
--- a/packages/express/lib/app.js
+++ b/packages/express/lib/app.js
@@ -6,6 +6,7 @@ var path = require('path');
 var express = require('express');
 var mime = require('mime');
 var helmet = require('helmet');
+var compression = require('compression');
 
 var hopsConfig = require('hops-config');
 var utils = require('./utils');
@@ -15,6 +16,7 @@ var swRe = new RegExp(hopsConfig.workerPath + '$');
 function createApp(options) {
   var app = express();
   app.use(helmet());
+  app.use(compression());
   app.use(utils.rewritePath);
   app.use(
     express.static(hopsConfig.buildDir, {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "compression": "^1.7.2",
     "express": "^4.16.0",
     "helmet": "^3.8.2",
     "hops-config": "10.2.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,13 +1710,31 @@ compress-commons@^1.2.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
+compressible@~2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
+  dependencies:
+    mime-db ">= 1.33.0 < 2"
+
+compression@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
+  dependencies:
+    accepts "~1.3.4"
+    bytes "3.0.0"
+    compressible "~2.0.13"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.1"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
@@ -5142,7 +5160,7 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.33.0:
+"mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
@@ -5546,6 +5564,10 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This PR adds gzip compression to the express server.

~WIP because it needs investigation how Lambda / API Gateway behave when
they deal with gzip compressed responses.~
API Gateway expects Lambda to return compressed responses in order to serve compressed responses to the client.