### PR TITLE
fix(test): Replace `ncp` with `fs-extra` package to prevent test runner from getting stuck

### DIFF
--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -5,7 +5,7 @@ const exec = promisify(require('child_process').exec);
 const puppeteer = require('puppeteer');
 const rimraf = promisify(require('rimraf'));
 
-const ncp = promisify(require('ncp'));
+const { copy } = require('fs-extra');
 const mktemp = require('mktemp').createDir;
 const mkdirp = promisify(require('mkdirp'));
 const debug = require('debug')('hops-spec:test-helpers');
@@ -84,7 +84,7 @@ const createWorkingDir = async srcDir => {
   await mkdirp(cwdRootPath);
   const cwdPath = await mktemp(path.resolve(cwdRootPath, 'XXXXX'));
 
-  await ncp(srcDir, cwdPath);
+  await copy(srcDir, cwdPath);
   return {
     cwd: cwdPath,
     removeWorkingDir: async () => {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -25,6 +25,7 @@
     "node": ">=8.10.0"
   },
   "devDependencies": {
+    "fs-extra": "^7.0.0",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^23.4.2",
     "jest-environment-node": "^23.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4189,6 +4189,14 @@ fs-extra@6.0.1, fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"


### PR DESCRIPTION
This pull request closes issue #594.