### PR TITLE
chore: ensure that travis always uses Node 8.10 to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ script:
   - yarn test --runInBand
 
 node_js:
-- '8'
-- '10'
+  - '8.10'
+  - '10'
 
 env:
   - HOST=0.0.0.0


### PR DESCRIPTION
Sometimes travis uses an older Node 8 version (8.9 for example) which
will break the build because the "engines" field in Hops is set to
">= 8.10".
This commit ensures that travis will always use Node 8.10