### PR TITLE
test: set jest timeout globally to 5 minutes (for each file)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
   ],
   "jest": {
     "projects": [
-      "packages/!(spec)",
-      "packages/spec/integration/*"
+      "<rootDir>/packages/!(spec)",
+      "<rootDir>/packages/spec/integration/*"
     ]
   },
   "devDependencies": {

--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -52,6 +52,7 @@ class FixtureEnvironment extends NodeEnvironment {
 
     this.global.createPage = async () => {
       const page = await browser.newPage();
+      page.setDefaultNavigationTimeout(2 * 60 * 1000);
       page.on('error', error => {
         throw error;
       });

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -2,16 +2,13 @@ const path = require('path');
 const { existsSync, readFileSync } = require('fs');
 const { execSync } = require('child_process');
 
-const ONE_MINUTE = 60 * 1000;
-
 const createHopsAppBin = require.resolve('create-hops-app');
 
-describe('postcss production build', () => {
+describe('create-hops-app', () => {
   const version = 'next';
   const template = 'hops-template-react';
 
   beforeAll(() => {
-    jest.setTimeout(5 * ONE_MINUTE);
     process.chdir(cwd);
   });
 

--- a/packages/spec/integration/create-hops-app/package.json
+++ b/packages/spec/integration/create-hops-app/package.json
@@ -6,6 +6,7 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   }
 }

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -8,8 +8,6 @@ describe('development proxy object config', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
-
     const packageJsonPath = path.join(global.cwd, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
     packageJson.hops.port = PORT;

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -8,8 +8,6 @@ describe('development proxy string config', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
-
     const packageJsonPath = path.join(global.cwd, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
     packageJson.hops.port = PORT;

--- a/packages/spec/integration/development-proxy/package.json
+++ b/packages/spec/integration/development-proxy/package.json
@@ -11,7 +11,8 @@
     "mixins": ["./"]
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/graphql-mock-server/__tests__/develop.js
+++ b/packages/spec/integration/graphql-mock-server/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('graphql development server', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/graphql-mock-server/package.json
+++ b/packages/spec/integration/graphql-mock-server/package.json
@@ -13,7 +13,8 @@
     "graphqlMockConfigFile": "<rootDir>/graphql-mock-config.js"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('graphql development client', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/graphql/package.json
+++ b/packages/spec/integration/graphql/package.json
@@ -9,7 +9,8 @@
     "graphqlUri": "https://www.graphqlhub.com/graphql"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/jest-preset/package.json
+++ b/packages/spec/integration/jest-preset/package.json
@@ -9,7 +9,8 @@
     "preset": "jest-preset-hops",
     "testPathIgnorePatterns": [
       "__tests__/setup"
-    ]
+    ],
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "dependencies": {
     "hops-preset-jest": "*"

--- a/packages/spec/integration/lambda/__tests__/build.js
+++ b/packages/spec/integration/lambda/__tests__/build.js
@@ -38,7 +38,6 @@ function invokeFunction(root, path) {
 
 describe('lambda production build', () => {
   beforeAll(async () => {
-    jest.setTimeout(60000);
     await HopsCLI.build('-p');
   });
 

--- a/packages/spec/integration/lambda/package.json
+++ b/packages/spec/integration/lambda/package.json
@@ -6,7 +6,8 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "hops": {
     "basePath": "/prod",

--- a/packages/spec/integration/postcss/__tests__/build.js
+++ b/packages/spec/integration/postcss/__tests__/build.js
@@ -2,7 +2,6 @@ describe('postcss production build', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start('-p');
   });
 

--- a/packages/spec/integration/postcss/__tests__/develop.js
+++ b/packages/spec/integration/postcss/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('react-postcss', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/postcss/package.json
+++ b/packages/spec/integration/postcss/package.json
@@ -6,7 +6,8 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/pwa/__tests__/build.js
+++ b/packages/spec/integration/pwa/__tests__/build.js
@@ -2,7 +2,6 @@ describe('pwa production build', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start('-p');
   });
 

--- a/packages/spec/integration/pwa/package.json
+++ b/packages/spec/integration/pwa/package.json
@@ -10,7 +10,8 @@
     "locations": ["/"]
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('react developmet server', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/react/package.json
+++ b/packages/spec/integration/react/package.json
@@ -9,7 +9,8 @@
     "mixins": ["./"]
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('redux developmet server', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/redux/package.json
+++ b/packages/spec/integration/redux/package.json
@@ -6,7 +6,8 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/styled-components/__tests__/develop.js
+++ b/packages/spec/integration/styled-components/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('styled-components development server', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/styled-components/package.json
+++ b/packages/spec/integration/styled-components/package.json
@@ -6,7 +6,8 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/integration/typescript/__tests__/develop.js
+++ b/packages/spec/integration/typescript/__tests__/develop.js
@@ -2,7 +2,6 @@ describe('typescript developmet server', () => {
   let url;
 
   beforeAll(async () => {
-    jest.setTimeout(30000);
     url = await HopsCLI.start();
   });
 

--- a/packages/spec/integration/typescript/package.json
+++ b/packages/spec/integration/typescript/package.json
@@ -6,7 +6,8 @@
     "node": ">= 8.10"
   },
   "jest": {
-    "testEnvironment": "../../helpers/env.js"
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/spec/jest.setup.js
+++ b/packages/spec/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(5 * 60 * 1000);


### PR DESCRIPTION
Our tests are sometimes failing with a jest timeout.

Therefore I have moved the timeout setup to a global
`setupTestFrameworkScriptFile` in which the timeout is set to 5 minutes.