### PR TITLE
[WIP]fix: do not use loader name options to configure assetPath anymore

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -10,16 +10,15 @@ var WriteFilePlugin = require('../plugins/write-file');
 var ServiceWorkerPlugin = require('../plugins/service-worker');
 
 var hopsConfig = require('hops-config');
-
-var getAssetPath = path.join.bind(path, hopsConfig.assetPath);
+var publicPath = ('/' + hopsConfig.assetPath + '/').replace(/\/\//, '/');
 
 module.exports = {
   entry: require.resolve('../shims/build'),
   output: {
-    path: hopsConfig.buildDir,
-    publicPath: '/',
-    filename: getAssetPath('[name]-[chunkhash:16].js'),
-    chunkFilename: getAssetPath('chunk-[id]-[chunkhash:16].js'),
+    path: path.join(hopsConfig.buildDir, hopsConfig.assetPath),
+    publicPath: publicPath,
+    filename: '[name]-[chunkhash:16].js',
+    chunkFilename: 'chunk-[id]-[chunkhash:16].js',
   },
   context: hopsConfig.appDir,
   resolve: require('../sections/resolve')('build'),
@@ -52,7 +51,7 @@ module.exports = {
     }),
     new webpack.HashedModuleIdsPlugin(),
     new ExtractTextPlugin({
-      filename: getAssetPath('[name]-[contenthash:16].css'),
+      filename: '[name]-[contenthash:16].css',
       allChunks: true,
       ignoreOrder: true,
     }),

--- a/packages/build-config/configs/develop.js
+++ b/packages/build-config/configs/develop.js
@@ -7,8 +7,7 @@ var webpack = require('webpack');
 var ServiceWorkerPlugin = require('../plugins/service-worker');
 
 var hopsConfig = require('hops-config');
-
-var getAssetPath = path.join.bind(path, hopsConfig.assetPath);
+var publicPath = ('/' + hopsConfig.assetPath + '/').replace(/\/\//, '/');
 
 module.exports = {
   entry: [
@@ -16,10 +15,10 @@ module.exports = {
     require.resolve('../shims/develop'),
   ],
   output: {
-    path: hopsConfig.buildDir,
-    publicPath: '/',
-    filename: getAssetPath('[name].js'),
-    chunkFilename: getAssetPath('chunk-[id].js'),
+    path: path.join(hopsConfig.buildDir, hopsConfig.assetPath),
+    publicPath: publicPath,
+    filename: '[name].js',
+    chunkFilename: 'chunk-[id].js',
   },
   context: hopsConfig.appDir,
   resolve: require('../sections/resolve')('develop'),

--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -35,12 +35,14 @@ function shouldIncludeExternalModuleInBundle(module) {
 
 var modulesDir = findNodeModules(process.cwd());
 
+var publicPath = ('/' + hopsConfig.assetPath + '/').replace(/\/\//, '/');
+
 module.exports = {
   target: 'node',
   entry: require.resolve('../shims/node'),
   output: {
     path: hopsConfig.cacheDir,
-    publicPath: '/',
+    publicPath: publicPath,
     filename: 'server.js',
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '[absolute-resource-path]',

--- a/packages/build-config/sections/module-rules/file.js
+++ b/packages/build-config/sections/module-rules/file.js
@@ -1,14 +1,10 @@
 'use strict';
 
-var path = require('path');
-
-var hopsConfig = require('hops-config');
-
 exports.default = {
   exclude: /\.(?:m?jsx?|html|json)$/,
   loader: require.resolve('file-loader'),
   options: {
-    name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]'),
+    name: '[name]-[hash:16].[ext]',
   },
 };
 
@@ -16,7 +12,7 @@ exports.node = {
   exclude: /\.(?:m?jsx?|html|json)$/,
   loader: require.resolve('file-loader'),
   options: {
-    name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]'),
+    name: '[name]-[hash:16].[ext]',
     emitFile: false,
   },
 };

--- a/packages/build-config/sections/module-rules/url.js
+++ b/packages/build-config/sections/module-rules/url.js
@@ -1,14 +1,10 @@
 'use strict';
 
-var path = require('path');
-
-var hopsConfig = require('hops-config');
-
 exports.default = {
   test: /\.(png|gif|jpe?g|webp)$/,
   loader: require.resolve('url-loader'),
   options: {
     limit: 10000,
-    name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]'),
+    name: '[name]-[hash:16].[ext]',
   },
 };

--- a/packages/build-config/sections/module-rules/webmanifest.js
+++ b/packages/build-config/sections/module-rules/webmanifest.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var path = require('path');
-
-var hopsConfig = require('hops-config');
-
 exports.default = {
   test: /\.webmanifest$/,
   use: [
     {
       loader: require.resolve('file-loader'),
       options: {
-        name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]'),
+        name: '[name]-[hash:16].[ext]',
       },
     },
     {
@@ -25,7 +21,7 @@ exports.node = {
     {
       loader: require.resolve('file-loader'),
       options: {
-        name: path.join(hopsConfig.assetPath, '[name]-[hash:16].[ext]'),
+        name: '[name]-[hash:16].[ext]',
         emitFile: false,
       },
     },

--- a/packages/express/lib/utils.js
+++ b/packages/express/lib/utils.js
@@ -11,7 +11,11 @@ var hopsConfig = require('hops-config');
 var stats;
 function getStatsFromFile() {
   if (!stats) {
-    var statsFilename = path.join(hopsConfig.buildDir, 'stats.json');
+    var statsFilename = path.join(
+      hopsConfig.buildDir,
+      hopsConfig.assetPath,
+      'stats.json'
+    );
     if (fs.existsSync(statsFilename)) {
       stats = require(statsFilename);
     }
@@ -100,6 +104,8 @@ exports.assetsMiddleware = function assetsMiddleware(req, res, next) {
   };
   res.locals.hops.assets = { js: [], css: [] };
   var assets = res.locals.hops.stats.assetsByChunkName;
+  var assetPath = ('/' + hopsConfig.assetPath + '/').replace(/\/\//, '/');
+
   if (assets) {
     ['vendor', 'main'].forEach(function(key) {
       var asset = assets[key];
@@ -107,13 +113,13 @@ exports.assetsMiddleware = function assetsMiddleware(req, res, next) {
         var js = asset.find(function(item) {
           return item.indexOf('.js') === item.length - 3;
         });
-        js && res.locals.hops.assets.js.push('/' + js);
+        js && res.locals.hops.assets.js.push(assetPath + js);
         var css = asset.find(function(item) {
           return item.indexOf('.css') === item.length - 4;
         });
-        css && res.locals.hops.assets.css.push('/' + css);
+        css && res.locals.hops.assets.css.push(assetPath + css);
       } else if (asset) {
-        res.locals.hops.assets.js.push('/' + asset);
+        res.locals.hops.assets.js.push(assetPath + asset);
       }
     });
   }


### PR DESCRIPTION
For a specific image I'd like to prevent url-loader from returning the base64 version of an image regardless of its size.

To do so, I tried to override the loader and configure it according to our needs:

```js
require('!url-loader?limit=1!../favicon.png')
```

The image will now be referenced by an URL instead of a data uri, however the asset path is missing from the url.

So I tried to set the name option as well.  in https://github.com/xing/hops/blob/d8b1ff3b0e4fb6431b43872d79a54600928964c9/packages/build-config/sections/module-rules/url.js#L12, we set the name of the file to include the asset path.

So naively, I tried something like:

```js
require(`!url-loader?limit=1&name=${hopsConfig.assetPath}/[name]-[hash:16].[ext]!../favicon.png`)
```
Unfortunately, I ended up with an error: 
```
Error: Cannot find module "."
```

After some fiddling around, I came to the conclusion that you simply can not put variables in the options string in `require` calls. (which kind of makes sense, the longer I think about it.)

I took a step back and thought about why are we even using `name` to set the `assetPath` in the first place.
If I recall correctly, it was done to allow html files being put into `/build` while assets should go into `/build/assets` and in earlier versions the html generation also was part of a webpack build which had to respect the `output.path`.

Those days are long gone and we simply write the html files into the `buildDir` on our own.
https://github.com/xing/hops/blob/master/packages/build/lib/generate.js#L21-L38

So, I thought we might be able to get rid off setting the assetPath in loader configs and use the "normal" webpack places instead.

This would allow users to override loaders, but still have their assets put into the correct folder.

This PR is meant as a discussion starter, I'm aware that the code could use some refactoring. 

@ZauberNerd @dmbch does anything I just wrote (and the code in this PR) make any sense to you? 
 