### PR TITLE
fix: remove superfluous react-router dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "hops",
     "react",
-    "react-router"
+    "router"
   ],
   "license": "MIT",
   "engines": {
@@ -23,8 +23,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@untool/core": "^0.24.0",
     "@untool/react": "^0.24.0",
-    "hops-mixin": "11.0.0-rc.39",
-    "react-router": "^4.3.1"
+    "hops-mixin": "11.0.0-rc.39"
   },
   "peerDependencies": {
     "react": "^16.3.0",

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -28,7 +28,6 @@
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.6",
-    "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"

--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -24,7 +24,6 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
   },
   "devDependencies": {

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -26,7 +26,6 @@
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.6",
-    "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"


### PR DESCRIPTION
The package react-router is a direct dependency of react-router-dom and
it is recommended to always import react-router-dom instead.