### PR TITLE
fix(graphql): operation name support in introspection query

### DIFF
--- a/packages/graphql/lib/fragments.js
+++ b/packages/graphql/lib/fragments.js
@@ -39,7 +39,7 @@ function executeLocalQuery(schemaFile, query) {
 }
 
 const query = `
-{
+query IntrospectionQuery {
   __schema {
     types {
       kind


### PR DESCRIPTION
## Current state

Some GraphQL server requires a operation name (operation name is mandatory).

## Changes introduced here

Add operation name to introspection query for compatibility reasons.