### PR TITLE
feat(graphql): Introduce getApolloCache hook

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -150,6 +150,14 @@ Useful when the link needs access to the current request object, which only exis
 
 Beware that `link` passed as render option takes precedence.
 
+#### `getApolloCache(): ApolloCache` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
+
+Hook to return a custom [ApolloCache](https://www.apollographql.com/docs/react/advanced/caching.html).
+
+### `createFragmentMatcher` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
+
+Allows to get the [fragment matcher](https://www.apollographql.com/docs/react/advanced/fragments.html) that needs to be passed to the `ApolloCache`. Useful if you plan to override `getApolloCache`.
+
 #### `shouldPrefetchOnServer(): boolean` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
 
 This is an overrideable hook that can be used to customize the behavior of when Hops should prefetch data during server-side rendering. E.g. execute GraphQL queries during initial render.

--- a/packages/graphql/mixin.browser.js
+++ b/packages/graphql/mixin.browser.js
@@ -2,7 +2,7 @@ const React = require('react');
 const {
   Mixin,
   strategies: {
-    sync: { override },
+    sync: { override, callable },
   },
 } = require('hops-mixin');
 
@@ -33,21 +33,27 @@ class GraphQLMixin extends Mixin {
   enhanceClientOptions(options) {
     return {
       ...options,
-      link: options.link || this.getApolloLink(),
-      cache: options.cache || this.createCache(),
+      link: this.getApolloLink(),
+      cache: this.getApolloCache(),
     };
   }
 
   getApolloLink() {
-    return new HttpLink({
-      uri: this.config.graphqlUri,
-    });
+    return (
+      this.options.link ||
+      new HttpLink({
+        uri: this.config.graphqlUri,
+      })
+    );
   }
 
-  createCache() {
-    return new InMemoryCache({
-      fragmentMatcher: this.createFragmentMatcher(),
-    }).restore(global['APOLLO_STATE']);
+  getApolloCache() {
+    return (
+      this.options.cache ||
+      new InMemoryCache({
+        fragmentMatcher: this.createFragmentMatcher(),
+      }).restore(global['APOLLO_STATE'])
+    );
   }
 
   createFragmentMatcher() {
@@ -70,6 +76,8 @@ class GraphQLMixin extends Mixin {
 
 GraphQLMixin.strategies = {
   getApolloLink: override,
+  getApolloCache: override,
+  createFragmentMatcher: callable,
 };
 
 module.exports = GraphQLMixin;

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -4,7 +4,7 @@ const { existsSync, readFileSync } = require('fs');
 const {
   Mixin,
   strategies: {
-    sync: { override },
+    sync: { override, callable },
   },
 } = require('hops-mixin');
 
@@ -56,20 +56,26 @@ class GraphQLMixin extends Mixin {
   enhanceClientOptions(options) {
     return {
       ...options,
-      link: options.link || this.getApolloLink(),
-      cache: options.cache || this.createCache(),
+      link: this.getApolloLink(),
+      cache: this.getApolloCache(),
       ssrMode: true,
     };
   }
 
   getApolloLink() {
-    return new HttpLink({
-      uri: this.config.graphqlUri,
-    });
+    return (
+      this.options.link ||
+      new HttpLink({
+        uri: this.config.graphqlUri,
+      })
+    );
   }
 
-  createCache() {
-    return new InMemoryCache({ fragmentMatcher: this.createFragmentMatcher() });
+  getApolloCache() {
+    return (
+      this.options.cache ||
+      new InMemoryCache({ fragmentMatcher: this.createFragmentMatcher() })
+    );
   }
 
   createFragmentMatcher() {
@@ -127,6 +133,8 @@ class GraphQLMixin extends Mixin {
 
 GraphQLMixin.strategies = {
   getApolloLink: override,
+  getApolloCache: override,
+  createFragmentMatcher: callable,
   shouldPrefetchOnServer: override,
 };
 


### PR DESCRIPTION
To be consistent with `getApolloLink`.

Also now calls the hook even if option.link is set. The hook now gets to decide whether to respect the options or ignore it. 