### PR TITLE
chore: specify yarn version in package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=8.10.0",
+    "yarn": ">=1.10.1"
   },
   "contributors": [
     "dmbch <daniel@dmbch.net> (https://www.xing.com/profile/Daniel_Dembach)",


### PR DESCRIPTION
yarn 1.10 adds "integrity" checksums to the lockfile while yarn < 1.10
removes them again.
In order to specify the versions that we want to use and support, we can
specify the yarn version in the "engines" field.