### PR TITLE
choose next free port

### DIFF
--- a/packages/config/__tests__/config.spec.js
+++ b/packages/config/__tests__/config.spec.js
@@ -16,7 +16,7 @@ describe('config', function() {
     expect(hopsConfig).toEqual({
       https: false,
       host: '0.0.0.0',
-      port: 8080,
+      port: undefined,
       locations: [],
       basePath: '',
       assetPath: '',
@@ -31,6 +31,13 @@ describe('config', function() {
       enableServerTimings: true,
       workerPath: '/sw.js',
     });
+  });
+
+  it('should default port to process.env.PORT', function() {
+    process.env.PORT = 8091;
+    var hopsConfig = require('..');
+    expect(hopsConfig.port).toBe(8091);
+    delete process.env.PORT;
   });
 
   it('should override defaults with config from package.json', function() {

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -25,7 +25,7 @@ function applyDefaultConfig(config) {
     {
       https: false,
       host: '0.0.0.0',
-      port: 8080,
+      port: parseInt(process.env.PORT, 10) || undefined,
       locations: [],
       basePath: '',
       assetPath: '',


### PR DESCRIPTION
- hops-config reads port from `process.env.PORT` and defaults to `undefined`
- hops-express reads port from hops-config:
  - if port is undefined it starts at 8080 and tries to find the next free port
  - if port has a value it uses that port and does not try to find a free port