### PR TITLE
feat(cli): log webpack errors and warnings in watch mode to terminal

### DIFF
--- a/packages/cli/mixin.core.js
+++ b/packages/cli/mixin.core.js
@@ -3,16 +3,41 @@
 const { format } = require('url');
 const prettyMS = require('pretty-ms');
 
-class LoggerPlugin {
+class HopsWebpackLoggerPlugin {
+  constructor() {
+    this.lastHashes = {};
+  }
+
   apply(compiler) {
-    compiler.hooks.done.tap('hops-logger-plugin', stats => {
-      if (stats.compilation.name === 'develop') {
-        console.log(
-          'Compiled successfully',
-          'in',
-          prettyMS(stats.endTime - stats.startTime)
-        );
+    compiler.hooks.done.tap(this.constructor.name, stats => {
+      const { name } = stats.compilation;
+      if (this.lastHashes[name] === stats.hash) {
+        return;
       }
+      this.lastHashes[name] = stats.hash;
+      const hasWarnings = stats.hasWarnings();
+      const hasErrors = stats.hasErrors();
+      const { errors, warnings, children } = stats.toJson({
+        all: false,
+        errors: true,
+        children: true,
+        moduleTrace: true,
+        warnings: true,
+      });
+      const allWarnings = warnings.concat(...children.map(c => c.warnings));
+      const allErrors = errors.concat(...children.map(c => c.errors));
+
+      console.log(
+        hasErrors
+          ? `Compilation ${name} failed after`
+          : `Compiled ${name} ${
+              hasWarnings ? 'with warnings' : 'successfully'
+            } in`,
+        prettyMS(stats.endTime - stats.startTime)
+      );
+
+      allErrors.forEach(error => console.log(`ERROR in: ${error}\n`));
+      allWarnings.forEach(warning => console.log(`WARNING in ${warning}\n`));
     });
   }
 }
@@ -40,10 +65,10 @@ module.exports = class CLIMixin {
     }
   }
   configureBuild(webpackConfig, loaderConfigs, target) {
-    if (target === 'develop') {
+    if (target !== 'build') {
       const { quiet } = this.options;
       if (!quiet) {
-        webpackConfig.plugins.push(new LoggerPlugin());
+        webpackConfig.plugins.push(new HopsWebpackLoggerPlugin());
       }
     }
   }


### PR DESCRIPTION
Since we don't break the build anymore when the build has warnings, we
now log errors and warnings during watch mode to the terminal.
We do however still reject the render middleware promise for errors, so
that express will then only render that error in case the build has any