### PR TITLE
fix(build-config): fix hmr not working with auto chunking/async scripts

### DIFF
--- a/packages/build-config/configs/develop.js
+++ b/packages/build-config/configs/develop.js
@@ -33,7 +33,7 @@ module.exports = {
   },
   plugins: [
     new ServiceWorkerPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
+    new webpack.HotModuleReplacementPlugin({ multiStep: true }),
     new webpack.NamedModulesPlugin(),
     new webpack.EnvironmentPlugin(
       Object.assign(


### PR DESCRIPTION
## Current state
- Start app in dev mode
- Open app in browser
- Change a file
- Wait for hmr to complete
- Reload page
- Witness `Uncaught ReferenceError: webpackHotUpdate is not defined` error in console

## Changes introduced here
Follow hints in https://github.com/webpack/webpack/issues/6693 and add `multiStep: true` to [HotModuleReplacementPlugin](https://webpack.js.org/plugins/hot-module-replacement-plugin/) to fix the issue.

Admittedly, I'm not 100% sure what is happening, but it appears to work fine and the explanation kind of sounds like something we'd want.
```
multiStep (boolean): If true, the plugin will build in two steps -- first compiling the hot update chunks, and then the remaining normal assets.
``` 

<!-- explanation of the changes you did in this pull request -->

## Checklist

* [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [x] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
