### PR TITLE
fix(build-config): Do not use optimizations that assume concatenation

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -48,7 +48,14 @@ module.exports = {
           output: { comments: false },
         },
       }),
-      new OptimizeCSSPlugin(),
+      new OptimizeCSSPlugin({
+        cssProcessorOptions: {
+          reduceIdents: { disable: true },
+          zindex: { disable: true },
+          mergeIdents: { disable: true },
+          discardUnused: { disable: true },
+        },
+      }),
     ],
   },
   plugins: [


### PR DESCRIPTION
for example keyframes in different chunks got the same name, causing all sorts of issues