### PR TITLE
fix(redux): Do not dispatch actions in bootstrap hook to avoid clashes

### DIFF
--- a/packages/redux/action-creator-dispatcher/mixin.server.js
+++ b/packages/redux/action-creator-dispatcher/mixin.server.js
@@ -10,11 +10,8 @@ const ReduxActionCreatorCommonMixin = require('./mixin.runtime-common');
 
 class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
   bootstrap(request) {
+    this.request = request;
     this.prefetchedOnServer = this.shouldPrefetchOnServer();
-    if (this.prefetchedOnServer) {
-      return this.dispatchAll(createLocation(request.path));
-    }
-    return Promise.resolve();
   }
 
   shouldPrefetchOnServer() {
@@ -22,6 +19,14 @@ class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
     return typeof shouldPrefetchOnServer === 'boolean'
       ? shouldPrefetchOnServer
       : true;
+  }
+
+  async fetchData(data) {
+    if (this.prefetchedOnServer) {
+      await this.dispatchAll(createLocation(this.request.path));
+    }
+
+    return data;
   }
 
   getTemplateData(data) {


### PR DESCRIPTION
mixins often use bootstrap for setup as it is the only place with access to req and res
when hooks of those mixins are called in bootstrap before their bootstrap hook ran, bugs are often the result