### PR TITLE
add hooks to allow overriding of data fetching

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -130,3 +130,13 @@ export default render(<MyApp />, {
   },
 });
 ```
+
+### Mixin Hooks API
+
+#### `getApolloLink(): ApolloLink` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
+
+Hook to return a custom [ApolloLink](https://github.com/apollographql/apollo-link).
+
+Useful when the link needs access to the current request object, which only exists in the mixin context.
+
+Beware that `link` passed as render option takes precedence.

--- a/packages/graphql/mixin.browser.js
+++ b/packages/graphql/mixin.browser.js
@@ -1,5 +1,9 @@
 const React = require('react');
 const { Mixin } = require('@untool/core');
+const {
+  sync: { override },
+} = require('mixinable');
+
 const { ApolloProvider } = require('react-apollo');
 const { default: ApolloClient } = require('apollo-client');
 const { HttpLink } = require('apollo-link-http');
@@ -23,12 +27,12 @@ class GraphQLMixin extends Mixin {
   enhanceClientOptions(options) {
     return {
       ...options,
-      link: options.link || this.createLink(),
+      link: options.link || this.getApolloLink(),
       cache: options.cache || this.createCache(),
     };
   }
 
-  createLink() {
+  getApolloLink() {
     return new HttpLink({ uri: this.config.graphqlUri });
   }
 
@@ -51,5 +55,9 @@ class GraphQLMixin extends Mixin {
     return <ApolloProvider client={this.client}>{reactElement}</ApolloProvider>;
   }
 }
+
+GraphQLMixin.strategies = {
+  getApolloLink: override,
+};
 
 module.exports = GraphQLMixin;

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -2,6 +2,9 @@ require('isomorphic-fetch');
 const React = require('react');
 const { existsSync, readFileSync } = require('fs');
 const { Mixin } = require('@untool/core');
+const {
+  sync: { override },
+} = require('mixinable');
 const { ApolloProvider, getDataFromTree } = require('react-apollo');
 const { default: ApolloClient } = require('apollo-client');
 const { HttpLink } = require('apollo-link-http');
@@ -34,13 +37,13 @@ class GraphQLMixin extends Mixin {
   enhanceClientOptions(options) {
     return {
       ...options,
-      link: options.link || this.createLink(),
+      link: options.link || this.getApolloLink(),
       cache: options.cache || this.createCache(),
       ssrMode: true,
     };
   }
 
-  createLink() {
+  getApolloLink() {
     return new HttpLink({ uri: this.config.graphqlUri });
   }
 
@@ -105,5 +108,9 @@ class GraphQLMixin extends Mixin {
     return <ApolloProvider client={this.client}>{reactElement}</ApolloProvider>;
   }
 }
+
+GraphQLMixin.strategies = {
+  getApolloLink: override,
+};
 
 module.exports = GraphQLMixin;

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -40,6 +40,7 @@
     "graphql": "^0.13.0",
     "graphql-tools": "^3.0.5",
     "isomorphic-fetch": "^2.2.1",
+    "mixinable": "^3.0.0",
     "pify": "^3.0.0",
     "strip-indent": "^2.0.0"
   },

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -114,3 +114,9 @@ export default render(<MyApp />, {
 #### `getReduxStore(): Store` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
 
 Use this method in your own mixins to get a reference to the currently used Redux [Store](https://redux.js.org/api-reference/store) instance.
+
+#### `getReduxMiddlewares(): [middleware]` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
+
+Allows to specify your own set of redux middlewares. Useful when middlewares need access to the current request object, which only exists in the mixin context.
+
+Beware that middlewares passed as render option take precedence.

--- a/packages/redux/mixin.browser.js
+++ b/packages/redux/mixin.browser.js
@@ -19,7 +19,7 @@ class ReduxMixin extends Mixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
 
-    this.middlewares = options.middlewares || [ReduxThunkMiddleware];
+    this.middlewares = options.middlewares;
     this.reducers = options.reducers || {};
   }
 
@@ -46,12 +46,14 @@ class ReduxMixin extends Mixin {
     return this.store;
   }
 
-  getMiddlewares() {
-    return this.middlewares;
+  getReduxMiddlewares() {
+    return [ReduxThunkMiddleware];
   }
 
   applyMiddlewares() {
-    return this.getMiddlewares().map(m => applyMiddleware(m));
+    const middlewares = this.middlewares || this.getReduxMiddlewares();
+
+    return middlewares.map(m => applyMiddleware(m));
   }
 
   composeEnhancers(...enhancers) {
@@ -65,6 +67,7 @@ class ReduxMixin extends Mixin {
 
 ReduxMixin.strategies = {
   getReduxStore: override,
+  getReduxMiddlewares: override,
 };
 
 module.exports = ReduxMixin;

--- a/packages/redux/mixin.server.js
+++ b/packages/redux/mixin.server.js
@@ -18,7 +18,7 @@ class ReduxMixin extends Mixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
 
-    this.middlewares = options.middlewares || [ReduxThunkMiddleware];
+    this.middlewares = options.middlewares;
     this.reducers = options.reducers || {};
   }
 
@@ -39,12 +39,14 @@ class ReduxMixin extends Mixin {
     return this.store;
   }
 
-  getMiddlewares() {
-    return this.middlewares;
+  getReduxMiddlewares() {
+    return [ReduxThunkMiddleware];
   }
 
   applyMiddlewares() {
-    return this.getMiddlewares().map(m => applyMiddleware(m));
+    const middlewares = this.middlewares || this.getReduxMiddlewares();
+
+    return middlewares.map(m => applyMiddleware(m));
   }
 
   composeEnhancers(...enhancers) {
@@ -68,6 +70,7 @@ class ReduxMixin extends Mixin {
 
 ReduxMixin.strategies = {
   getReduxStore: override,
+  getReduxMiddlewares: override,
 };
 
 module.exports = ReduxMixin;


### PR DESCRIPTION
For some use cases, we need to be able to inject a request-aware fetch implementation.

For redux, we'd like to be able to override the thunk middleware to use [extraArguments](https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument).

In Apollo, we'll inject a custom fetch into the `ApolloLink`.

This PR adds hook that'll enable such efforts.
