### PR TITLE
fix(build): exit with exitCode 1 when build fails

### DIFF
--- a/packages/build/commands/build.js
+++ b/packages/build/commands/build.js
@@ -36,7 +36,25 @@ module.exports = function defineBuildCommand(args) {
       if (argv.static) {
         process.env.HOPS_MODE = 'static';
       }
-      require('..').runBuild(argv);
+      require('..').runBuild(argv, function(error, stats) {
+        if (error) {
+          console.error(
+            error.stack ? error.stack.toString() : error.toString()
+          );
+        } else {
+          console.log(
+            stats.toString({
+              chunks: false,
+              modules: false,
+              entrypoints: false,
+            })
+          );
+        }
+
+        if (error || stats.hasErrors() || stats.hasWarnings()) {
+          process.exit(1);
+        }
+      });
     },
   });
 };


### PR DESCRIPTION
Bug noticed earlier today by a co-worker (can't find his github handle :(), will attribute later.

If `hops-build` fails, it still exits with exitCode 0.

After this PR, `hops-build` will exit with exitCode 1 for webpack errors, build errors and build warnings. I guess it is fair to fail on warnings in a production build.

https://github.com/webpack/docs/wiki/node.js-api#error-handling
