### PR TITLE
fix(config): pass required arguments to `getConfig` calls

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -1,5 +1,5 @@
 process.env.UNTOOL_NSP = 'hops';
 
 module.exports = require('@untool/core/lib/env').environmentalize(
-  require('@untool/core/lib/config').getConfig()
+  require('@untool/core/lib/config').getConfig({ configNamespace: 'hops' })
 );

--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'production';
 
 const serverlessHttp = require('serverless-http');
 const config = require('@untool/core/lib/env').environmentalize(
-  require('@untool/core/lib/config').getConfig()
+  require('@untool/core/lib/config').getConfig({ configNamespace: 'hops' })
 );
 const {
   stripLeadingSlash,


### PR DESCRIPTION
Otherwise it will break with:
`TypeError: Cannot destructure propertyconfigNamespaceof 'undefined' or 'null'.`
Because `getConfig()` expects an object as its only argument.