### PR TITLE
allow function as Header prop

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -64,7 +64,7 @@ To declaratively control server behavior from your application, you can use the 
 
 On the server, however, `<Miss />` makes sure Express' `next()` middleware function is being called, signalling Express that your application is not responsible for handling the current request. `<Status />`, however controls the HTTP status code returned by the server.
 
-`<Header />` allows to set abritraty http headers for each request. Elements rendered more deeply will override those included higher up in the rendered tree. Adding the same header (such as `Set-Cookie`) multiple times can be achieved by providing an array as value. `<Header name="x-foo" value={['bar', 'baz']}/>`
+`<Header />` allows to set abritraty http headers for each request. Elements rendered more deeply will override those included higher up in the rendered tree. Adding the same header (such as `Set-Cookie`) multiple times can be achieved by providing an array as value. `<Header name="x-foo" value={['bar', 'baz']}/>` If a function is passed as `value`, it will be called with the headers that have already been set and the return value is used as header value.
 
 # Basic Example
 

--- a/packages/react/lib/components.js
+++ b/packages/react/lib/components.js
@@ -19,7 +19,10 @@ exports.Status = ReactRouter.withRouter(function Status(props) {
 exports.Header = ReactRouter.withRouter(function Header(props) {
   if (props.staticContext) {
     props.staticContext.headers = props.staticContext.headers || {};
-    props.staticContext.headers[props.name] = props.value;
+    props.staticContext.headers[props.name] =
+      typeof props.value === 'function'
+        ? props.value(props.staticContext.headers)
+        : props.value;
   }
   return null;
 });

--- a/packages/spec/mock/integration/headers/index.js
+++ b/packages/spec/mock/integration/headers/index.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { Miss, Header } from 'hops-react';
+
+export default () => {
+  return (
+    <Switch>
+      <Route
+        path="/headers/simple"
+        render={() => {
+          return (
+            <Fragment>
+              <Header name="foo" value="bar" />
+              <Header name="x-accel-expires" value="no" />
+            </Fragment>
+          );
+        }}
+      />
+      <Route
+        path="/headers/multiple"
+        render={() => {
+          return <Header name="set-cookie" value={['foo=bar', 'bar=foo']} />;
+        }}
+      />
+      <Route
+        path="/headers/function"
+        render={() => {
+          return (
+            <Fragment>
+              <Header name="foo" value="ba" />
+              <Header
+                name="foo"
+                value={headers => {
+                  return headers.foo + 'r';
+                }}
+              />
+            </Fragment>
+          );
+        }}
+      />
+      <Miss />
+    </Switch>
+  );
+};

--- a/packages/spec/mock/integration/main.js
+++ b/packages/spec/mock/integration/main.js
@@ -5,10 +5,12 @@ import { Miss, render, createContext } from 'hops-react';
 import { headline } from './style.css';
 
 const Home = () => <h1 className={headline}>Hello World!</h1>;
+import Headers from './headers';
 
 const App = () => (
   <Switch>
     <Route exact path="/" component={Home} />
+    <Route path="/headers" component={Headers} />
     <Miss />
   </Switch>
 );

--- a/packages/spec/serve.js
+++ b/packages/spec/serve.js
@@ -131,4 +131,33 @@ describe('production server', function() {
       );
     });
   });
+
+  describe('Header component', function() {
+    it('adds headers', function() {
+      return fetch('http://localhost:8080/headers/simple').then(function(
+        response
+      ) {
+        assert.equal(response.headers.get('foo'), 'bar');
+        assert.equal(response.headers.get('x-accel-expires'), 'no');
+      });
+    });
+
+    it('adds same header multiple times', function() {
+      return fetch('http://localhost:8080/headers/multiple').then(function(
+        response
+      ) {
+        var setCookieHeaders = response.headers.getAll('set-cookie');
+        assert(setCookieHeaders.indexOf('foo=bar') > -1);
+        assert(setCookieHeaders.indexOf('bar=foo') > -1);
+      });
+    });
+
+    it('allows to pass function as value', function() {
+      return fetch('http://localhost:8080/headers/function').then(function(
+        response
+      ) {
+        assert.equal(response.headers.get('foo'), 'bar');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Current state
Header component can only be used to override headers. 

## Changes introduced here
`value` can be a function which gets passed headers that were already set, which allows to derive headers from those.
E.g. one could add to existing cookies.

## Checklist

* [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [ ] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
