### PR TITLE
feat(spec): add debug output for integration tests

### DIFF
--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -1,4 +1,5 @@
 const NodeEnvironment = require('jest-environment-node');
+const debug = require('debug')('hops-spec:env');
 const {
   launchPuppeteer,
   startServer,
@@ -37,9 +38,11 @@ class FixtureEnvironment extends NodeEnvironment {
   }
   async setup() {
     await super.setup();
+    debug('Creating working directory for:', this.config.rootDir);
     const { cwd, removeWorkingDir } = await createWorkingDir(
       this.config.rootDir
     );
+    debug('Working directory created:', cwd);
     this.cwd = cwd;
     this.removeWorkingDir = removeWorkingDir;
     const { browser, teardown: closeBrowser } = await launchPuppeteer();


### PR DESCRIPTION
Sometimes the integration tests just hang and it is hard to see why.
With this change we use the "debug" module to output "hops-spec:*" debug
messages which can be printed to the terminal when setting the
`DEBUG` environment variable to: `DEBUG=hops-spec:*`.

In order to still allow to debug puppeteer visually (starting it in
non-headless mode) we changed the environment variable name from:
`DEBUG=true` to `DEBUG_PUPPETEER=true` in order to not interfere with
the actual debug output.