### PR TITLE
refactor(lambda): use NODE_ENV instead of CLI args to start prod mode

### DIFF
--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -1,6 +1,7 @@
 'use strict';
 
 process.env.UNTOOL_NSP = 'hops';
+process.env.NODE_ENV = 'production';
 
 const serverlessHttp = require('serverless-http');
 const config = require('@untool/core/lib/env').environmentalize(
@@ -10,9 +11,7 @@ const {
   stripLeadingSlash,
   stripTrailingSlash,
 } = require('@untool/express').uri;
-const app = require('@untool/express').createServer('serve', {
-  production: true,
-});
+const app = require('@untool/express').createServer('serve');
 
 const awsConfig = require('./lib/aws-config')(config);
 


### PR DESCRIPTION
This pull request closes issue # (_put the issue number here_)

_This is a template. Feel free to remove the parts you do not need! Start with this line, for example_ :wink:


<!-- explanation of the current state -->


<!-- explanation of the changes you did in this pull request -->


* [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
* [ ] All code is written in plain ECMAScript v5 and is formatted using [prettier](https://prettier.io)
* [ ] Necessary unit tests are added in order to ensure correct behavior
* [ ] Documentation has been added