### PR TITLE
feat(development-proxy): add development proxy

### DIFF
--- a/packages/development-proxy/README.md
+++ b/packages/development-proxy/README.md
@@ -1,0 +1,3 @@
+# `hops-development-proxy`
+
+TBD

--- a/packages/development-proxy/README.md
+++ b/packages/development-proxy/README.md
@@ -1,3 +1,88 @@
 # `hops-development-proxy`
 
-TBD
+[![npm](https://img.shields.io/npm/v/hops-development-proxy.svg)](https://www.npmjs.com/package/hops-development-proxy)
+
+[Hops preset](https://missing-link-explain-what-are-presets) that adds an API-proxy for development.
+
+Hops apps are often run on the same host as their backend/api endpoints. However, when working locally, backend apps often run on a different host as the frontend application. This can cause issues with cross origin requests during development that are of no concern in the production environment.
+
+This package allows to proxy requests to your api server which runs on a different host/port.
+
+## Installation
+
+Add `hops-development-proxy` to your project.
+
+```bash
+$ yarn add hops-development-proxy
+# OR npm install --save hops-development-proxy
+```
+
+### Usage
+
+`hops-development-proxy` attaches a proxy when the application runs in development mode. It does not do anything when run in production mode.
+
+### Configuration
+
+#### Preset Options
+
+| Name    | Type                 | Default     | Required | Description                |
+| ------- | -------------------- | ----------- | -------- | -------------------------- |
+| `proxy` | `String` \| `Object` | `undefined` | _no_     | Proxy target configuration |
+
+##### proxy
+
+Configures where to proxy API requests to.
+
+Simplest way to set up the proxy is to configure the proxy target URL as string. In this case, the proxy target URL is used for every request that is not an HTML document (i.e. a requested page) or an asset (js file, css file etc.) served by the webpack dev server.
+
+Example
+
+`.hopsrc.js`
+
+```javascript
+module.exports = {
+  proxy: 'https://example.org/',
+};
+```
+
+`browser GET /` -> Is handled by your Hops application, because browser requests an html file.
+
+`GET /assets/main.js` -> Will always be handled by webpack dev server, because it takes precedence.
+
+`fetch GET /api/data` -> Is proxied to https://example.org/, results in `https://example.org/api/data` being requested.
+
+If more flexibility is needed, `proxy` can also be configured as an object, where the keys represent express route matchers to be proxied and the values configure the respective proxy. In the config, any [http-proxy-middleware option](https://github.com/chimurai/http-proxy-middleware#options) can be used.
+
+`.hopsrc.js`
+
+```javascript
+module.exports = {
+  proxy: {
+    '/api': { target: 'https://example.org/' },
+    '/legacy-api': { target: 'https://example.org/old' },
+  },
+};
+```
+
+When the object notation is used, every request that is not handled by the webpack dev server, will be proxied as long as the route matches. This is also true for html documents.
+
+### Examples
+
+#### Adding request headers
+
+Sometimes additional request headers are needed, for example to add a fake user id for the backend api. Since any [http-proxy-middleware option](https://github.com/chimurai/http-proxy-middleware#options) can be used, you can make use of the `onProxyReq` callback to add additional headers.
+
+`.hopsrc.js`
+
+```javascript
+module.exports = {
+  proxy: {
+    '/api': {
+      target: 'https://httpbin.org/anything/',
+      onProxyReq(proxyReq) {
+        proxyReq.setHeader('x-USER-ID', '27');
+      },
+    },
+  },
+};
+```

--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -1,0 +1,56 @@
+const debug = require('debug')('hops:development-proxy');
+const { Mixin } = require('@untool/core');
+const proxy = require('http-proxy-middleware');
+
+class ProxyMixin extends Mixin {
+  configureServer(app, middlewares, mode) {
+    const proxyConfig = this.config.proxy;
+
+    if (mode !== 'develop' || !proxyConfig) {
+      return app;
+    }
+
+    if (typeof proxyConfig === 'string') {
+      debug('Using proxy string version: ', proxyConfig);
+
+      middlewares.initial.push(
+        proxy(
+          (pathName, req) => {
+            return (
+              req.headers.accept && !req.headers.accept.includes('text/html')
+            );
+          },
+          {
+            target: proxyConfig,
+            changeOrigin: true,
+            logLevel: 'warn',
+          }
+        )
+      );
+    }
+
+    if (typeof proxyConfig === 'object') {
+      debug('Using proxy object version', proxyConfig);
+
+      Object.entries(proxyConfig).forEach(([path, config]) => {
+        middlewares.initial.push(
+          proxy(
+            path,
+            Object.assign(
+              {},
+              {
+                changeOrigin: true,
+                logLevel: 'warn',
+              },
+              config
+            )
+          )
+        );
+      });
+    }
+
+    return app;
+  }
+}
+
+module.exports = ProxyMixin;

--- a/packages/development-proxy/package.json
+++ b/packages/development-proxy/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hops-development-proxy",
+  "version": "11.0.0-rc.17",
+  "description": "Proxy",
+  "keywords": [
+    "hops"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=8.10.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xing/hops.git"
+  },
+  "dependencies": {
+    "@untool/core": "^0.12.1",
+    "debug": "^3.1.0",
+    "http-proxy-middleware": "^0.18.0"
+  }
+}

--- a/packages/development-proxy/preset.js
+++ b/packages/development-proxy/preset.js
@@ -1,0 +1,3 @@
+module.exports = {
+  mixins: [__dirname],
+};

--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -45,6 +45,7 @@ class FixtureEnvironment extends NodeEnvironment {
     const { browser, teardown: closeBrowser } = await launchPuppeteer();
     this.closeBrowser = closeBrowser;
     this.global.browser = browser;
+    this.global.cwd = cwd;
 
     this.global.createPage = async () => {
       const page = await browser.newPage();

--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -40,7 +40,7 @@ class FixtureEnvironment extends NodeEnvironment {
     const { cwd, removeWorkingDir } = await createWorkingDir(
       this.config.rootDir
     );
-    this.cwd = global.cwd = cwd;
+    this.cwd = cwd;
     this.removeWorkingDir = removeWorkingDir;
     const { browser, teardown: closeBrowser } = await launchPuppeteer();
     this.closeBrowser = closeBrowser;

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+
+const PORT = 8998;
+
+describe('development proxy object config', () => {
+  let url;
+
+  beforeAll(async () => {
+    jest.setTimeout(30000);
+
+    const packageJsonPath = path.join(global.cwd, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+    packageJson.hops.port = PORT;
+
+    packageJson.hops.proxy = {
+      '/dmbch': { target: `http://localhost:${PORT}/proxy` },
+      '/zaubernerd': { target: `http://localhost:${PORT}/proxy2` },
+    };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+    url = await HopsCLI.develop();
+  });
+
+  it('proxies with proxy config set as object', async () => {
+    expect(await fetch(url + '/dmbch').then(r => r.text())).toBe('proxy:dmbch');
+    expect(await fetch(url + '/zaubernerd').then(r => r.text())).toBe(
+      'proxy2:zaubernerd'
+    );
+  });
+});

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+
+const PORT = 8999;
+
+describe('development proxy string config', () => {
+  let url;
+
+  beforeAll(async () => {
+    jest.setTimeout(30000);
+
+    const packageJsonPath = path.join(global.cwd, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+    packageJson.hops.port = PORT;
+    packageJson.hops.proxy = `http://localhost:${PORT}/proxy`;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+    url = await HopsCLI.develop();
+  });
+
+  it('proxies with proxy config set as string', async () => {
+    const content = await fetch(url + '/dmbch').then(r => r.text());
+    expect(content).toBe('proxy:dmbch');
+  });
+
+  it('does not proxy when browser explicitly requests html document', async () => {
+    const content = await fetch(url + '/dmbch', {
+      headers: { accept: 'text/html' },
+    }).then(r => r.text());
+
+    expect(content).toBe('hello world');
+  });
+});

--- a/packages/spec/integration/development-proxy/browser.js
+++ b/packages/spec/integration/development-proxy/browser.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/packages/spec/integration/development-proxy/mixin.core.js
+++ b/packages/spec/integration/development-proxy/mixin.core.js
@@ -1,0 +1,17 @@
+const { Mixin } = require('@untool/core');
+
+class ProxyTargetMixin extends Mixin {
+  configureServer(app) {
+    app.get('/proxy/:slug', (req, res) => {
+      res.send('proxy:' + req.params.slug);
+    });
+
+    app.get('/proxy2/:slug', (req, res) => {
+      res.send('proxy2:' + req.params.slug);
+    });
+
+    return app;
+  }
+}
+
+module.exports = ProxyTargetMixin;

--- a/packages/spec/integration/development-proxy/package.json
+++ b/packages/spec/integration/development-proxy/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fixture-development-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">= 8.10"
+  },
+  "browser": "browser.js",
+  "server": "server.js",
+  "hops": {
+    "mixins": ["./"]
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js"
+  },
+  "scripts": {
+    "start": "node -e 'require(\"hops\").run(\"start\")'"
+  },
+  "dependencies": {
+    "hops-preset-defaults": "*",
+    "hops-development-proxy": "*"
+  }
+}

--- a/packages/spec/integration/development-proxy/server.js
+++ b/packages/spec/integration/development-proxy/server.js
@@ -1,0 +1,3 @@
+export default () => (req, res) => {
+  res.send('hello world');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,6 +3248,10 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+eventemitter3@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
+
 events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -3637,6 +3641,12 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
+
+follow-redirects@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4178,6 +4188,23 @@ http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-proxy-middleware@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
+  dependencies:
+    http-proxy "^1.16.2"
+    is-glob "^4.0.0"
+    lodash "^4.17.5"
+    micromatch "^3.1.9"
+
+http-proxy@^1.16.2:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+  dependencies:
+    eventemitter3 "^3.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5672,7 +5699,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -7641,6 +7668,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add a simple proxy for API requests which runs on the same port as the app, mitigating issues with CORS.

Inspired by cra proxy.
Configuration is meant to be simple and limited. For more sophisticated use cases it is probably more feasible to build a custom mixin.

## Configuration

Can be configured in two ways in preset config.
`proxy` string: In this case all<sup>[1]</sup>requests will be proxied to the specified proxy URL.
[1] All meaning every request that is not handled by the webpack dev middleware and that is not a requested html document. Those are handled by the app itself.

```json
{
  "hops": {
    "proxy": "https://example.org"
  }
}
```

or with env var:

```json
{
  "hops": {
    "proxy": "[PROXY_URL]"
  }
}
```

`proxy` can also be an object.

```json
{
  "hops": {
    "proxy": {
      "/foo": { "target": "https://example.org" },
      "/get": { "target": "https://httpbin.org" }
    }
  }
}
```

In that case for each entry a proxy middleware will be created and the config object will be passed to it.

## open questions

- Do we need/want something like that at all?
- Does it make sense to create a dedicated package or should it be part of another preset?

## todo

- [x] tests
- [x] docs
- [x] early return on empty config