### PR TITLE
fix(react): do not throw error when no options are passed in render

### DIFF
--- a/packages/react/lib/common.js
+++ b/packages/react/lib/common.js
@@ -5,6 +5,7 @@ exports.createCombinedContext = function(
   ReactContext,
   combineContexts
 ) {
+  config = config || {};
   var mergedConfig = Object.assign({}, config);
   delete mergedConfig.extensions;
   var mergedContexts = [ReactContext];


### PR DESCRIPTION
Currently, if you do not pass any options (i.e. extensions) to render, the following error is thrown:

`TypeError: Cannot read property extensions of undefined`
This PR makes options an object by default, preventing the error
