### PR TITLE
test: make paths in config unit tests more robust by using __dirname

### DIFF
--- a/packages/spec/config.js
+++ b/packages/spec/config.js
@@ -33,7 +33,7 @@ describe('config', function() {
       moduleDirs: [],
       appDir: process.cwd(),
       buildDir: path.resolve('build'),
-      cacheDir: path.resolve(path.join('node_modules', '.cache', 'hops')),
+      cacheDir: path.resolve('node_modules', '.cache', 'hops'),
       workerFile: null,
       enableServerTimings: true,
       workerPath: '/sw.js',
@@ -41,38 +41,38 @@ describe('config', function() {
   });
 
   it('should override defaults with config from package.json', function() {
-    process.chdir(path.resolve('mock', 'config', 'package-json'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'package-json'));
     var hopsConfig = require('hops-config');
     assert.equal(hopsConfig.port, 1337);
   });
 
   it('should override defaults with config from .hopsrc.json', function() {
-    process.chdir(path.resolve('mock', 'config', 'rc-file'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'rc-file'));
     var hopsConfig = require('hops-config');
     assert.equal(hopsConfig.port, 3000);
   });
 
   it('should overwrite base config with config defined in extension', function() {
-    process.chdir(path.resolve('mock', 'config', 'simple-extends'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'simple-extends'));
     var hopsConfig = require('hops-config');
     assert.equal(hopsConfig.https, true);
   });
 
   it('should ensure that user config takes precedence over extenion / base config', function() {
-    process.chdir(path.resolve('mock', 'config', 'simple-extends'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'simple-extends'));
     var hopsConfig = require('hops-config');
     assert.equal(hopsConfig.port, 8082);
   });
 
   it('should allow nested extends', function() {
-    process.chdir(path.resolve('mock', 'config', 'nested-extends'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'nested-extends'));
     var hopsConfig = require('hops-config');
     assert.deepEqual(hopsConfig.locations, ['/foo']);
     assert.equal(hopsConfig.node, '8.0.0');
   });
 
   it('should use deep-merge strategy for objects', function() {
-    process.chdir(path.resolve('mock', 'config', 'deep-merge'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'deep-merge'));
     var hopsConfig = require('hops-config');
     assert.deepEqual(hopsConfig.aws, {
       stageName: 'foo',
@@ -84,7 +84,7 @@ describe('config', function() {
   });
 
   it('should overwrite values via env config', function() {
-    process.chdir(path.resolve('mock', 'config', 'env'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'env'));
     process.env.HOPS_ENV = 'test-1';
     var hopsConfig = require('hops-config');
     assert.deepEqual(hopsConfig.aws, {
@@ -94,7 +94,7 @@ describe('config', function() {
   });
 
   it('should replace placeholders in config values', function() {
-    process.chdir(path.resolve('mock', 'config', 'placeholders'));
+    process.chdir(path.join(__dirname, 'mock', 'config', 'placeholders'));
     var hopsConfig = require('hops-config');
     assert.equal(hopsConfig.fonts, hopsConfig.assetPath + '/foo');
   });

--- a/packages/spec/mock/config/nested-extends/package.json
+++ b/packages/spec/mock/config/nested-extends/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hops-config-package-json",
+  "name": "hops-config-nested-extends",
   "version": "1.0.0",
   "hops": {
     "extends": "./config-1.js"


### PR DESCRIPTION
When executing tests from the workspace root directly (through
`./node_modules/.bin/mocha 'packages/spec/*.js'`) the config tests will
not be able to resolve to the correct mock directories because at the
moment they were using `path.resolve` which resolves from the current
working directory.
By using `__dirname` we can circumvent this issue and make the tests
more robust.