### PR TITLE
Fix GraphQL mixin and fragment type caching

### DIFF
--- a/packages/graphql/mixin.browser.js
+++ b/packages/graphql/mixin.browser.js
@@ -19,7 +19,11 @@ class GraphQLMixin extends Mixin {
   constructor(config, element, { graphql: options = {} } = {}) {
     super(config, element);
 
-    this.client = this.createClient(options);
+    this.options = options;
+  }
+
+  bootstrap() {
+    this.client = this.createClient(this.options);
   }
 
   createClient(options) {

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -23,7 +23,11 @@ class GraphQLMixin extends Mixin {
   constructor(config, element, { graphql: options = {} } = {}) {
     super(config, element);
 
-    this.client = this.createClient(options);
+    this.options = options;
+  }
+
+  bootstrap() {
+    this.client = this.createClient(this.options);
   }
 
   createClient(options) {


### PR DESCRIPTION
This pull request closes issue #619


We had a bug in our GraphQL mixin that prevented us from overriding the
exposed `getApolloLink` mixin hook.

The problem was that we called mixin methods inside the constructor, but
at that time the mixin container has not been created, so when some
other mixin tries to override the mixin method it will never be called.

Also while working on this problem I found out that our introspection
results are never actually used, because a new instance is created for
each request and therefore `this.introspectionResult` was always set to
`undefined`.


I moved the instantiation of the apollo client from the constructor to
the `bootstrap` method in order to allow for `getApolloLink` to use an
overridden implementation.

I also moved the fragment types reading / caching mechanism to the
constructor and the cache itself outside of the class as a module-scoped
variable so that the generated fragment types are being used on both
server- and client-side.


- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added