### PR TITLE
Fix configure fetch

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -140,7 +140,3 @@ Hook to return a custom [ApolloLink](https://github.com/apollographql/apollo-lin
 Useful when the link needs access to the current request object, which only exists in the mixin context.
 
 Beware that `link` passed as render option takes precedence.
-
-#### `configureFetch(fetch): fetch` ([pipe](https://github.com/untool/mixinable/blob/master/README.md#definepipe))
-
-Method to alter `fetch` implementation that is being passed into the default ApolloLink. Allows to closure request-specific data. Returns [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) by default.

--- a/packages/graphql/mixin.browser.js
+++ b/packages/graphql/mixin.browser.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const { Mixin } = require('@untool/core');
 const {
-  sync: { override, pipe },
+  sync: { override },
 } = require('mixinable');
 
 const { ApolloProvider } = require('react-apollo');
@@ -31,14 +31,11 @@ class GraphQLMixin extends Mixin {
       cache: options.cache || this.createCache(),
     };
   }
-  configureFetch() {
-    return require('isomorphic-fetch');
-  }
 
   getApolloLink() {
     return new HttpLink({
       uri: this.config.graphqlUri,
-      fetch: this.configureFetch(),
+      fetch: this.fetch,
     });
   }
 
@@ -64,7 +61,6 @@ class GraphQLMixin extends Mixin {
 
 GraphQLMixin.strategies = {
   getApolloLink: override,
-  configureFetch: pipe,
 };
 
 module.exports = GraphQLMixin;

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -3,7 +3,7 @@ const React = require('react');
 const { existsSync, readFileSync } = require('fs');
 const { Mixin } = require('@untool/core');
 const {
-  sync: { override, pipe },
+  sync: { override },
 } = require('mixinable');
 const { ApolloProvider, getDataFromTree } = require('react-apollo');
 const { default: ApolloClient } = require('apollo-client');
@@ -43,14 +43,10 @@ class GraphQLMixin extends Mixin {
     };
   }
 
-  configureFetch() {
-    return require('isomorphic-fetch');
-  }
-
   getApolloLink() {
     return new HttpLink({
       uri: this.config.graphqlUri,
-      fetch: this.configureFetch(),
+      fetch: this.fetch,
     });
   }
 
@@ -118,7 +114,6 @@ class GraphQLMixin extends Mixin {
 
 GraphQLMixin.strategies = {
   getApolloLink: override,
-  configureFetch: pipe,
 };
 
 module.exports = GraphQLMixin;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -99,3 +99,11 @@ Only exists on the server.
 #### `getServerData(): serverData` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
 
 Returns the `serverData` produced by `enhanceServerData` on server and client.
+
+#### `configureFetch(fetch): fetch` ([pipe](https://github.com/untool/mixinable/blob/master/README.md#definepipe))
+
+Method to alter `fetch` implementation that is being used by `fetch` hook. Allows to closure request-specific data. Returns [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) by default.
+
+#### `fetch(...fetchArguments): Promise ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))`
+
+Fetch method that can be used inside mixins, but can also be passed to the react app to be used there.

--- a/packages/react/fetch/mixin.runtime.js
+++ b/packages/react/fetch/mixin.runtime.js
@@ -1,0 +1,18 @@
+const { Mixin } = require('@untool/core');
+const {
+  sync: { pipe: pipeSync },
+  async: { override: overrideAsync },
+} = require('mixinable');
+
+class ReactFetchMixin extends Mixin {
+  fetch(...fetchArgs) {
+    return this.configureFetch(require('isomorphic-fetch'))(...fetchArgs);
+  }
+}
+
+ReactFetchMixin.strategies = {
+  configureFetch: pipeSync,
+  fetch: overrideAsync,
+};
+
+module.exports = ReactFetchMixin;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,7 @@
     "@untool/react": "^0.13.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "isomorphic-fetch": "^2.2.1",
     "mixinable": "^3.0.0",
     "react-router": "^4.3.1"
   },

