### PR TITLE
refactor(lambda): only rewrite request when basePath contains stage

### DIFF
--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -2,6 +2,13 @@
 
 var serverlessHttp = require('serverless-http');
 var app = require('hops-express').createApp({});
+var hopsConfig = require('hops-config');
+
+var awsConfig = require('./lib/aws-config')();
+
+var shouldIncludeStageInRequest =
+  awsConfig.basePath.indexOf(awsConfig.stageName) === 0 &&
+  hopsConfig.assetPath.indexOf(awsConfig.stageName) === 0;
 
 // NOTE: If you get ERR_CONTENT_DECODING_FAILED in your browser, this is likely
 // due to a compressed response (e.g. gzip) which has not been handled correctly
@@ -35,7 +42,9 @@ var binaryMimeTypes = [
 exports.handler = serverlessHttp(app, {
   binary: binaryMimeTypes,
   request: function(request, context) {
-    request.url = context.requestContext.path;
+    if (shouldIncludeStageInRequest) {
+      request.url = context.requestContext.path;
+    }
     return request;
   },
 });


### PR DESCRIPTION
This fixes an issue we had with our internal deployment where a proxy
would be used in front of Lambda, which broke when basePath was set to
'/'.