### PR TITLE
chore: silence stdio in create-hops-app integration tests

### DIFF
--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -23,7 +23,7 @@ describe('postcss production build', () => {
       `--template ${template}@${version}`,
     ].join(' ');
 
-    execSync(`${createHopsAppBin} ${args}`);
+    execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 
     const lockFile = path.join(cwd, name, 'yarn.lock');
 
@@ -40,7 +40,7 @@ describe('postcss production build', () => {
       `--npm`,
     ].join(' ');
 
-    execSync(`${createHopsAppBin} ${args}`);
+    execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 
     const lockFile = path.join(cwd, name, 'package-lock.json');
 


### PR DESCRIPTION
Yarn and npm write information to stdout/stderr which will then show up
in the integration tests - this commit suppresses their output.