### PR TITLE
fix(renderer): fix static build not working due to missing res.locals.timing

### DIFF
--- a/packages/build/lib/renderer.js
+++ b/packages/build/lib/renderer.js
@@ -12,6 +12,7 @@ var createMiddleware = require('./middleware');
 
 module.exports = function createRenderer(webpackConfig, watchOptions) {
   var router = new express.Router();
+  router.use(hopsExpressUtils.timings);
   hopsExpressUtils.bootstrap(router, hopsConfig);
   hopsExpressUtils.registerMiddleware(
     router,


### PR DESCRIPTION
# Current state
Static builds due not work, because the server timings middleware is not applied in the renderer. 

```
$ hops build --static
TypeError: Cannot read property 'start' of undefined
    at /Users/robin.drexler/Development/_hops/packages/react/node.js:73:1
    at /Users/robin.drexler/Development/_hops/packages/build/lib/middleware.js:42:9
    at <anonymous>
✨  Done in 6.31s.
```

# New state

Server timings middleware is not applied in the renderer, fixing the issue. 
I will provide tests for that, after #436 is merged. 