### PR TITLE
fix(postcss): do not output custom properties in resulting css

### DIFF
--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -36,6 +36,9 @@ const getCSSLoaderConfig = browsers => ({
             features: {
               'nesting-rules': true,
               'custom-media-queries': true,
+              'custom-properties': {
+                preserve: false,
+              },
             },
           }),
         ],


### PR DESCRIPTION
Because this creates a lot of duplication when importing css variables
files in other css files which are then imported via js.
See:
- https://github.com/postcss/postcss-import/issues/316
- https://github.com/postcss/postcss-import/issues/294
- https://github.com/postcss/postcss-import/issues/224