### PR TITLE
fix(express): exclude hot-update.js from being added as script tag

### DIFF
--- a/packages/express/lib/utils.js
+++ b/packages/express/lib/utils.js
@@ -135,6 +135,9 @@ exports.assetsMiddleware = function assetsMiddleware(req, res, next) {
 
   res.locals.hops.assets = assets.reduce(
     function(byType, asset) {
+      if (asset.indexOf('.hot-update.js') > 0) {
+        return byType;
+      }
       var type = path.extname(asset).slice(1);
       byType[type] = (byType[type] || []).concat(asset);
       return byType;


### PR DESCRIPTION
with the new webpack entrypoint API the hot-update.js chunk will also be
included as entrypoint and therefore will be loaded as script tag in our
HTML template.

This breaks when we load the scripts with the "async" attribute set:
`Uncaught ReferenceError: webpackHotUpdate is not defined`.

This commit is a quick fix to restore the previous behaviour where we
will not include the hot-update.js chunk as a script in our template.

Other possible fixes:
- Enable `multiStep` in HotModuleReplacementPlugin
- Load all scripts sync or in order (defer instead of async)