### PR TITLE
feat(cli): remove dotenv again as it is now part of untool

### DIFF
--- a/packages/cli/lib/run.js
+++ b/packages/cli/lib/run.js
@@ -1,7 +1,6 @@
 'use strict';
 
 process.env.UNTOOL_NSP = 'hops';
-require('dotenv').config();
 
 // @untool/yargs is a dependency of hops-preset-defaults and should already be
 // installed in the project where the local CLI is executed.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "dotenv": "^6.0.0",
     "pkg-dir": "^3.0.0",
     "resolve-cwd": "^2.0.0",
     "tar": "^4.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,10 +2793,6 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
dotenv has become part of untool: https://github.com/untool/untool/pull/63

Hence, we can remove it again from hops.