### PR TITLE
fix(build): do not break build on webpack warnings

### DIFF
--- a/packages/build/commands/build.js
+++ b/packages/build/commands/build.js
@@ -51,7 +51,7 @@ module.exports = function defineBuildCommand(args) {
           );
         }
 
-        if (error || stats.hasErrors() || stats.hasWarnings()) {
+        if (error || stats.hasErrors()) {
           process.exit(1);
         }
       });


### PR DESCRIPTION
Breaking the webpack build on webpack warnings seems a little too
restrictive.
For example the performance hints are logged as warnings and therefore
break the build.

After this change the build will only exit with an error code of 1, if
the build contains errors, but not if the build only contains warnings.