### PR TITLE
Revert @babel/preset-typescript to use ts-loader and typescript

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -9,7 +9,8 @@ module.exports = {
   },
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'ts', 'tsx'],
   transform: {
-    '^.+\\.(js|jsx|mjs|ts|tsx)$': 'jest-preset-hops/transforms/babel.js',
+    '^.+\\.(js|jsx|mjs)$': 'jest-preset-hops/transforms/babel.js',
+    '^.+\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(gql|graphql)$': 'jest-preset-hops/transforms/graphql.js',
   },
   transformIgnorePatterns: [],

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -26,11 +26,11 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@babel/preset-typescript": "^7.0.0",
     "babel-jest": "^23.4.2",
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "jest-config": "^23.0.0"
+    "jest-config": "^23.0.0",
+    "ts-jest": "^23.1.2"
   },
   "peerDependencies": {
     "jest": "^23.0.0"

--- a/packages/jest-preset/transforms/babel.js
+++ b/packages/jest-preset/transforms/babel.js
@@ -11,7 +11,6 @@ module.exports = babelJest.createTransformer({
       },
     ],
     '@babel/preset-react',
-    '@babel/preset-typescript',
   ],
   plugins: [
     require.resolve('babel-plugin-dynamic-import-node'),

--- a/packages/spec/integration/jest-preset/tsconfig.json
+++ b/packages/spec/integration/jest-preset/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../node_modules/hops-typescript/tsconfig.json"
+}

--- a/packages/spec/integration/typescript/package.json
+++ b/packages/spec/integration/typescript/package.json
@@ -9,13 +9,11 @@
     "testEnvironment": "../../helpers/env.js"
   },
   "scripts": {
-    "start": "node -e 'require(\"hops\").run(\"start\")'",
-    "type-check": "tsc"
+    "start": "node -e 'require(\"hops\").run(\"start\")'"
   },
   "dependencies": {
     "hops-preset-defaults": "*",
     "hops-react": "*",
-    "hops-typescript": "*",
-    "typescript": "^3.0.3"
+    "hops-typescript": "*"
   }
 }

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -9,11 +9,9 @@ This is a [preset for Hops](https://github.com/xing/hops/tree/master#presets) th
 Add this preset to your existing Hops React project:
 
 ```bash
-$ yarn add hops-typescript@next typescript
-# OR npm install --save hops-typescript@next typescript
+$ yarn add hops-typescript@next
+# OR npm install --save hops-typescript@next
 ```
-
-And add a `"type-check": "tsc"` script to your `package.json` to run type-checks.
 
 If you don't already have an existing Hops project read this section [on how to set up your first Hops project.](https://github.com/xing/hops/tree/master#quick-start)
 

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -1,12 +1,13 @@
 const { Mixin } = require('hops-mixin');
 
 class TypescriptMixin extends Mixin {
-  configureBuild(webpackConfig, { jsLoaderConfig }) {
+  configureBuild(webpackConfig, { allLoaderConfigs }) {
     webpackConfig.resolve.extensions.unshift('.ts', '.tsx');
-    jsLoaderConfig.test.push(/\.tsx?$/);
-    jsLoaderConfig.options.presets.push(
-      require.resolve('@babel/preset-typescript')
-    );
+
+    allLoaderConfigs.unshift({
+      test: /\.tsx?$/,
+      use: [{ loader: require.resolve('ts-loader') }],
+    });
 
     return webpackConfig;
   }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@babel/preset-typescript": "^7.0.0",
-    "hops-mixin": "11.0.0-rc.32"
+    "hops-mixin": "11.0.0-rc.32",
+    "ts-loader": "^4.4.2",
+    "typescript": "^3.0.0"
   }
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "target": "esnext",
     "jsx": "react",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "allowJs": true
+    "moduleResolution": "node"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2528,7 +2528,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -8705,7 +8705,7 @@ semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
@@ -9432,6 +9432,16 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+ts-loader@^4.4.2:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.5.0.tgz#a1ce70b2dc799941fb2197605f0d67874097859b"
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^3.1.4"
+    semver "^5.0.1"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -9466,6 +9476,10 @@ type-is@^1.6.14, type-is@~1.6.15, type-is@~1.6.16:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,12 +344,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-typescript@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0.tgz#90f4fe0a741ae9c0dcdc3017717c05a0cbbd5158"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
 "@babel/plugin-transform-arrow-functions@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz#a6c14875848c68a3b4b3163a486535ef25c7e749"
@@ -565,13 +559,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typescript@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.0.0.tgz#71bf13cae08117ae5dc1caec5b90938d8091a01e"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-typescript" "^7.0.0"
-
 "@babel/plugin-transform-unicode-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz#c6780e5b1863a76fe792d90eded9fcd5b51d68fc"
@@ -649,13 +636,6 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-
-"@babel/preset-typescript@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.0.0.tgz#1e65c8b863ff5b290f070d999c810bb48a8e3904"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.0.0"
 
 "@babel/runtime@^7.0.0-rc.1":
   version "7.0.0"
@@ -2640,6 +2620,10 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
+closest-file-data@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/closest-file-data/-/closest-file-data-0.1.4.tgz#975f87c132f299d24a0375b9f63ca3fb88f72b3a"
+
 cmd-shim@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
@@ -4301,7 +4285,7 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
 
-fs-extra@^6.0.1:
+fs-extra@6.0.1, fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
@@ -9431,6 +9415,15 @@ trim-off-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+ts-jest@^23.1.2:
+  version "23.1.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.4.tgz#66ac1d8d3fbf8f9a98432b11aa377aa850664b2b"
+  dependencies:
+    closest-file-data "^0.1.4"
+    fs-extra "6.0.1"
+    json5 "^0.5.0"
+    lodash "^4.17.10"
 
 ts-loader@^4.4.2:
   version "4.5.0"


### PR DESCRIPTION
Due to several issues with the new @babel/preset-typescript we decided
to revert back to using typescript itself:
https://github.com/xing/hops/pull/613#issuecomment-418701043