### PR TITLE
chore: make travis a little bit faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,29 @@
 language: node_js
 
-before_install:
-  - npm install -g yarn@1
-
-install:
-  - yarn install
-
-script:
-  - yarn lint
-  - yarn test --runInBand
-
 node_js:
   - '8.10'
   - '10'
 
 env:
   - HOST=0.0.0.0
+
+cache:
+  yarn: true
+  directories:
+    - 'node_modules'
+
+git:
+  depth: 3
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
+
+install:
+  - yarn install --frozen-lockfile
+
+before_script:
+  - yarn lint
+
+script:
+  - yarn test --maxWorkers=2 --ci


### PR DESCRIPTION
- enables caching
- sets max worker threads for jest to 2
- clone only last 3 commits
- install up-to-date yarn