### PR TITLE
add Create hops app package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ $ yarn global add hops
 # OR npm install --global hops
 ```
 
-Or use [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) to execute a one-off comand:
+Or use our [`create-hops-app`](https://github.com/xing/hops/packages/create-hops-app) package with [`yarn create`](https://yarnpkg.com/lang/en/docs/cli/create/) or [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b):
 
 ```shell
-npx hops@next init --hops-version next --template hops-template-react@next my-awesome-project
-cd my-awesome-project
-npm start
+$ yarn create hops-app@next --hops-version next --template hops-template-react@next my-awesome-project
+# OR npx create-hops-app@next --hops-version next --template hops-template-react@next my-awesome-project
+$ cd my-awesome-project
+$ yarn start
 ```
 
 This will start hops in development mode. Visit [http://localhost:8080](http://localhost:8080) to see your app in the browser and make some changes to the code in your editor to see it live-reloading.

--- a/packages/cli/lib/create-app.js
+++ b/packages/cli/lib/create-app.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const resolveCwd = require('resolve-cwd');
+const validatePackageName = require('validate-npm-package-name');
+
+const pm = require('./package-manager');
+
+function validateName(name) {
+  const validationResult = validatePackageName(name);
+  if (!validationResult.validForNewPackages) {
+    console.error(
+      'Cannot create a project with the name:',
+      name,
+      'because of the following npm restrictions:'
+    );
+    if (validationResult.errors) {
+      validationResult.errors.forEach(msg => {
+        console.error(msg);
+      });
+    }
+    if (validationResult.warnings) {
+      validationResult.warnings.forEach(msg => {
+        console.warn(msg);
+      });
+    }
+    process.exit(1);
+  }
+}
+
+function createDirectory(root, name) {
+  if (fs.existsSync(root)) {
+    console.error(
+      'A directory with the name:',
+      name,
+      'already exists in:',
+      process.cwd(),
+      '\nPlease remove this directory or choose a different project-name.'
+    );
+    process.exit(1);
+  }
+  fs.mkdirSync(root);
+}
+
+function writePackageManifest(root, name) {
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify(
+      {
+        name: name,
+        version: '1.0.0',
+        private: true,
+      },
+      null,
+      2
+    )
+  );
+}
+
+module.exports = function init(options, root) {
+  const name = options.projectName;
+  const appDir = path.join(root, name);
+
+  validateName(name);
+  createDirectory(appDir, name);
+  writePackageManifest(appDir, name);
+  process.chdir(appDir);
+  pm.installPackages(['hops@' + options.hopsVersion], 'prod', options);
+  require(resolveCwd.silent('hops')).init(root, name, options);
+};

--- a/packages/create-hops-app/README.md
+++ b/packages/create-hops-app/README.md
@@ -35,7 +35,6 @@ The following arguments are optional:
 - `--template` - to specify a different template for the intial structure. available templates:
   - [hops-template-react](https://github.com/xing/hops/tree/master/packages/template-react)
   - [hops-template-redux](https://github.com/xing/hops/tree/master/packages/template-redux)
-  - [hops-template-minimal](https://github.com/xing/hops/tree/master/packages/template-minimal)
   - [hops-template-graphql](https://github.com/xing/hops/tree/master/packages/template-graphql)
 
 Then `cd` into `my-new-hops-project` and execute `yarn hops --help` or `npx hops --help` again to see a list of supported commands.

--- a/packages/create-hops-app/README.md
+++ b/packages/create-hops-app/README.md
@@ -1,0 +1,41 @@
+# Create Hops App
+
+[![npm](https://img.shields.io/npm/v/create-hops-app/next.svg)](https://www.npmjs.com/package/create-hops-app)
+
+This package provides a binary (`create-hops-app`) that can be used to create Hops applications.
+
+## Bootstrap a Hops app
+
+The recommended ways bootstrapping hops apps are either trough [`yarn create`](https://yarnpkg.com/lang/en/docs/cli/create/) or [`npx`](https://www.npmjs.com/package/npx).
+
+Bootstrap using yarn create:
+
+```bash
+yarn create hops-app my-new-hops-project
+```
+
+Bootstrap using npx:
+
+```bash
+npx create-hops-app my-new-hops-project
+```
+
+## Usage
+
+```bash
+yarn create hops-app my-new-hops-project [--verbose] [--npm] [--template hops-template-*]
+```
+
+This will create a very basic hops example project that is ready to go.
+
+The following arguments are optional:
+
+- `--verbose` - to increase the verbosity of the output for debugging purposes
+- `--npm` - to force usage of `npm` instead of `yarn` even if yarn is available
+- `--template` - to specify a different template for the intial structure. available templates:
+  - [hops-template-react](https://github.com/xing/hops/tree/master/packages/template-react)
+  - [hops-template-redux](https://github.com/xing/hops/tree/master/packages/template-redux)
+  - [hops-template-minimal](https://github.com/xing/hops/tree/master/packages/template-minimal)
+  - [hops-template-graphql](https://github.com/xing/hops/tree/master/packages/template-graphql)
+
+Then `cd` into `my-new-hops-project` and execute `yarn hops --help` or `npx hops --help` again to see a list of supported commands.

--- a/packages/create-hops-app/index.js
+++ b/packages/create-hops-app/index.js
@@ -42,7 +42,7 @@ const options = yargs
       'initializes a sample hops react project inside it.'
   )
   .example(
-    '$0 --template hops-template-minimal my-project',
+    '$0 --template hops-template-react my-project',
     'Creates the folder my-project inside the current directory and ' +
       'initializes a minimal hops example inside it.'
   )

--- a/packages/create-hops-app/index.js
+++ b/packages/create-hops-app/index.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const yargs = require('yargs');
+const createApp = require('hops/lib/create-app');
+
+const { version } = require('./package.json');
+
+const { npm_execpath: execPath = '', _: lastArg = '' } = process.env;
+const isNpx = execPath.endsWith('npx') || lastArg.endsWith('npx');
+const isNpm = isNpx || execPath.endsWith('npm') || lastArg.endsWith('npm');
+
+const options = yargs
+  .version(version)
+  .usage('Usage: $0 <project-name> [options]')
+  .option('template', {
+    type: 'string',
+    describe:
+      'Use this with the npm package name of a template to initialize with ' +
+      'a different template',
+    default: 'hops-template-react',
+  })
+  .option('hops-version', {
+    type: 'string',
+    describe: 'Which version (or npm dist-tag) of hops to use',
+    default: 'latest',
+  })
+  .option('verbose', {
+    type: 'boolean',
+    describe: 'Increase verbosity of command',
+    default: false,
+  })
+  .option('npm', {
+    type: 'boolean',
+    describe: 'Force usage of `npm` instead of yarn',
+    default: isNpm,
+  })
+  .example(
+    '$0 my-project',
+    'Creates the folder my-project inside the current directory and ' +
+      'initializes a sample hops react project inside it.'
+  )
+  .example(
+    '$0 --template hops-template-minimal my-project',
+    'Creates the folder my-project inside the current directory and ' +
+      'initializes a minimal hops example inside it.'
+  )
+  .help('h')
+  .alias('h', 'help')
+  .wrap(72)
+  .parse(process.argv);
+
+const argv = options._.filter(a => !path.isAbsolute(a));
+options.projectName = argv[argv.length - 1];
+
+if (!options.projectName) {
+  console.error('No project-name given!');
+  yargs.showHelp();
+  process.exit(1);
+} else {
+  createApp(options, process.cwd());
+}

--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "create-hops-app",
+  "version": "11.0.0-rc.37",
+  "description": "CLI tool to create Hops applications",
+  "keywords": [
+    "hops",
+    "cli"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=8.10.0"
+  },
+  "bin": {
+    "create-hops-app": "./index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xing/hops.git"
+  },
+  "dependencies": {
+    "hops": "11.0.0-rc.37",
+    "yargs": "^11.0.0"
+  }
+}

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const { existsSync, readFileSync } = require('fs');
+const { execSync } = require('child_process');
+
+const ONE_MINUTE = 60 * 1000;
+
+const createHopsAppBin = require.resolve('create-hops-app');
+
+describe('postcss production build', () => {
+  const version = 'next';
+  const template = 'hops-template-minimal';
+
+  beforeAll(() => {
+    jest.setTimeout(5 * ONE_MINUTE);
+    process.chdir(cwd);
+  });
+
+  it('initializes a Hops app with yarn', () => {
+    const name = 'my-app-yarn';
+    const args = [
+      name,
+      `--hops-version ${version}`,
+      `--template ${template}@${version}`,
+    ].join(' ');
+
+    execSync(`${createHopsAppBin} ${args}`);
+
+    const lockFile = path.join(cwd, name, 'yarn.lock');
+
+    expect(existsSync(lockFile)).toBeTruthy();
+    expect(readFileSync(lockFile, 'utf-8')).toContain('hops-preset-defaults');
+  });
+
+  it('initializes a Hops app with npm', () => {
+    const name = 'my-app-npm';
+    const args = [
+      name,
+      `--hops-version ${version}`,
+      `--template ${template}@${version}`,
+      `--npm`,
+    ].join(' ');
+
+    execSync(`${createHopsAppBin} ${args}`);
+
+    const lockFile = path.join(cwd, name, 'package-lock.json');
+
+    expect(existsSync(lockFile)).toBeTruthy();
+    expect(readFileSync(lockFile, 'utf-8')).toContain('hops-preset-defaults');
+  });
+});

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -8,7 +8,7 @@ const createHopsAppBin = require.resolve('create-hops-app');
 
 describe('postcss production build', () => {
   const version = 'next';
-  const template = 'hops-template-minimal';
+  const template = 'hops-template-react';
 
   beforeAll(() => {
     jest.setTimeout(5 * ONE_MINUTE);

--- a/packages/spec/integration/create-hops-app/package.json
+++ b/packages/spec/integration/create-hops-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fixture-create-hops-app",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">= 8.10"
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js"
+  }
+}

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -25,6 +25,7 @@
     "node": ">=8.10.0"
   },
   "devDependencies": {
+    "create-hops-app": "11.0.0-rc.37",
     "fs-extra": "^7.0.0",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^23.4.2",


### PR DESCRIPTION
Add package to allow using `yarn create hops-app` to initialize a new hops application.

I moved the code from `hops` to this new package and would remove it from `hops` in an additional commit. Leaving the `hops` package as a local cli only.

Is that a direction you'd support @ZauberNerd @dmbch ?
