### PR TITLE
Revert "serve command missing"

### DIFF
--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "start": "hops start",
     "build": "hops build",
-    "test": "jest",
-    "serve": "hops serve"
+    "test": "jest"
   },
   "dependencies": {
     "graphql-tag": "^2.6.1",


### PR DESCRIPTION
I am sorry, I didn't read the documentation enough.
This package differs from the others by using `npm start --production` instead of `yarn serve`

Reverts xing/hops#566