### PR TITLE
chore: make internal peer dependencies actual dependencies

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,19 +30,19 @@
     "apollo-link-http": "^1.3.2",
     "graphql": "^0.12.3",
     "graphql-tools": "^2.20.0",
+    "hops-config": "10.3.0-rc.0",
+    "hops-react": "10.3.0-rc.0",
     "isomorphic-fetch": "^2.2.1",
     "pify": "^3.0.0"
   },
   "peerDependencies": {
     "graphql-tag": "^2.5.0",
-    "hops-react": "10.3.0-rc.0",
     "react": ">=15.0.0 <17.0.0",
     "react-apollo": "^2.0.0"
   },
   "devDependencies": {
     "fetch-mock": "^6.3.0",
     "graphql-tag": "^2.5.0",
-    "hops-react": "10.3.0-rc.0",
     "jest": "^22.0.4",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -26,14 +26,9 @@
     "aws-sdk": "^2.177.0",
     "globby": "^7.1.1",
     "hops-config": "10.3.0-rc.0",
+    "hops-express": "10.3.0-rc.0",
     "prompt": "^1.0.0",
     "resolve-tree": "^0.1.13",
     "serverless-http": "^1.5.2"
-  },
-  "peerDependencies": {
-    "hops-express": "10.3.0-rc.0"
-  },
-  "devDependencies": {
-    "hops-express": "10.3.0-rc.0"
   }
 }


### PR DESCRIPTION
This makes it consistent with the other packages we have that have internal peer dependencies to other Hops packages. e.g. https://github.com/xing/hops/blob/master/packages/redux/package.json#L22