### PR TITLE
chore: set correct dependencies/peerDependencies

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -39,7 +39,6 @@
     "filesize": "^3.5.11",
     "hops-build-config": "10.3.0-rc.2",
     "hops-config": "10.3.0-rc.0",
-    "hops-express": "10.3.0-rc.0",
     "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
     "node-mocks-http": "^1.6.7",
@@ -50,7 +49,11 @@
     "webpack-dev-middleware": "^3.0.0",
     "webpack-hot-middleware": "^2.21.0"
   },
+  "peerDependencies": {
+    "hops-express": "^10.2.0"
+  },
   "devDependencies": {
+    "hops-express": "10.3.0-rc.0",
     "jest": "^22.0.4"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "graphql-tag": "^2.5.0",
-    "hops-react": "10.3.0-rc.0",
+    "hops-react": "^10.0.0",
     "react": ">=15.0.0 <17.0.0",
     "react-apollo": "^2.0.0"
   },

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -31,7 +31,7 @@
     "serverless-http": "^1.5.2"
   },
   "peerDependencies": {
-    "hops-express": "10.3.0-rc.0"
+    "hops-express": "^10.0.0"
   },
   "devDependencies": {
     "hops-express": "10.3.0-rc.0"

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -18,16 +18,15 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "dependencies": {
-    "hops-react": "10.3.0-rc.0"
-  },
   "peerDependencies": {
+    "hops-react": "^10.0.0",
     "react": ">=15.0.0 <17.0.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
+    "hops-react": "10.3.0-rc.0",
     "jest": "^22.0.4",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",


### PR DESCRIPTION
This PR marks hops-react and hops-express as peerDependencies with a
range instead of a single version in all packages that depend upon it.

This is only partially correct as we should declare hops-config and
hops-build-config also as peerDependencies in all packages that depend
on them - but that would be a breaking change as these packages are
currently specified as direct dependencies and it would require changing
the templates and all projects that are currently using hops.