### PR TITLE
fix: correct CORS headers for graphql mock server

### DIFF
--- a/packages/graphql/mock-server/README.md
+++ b/packages/graphql/mock-server/README.md
@@ -60,6 +60,27 @@ module.exports = {
 };
 ```
 
+If you want to apply additional settings to the apollo middleware, you can do so with settings like these:
+
+```js
+module.exports = {
+  remoteSchemas: [...],
+
+  schemaMocks: [...],
+
+  middlewareConfig: {
+    cors: {
+      credentials: true,
+      origin: true,
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      allowedHeaders: ['Content-Type', 'X-My-Special-Header'],
+    },
+  },
+};
+```
+
+For all possible options, please see the [original apollo server documentation section](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#ApolloServer-applyMiddleware).
+
 ## GraphQL Mock-Server usage examples
 
 - [Define your own schema extentions](#define-your-own-schema-extentions)

--- a/packages/graphql/mock-server/mixin.core.js
+++ b/packages/graphql/mock-server/mixin.core.js
@@ -174,7 +174,10 @@ module.exports = class GraphQLMockServerMixin extends Mixin {
     const app = express();
     app.use(cookieParser());
 
-    const { remoteSchemas = [] } = this.graphqlMockServerConfig;
+    const {
+      remoteSchemas = [],
+      middlewareConfig = {},
+    } = this.graphqlMockServerConfig;
 
     const remoteSchemaOptions = remoteSchemas.map(value =>
       mapRemoteSchemaOptions(value)
@@ -210,9 +213,17 @@ module.exports = class GraphQLMockServerMixin extends Mixin {
       const server = new ApolloServer({
         schema: this.schema,
         context: ({ req }) => ({ req, config: this.config }),
+        playground: {
+          settings: {
+            'request.credentials': 'include',
+          },
+        },
       });
 
-      server.applyMiddleware({ app });
+      server.applyMiddleware({
+        ...middlewareConfig,
+        app,
+      });
     });
 
     middlewares.preroutes.push(app);


### PR DESCRIPTION
affects: hops-graphql


## Current state

graphql mock server requests are answered with invalid CORS headers

## Changes introduced here

leverage CORS config options in apollo middleware / server and configure them correctly

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
