### PR TITLE
chore(build-config): override minimizer defaults to not use uglify for node build

### DIFF
--- a/packages/build-config/configs/node.js
+++ b/packages/build-config/configs/node.js
@@ -75,4 +75,7 @@ module.exports = {
     hints: false,
   },
   devtool: process.env.NODE_ENV !== 'production' && '#inline-source-map',
+  optimization: {
+    minimizer: [],
+  },
 };


### PR DESCRIPTION
## Current state
Due to [webpack defaults](https://github.com/webpack/webpack/blob/1313300b52d933dc4519ee70142db8e9ad3eecd8/lib/WebpackOptionsDefaulter.js#L272) uglify is used to minify server-side code, resulting in longer build times and errors.

## Changes introduced here
Default is overridden so that no uglify is used for server build.

## Checklist

* [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [ ] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