--- a/packages/react/preset.js
+++ b/packages/react/preset.js
@@ -1,4 +1,9 @@
 module.exports = {
   presets: ['@untool/react'],
-  mixins: ['@untool/react', __dirname, `${__dirname}/server-data`],
+  mixins: [
+    '@untool/react',
+    __dirname,
+    `${__dirname}/server-data`,
+    `${__dirname}/fetch`,
+  ],
 };

--- a/packages/react/preset.js
+++ b/packages/react/preset.js
@@ -1,9 +1,4 @@
 module.exports = {
   presets: ['@untool/react'],
-  mixins: [
-    '@untool/react',
-    __dirname,
-    `${__dirname}/server-data`,
-    `${__dirname}/fetch`,
-  ],
+  mixins: [__dirname, `${__dirname}/server-data`, `${__dirname}/fetch`],
 };

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -117,13 +117,9 @@ Use this method in your own mixins to get a reference to the currently used Redu
 
 #### `getReduxMiddlewares(): [middleware]` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
 
-Allows to specify your own set of redux middlewares. Useful when middlewares need access to the current request object, which only exists in the mixin context.
+Allows to specify your own set of redux middlewares. Useful when middlewares need access to the current request object, which only exists in the mixin context. Passes fetch implementation as extra argument to thunks.
 
 Beware that middlewares passed as render option take precedence.
-
-#### `configureFetch(fetch): fetch` ([pipe](https://github.com/untool/mixinable/blob/master/README.md#definepipe))
-
-Method to alter `fetch` implementation that is being passed as [custom argument](https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument) to redux-thunk-based action creators. Allows to closure request-specific data. Returns [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) by default.
 
 ##### Example thunk-based action creator
 

--- a/packages/redux/mixin.browser.js
+++ b/packages/redux/mixin.browser.js
@@ -10,7 +10,7 @@ const { Provider } = require('react-redux');
 const { Mixin } = require('@untool/core');
 
 const {
-  sync: { override, pipe },
+  sync: { override },
 } = require('mixinable');
 
 const ReduxCompose = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -45,14 +45,10 @@ class ReduxMixin extends Mixin {
     return this.store;
   }
 
-  configureFetch() {
-    return require('isomorphic-fetch');
-  }
-
   getReduxMiddlewares() {
     return [
       ReduxThunkMiddleware.withExtraArgument({
-        fetch: this.configureFetch(),
+        fetch: this.fetch,
       }),
     ];
   }
@@ -75,7 +71,6 @@ class ReduxMixin extends Mixin {
 ReduxMixin.strategies = {
   getReduxStore: override,
   getReduxMiddlewares: override,
-  configureFetch: pipe,
 };
 
 module.exports = ReduxMixin;

--- a/packages/redux/mixin.server.js
+++ b/packages/redux/mixin.server.js
@@ -11,7 +11,7 @@ const { Provider } = require('react-redux');
 const { Mixin } = require('@untool/core');
 
 const {
-  sync: { override, pipe },
+  sync: { override },
 } = require('mixinable');
 
 class ReduxMixin extends Mixin {
@@ -38,14 +38,10 @@ class ReduxMixin extends Mixin {
     return this.store;
   }
 
-  configureFetch() {
-    return require('isomorphic-fetch');
-  }
-
   getReduxMiddlewares() {
     return [
       ReduxThunkMiddleware.withExtraArgument({
-        fetch: this.configureFetch(),
+        fetch: this.fetch,
       }),
     ];
   }
@@ -78,7 +74,6 @@ class ReduxMixin extends Mixin {
 ReduxMixin.strategies = {
   getReduxStore: override,
   getReduxMiddlewares: override,
-  configureFetch: pipe,
 };
 
 module.exports = ReduxMixin;


### PR DESCRIPTION
Why the move to react?

- with the introduction of `fetch` in addition to `configureFetch`, we are able to access the fetch without having to pass a default implementation every time when calling `configureFetch`
- moving it to react will allow us to easily add hoc and context for fetch, so it can be used inside the app, too