### PR TITLE
fix(build): fix prefixes in dev and prod being different

### DIFF
--- a/packages/build-config/configs/build.js
+++ b/packages/build-config/configs/build.js
@@ -54,6 +54,7 @@ module.exports = {
           zindex: { disable: true },
           mergeIdents: { disable: true },
           discardUnused: { disable: true },
+          autoprefixer: { disable: true },
         },
       }),
     ],


### PR DESCRIPTION
There are occasions where the css optimizer plugin would remove prefixes that should not be
removed. This might be caused by the plugin using an older cssnano and autoprefixer version

Since we already deal with prefixes at other points in the config, we remove it here to be safe


## Current state

<!-- explanation of the current state -->

## Changes introduced here

<!-- explanation of the changes you did in this pull request -->

## Checklist

* [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [ ] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added
