### PR TITLE
Upgrade untool to fix HMR

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/yargs": "^1.0.0-rc.4",
+    "@untool/yargs": "^1.0.0-rc.5",
     "enhanced-resolve": "^4.1.0",
     "find-up": "^3.0.0",
     "pretty-ms": "^3.2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.0.0-rc.4",
-    "@untool/webpack": "^1.0.0-rc.4"
+    "@untool/core": "^1.0.0-rc.5",
+    "@untool/webpack": "^1.0.0-rc.5"
   }
 }

--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -4,11 +4,7 @@ process.env.NODE_ENV = 'production';
 
 const serverlessHttp = require('serverless-http');
 const config = require('hops-config');
-const {
-  internal: {
-    uri: { trimSlashes },
-  },
-} = require('@untool/express');
+const { trimSlashes } = require('pathifist');
 
 const app = require('@untool/express').createServer('serve');
 

--- a/packages/lambda/lib/aws-config.js
+++ b/packages/lambda/lib/aws-config.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const semver = require('semver');
-const {
-  internal: {
-    uri: { trimSlashes },
-  },
-} = require('@untool/express');
+const { trimSlashes } = require('pathifist');
 
 const MAX_NODE_VERSION = '8.10';
 

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -18,13 +18,14 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.0.0-rc.4",
-    "@untool/express": "^1.0.0-rc.4",
+    "@untool/core": "^1.0.0-rc.5",
+    "@untool/express": "^1.0.0-rc.5",
     "archiver": "^3.0.0",
     "aws-sdk": "^2.286.2",
     "globby": "^8.0.0",
     "hops-config": "11.0.0-rc.40",
     "hops-mixin": "11.0.0-rc.40",
+    "pathifist": "^0.0.2",
     "prompt": "^1.0.0",
     "resolve-tree": "^0.1.13",
     "semver": "^5.5.0",

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.0.0-rc.4",
+    "@untool/core": "^1.0.0-rc.5",
     "mixinable": "^4.0.0"
   }
 }

--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -3,11 +3,9 @@ const postcssPresetEnv = require('postcss-preset-env');
 const ExtractCSSPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin');
 const { Mixin } = require('hops-mixin');
-const {
-  internal: {
-    uri: { resolveRelative },
-  },
-} = require('@untool/express');
+const { join, trimSlashes } = require('pathifist');
+
+const getAssetPath = (...args) => trimSlashes(join(...args));
 
 const cssLoaderOptions = {
   camelCase: true,
@@ -81,11 +79,11 @@ class PostCSSMixin extends Mixin {
 
     webpackConfig.plugins.push(
       new ExtractCSSPlugin({
-        filename: resolveRelative(
+        filename: getAssetPath(
           this.config.assetPath,
           '[name]-[contenthash:12].css'
         ),
-        chunkFilename: resolveRelative(
+        chunkFilename: getAssetPath(
           this.config.assetPath,
           '[name]-[contenthash:12].css'
         ),

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -18,11 +18,11 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/express": "^1.0.0-rc.4",
     "css-loader": "^1.0.0",
     "hops-mixin": "11.0.0-rc.40",
     "mini-css-extract-plugin": "^0.4.1",
     "optimize-css-assets-webpack-plugin": "^5.0.0",
+    "pathifist": "^0.0.2",
     "postcss-import": "^12.0.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.0.0",

--- a/packages/preset-defaults/package.json
+++ b/packages/preset-defaults/package.json
@@ -16,9 +16,9 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/express": "^1.0.0-rc.4",
-    "@untool/webpack": "^1.0.0-rc.4",
-    "@untool/yargs": "^1.0.0-rc.4",
+    "@untool/express": "^1.0.0-rc.5",
+    "@untool/webpack": "^1.0.0-rc.5",
+    "@untool/yargs": "^1.0.0-rc.5",
     "hops-express": "11.0.0-rc.40"
   }
 }

--- a/packages/pwa/mixin.core.js
+++ b/packages/pwa/mixin.core.js
@@ -1,10 +1,8 @@
 const { Mixin } = require('hops-mixin');
-const {
-  internal: {
-    uri: { resolveRelative },
-  },
-} = require('@untool/express');
+const { join, trimSlashes } = require('pathifist');
 const ServiceWorkerPlugin = require('./lib/service-worker-plugin');
+
+const getAssetPath = (...args) => trimSlashes(join(...args));
 
 class PWAMixin extends Mixin {
   configureBuild(webpackConfig, { allLoaderConfigs }, target) {
@@ -14,10 +12,7 @@ class PWAMixin extends Mixin {
         {
           loader: require.resolve('file-loader'),
           options: {
-            name: resolveRelative(
-              this.config.assetPath,
-              '[name]-[hash:16].[ext]'
-            ),
+            name: getAssetPath(this.config.assetPath, '[name]-[hash:16].[ext]'),
             emitFile: target === 'build' || target === 'develop',
           },
         },

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -19,12 +19,12 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.0.0-rc.4",
-    "@untool/express": "^1.0.0-rc.4",
-    "@untool/webpack": "^1.0.0-rc.4",
+    "@untool/core": "^1.0.0-rc.5",
+    "@untool/webpack": "^1.0.0-rc.5",
     "app-manifest-loader": "^2.0.0",
     "file-loader": "^2.0.0",
     "hops-mixin": "11.0.0-rc.40",
+    "pathifist": "^0.0.2",
     "webpack": "^4.16.5",
     "webpack-sources": "^1.1.0"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,8 +21,8 @@
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-    "@untool/core": "^1.0.0-rc.4",
-    "@untool/react": "^1.0.0-rc.4",
+    "@untool/core": "^1.0.0-rc.5",
+    "@untool/react": "^1.0.0-rc.5",
     "hops-mixin": "11.0.0-rc.40"
   },
   "peerDependencies": {

--- a/packages/spec/integration/hot-module-reload/__tests__/develop.js
+++ b/packages/spec/integration/hot-module-reload/__tests__/develop.js
@@ -34,4 +34,22 @@ describe('hot module reload', () => {
 
     await page.close();
   });
+
+  // test against regression where reloading would not work after changing a file
+  // https://github.com/untool/untool/pull/189
+  it('allows to reload after a file change', async () => {
+    const { page } = await createPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    changeFile('two');
+    await page.waitForSelector('#two', { timeout: 10000 });
+
+    await page.reload();
+    await page.waitForSelector('#two', { timeout: 10000 });
+
+    changeFile('three');
+    await page.waitForSelector('#three', { timeout: 10000 });
+
+    await page.close();
+  });
 });

--- a/packages/spec/integration/hot-module-reload/__tests__/develop.js
+++ b/packages/spec/integration/hot-module-reload/__tests__/develop.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function changeFile(id) {
+  const content = `
+  import { render } from 'hops-react';
+  import React from 'react';
+  export default render(<h1 id="${id}">hello</h1>);
+  `;
+
+  fs.writeFileSync(path.join(global.cwd, 'index.js'), content);
+}
+
+describe('hot module reload', () => {
+  let url;
+
+  beforeAll(async () => {
+    url = await HopsCLI.start();
+  });
+
+  it('reflects changes automatically', async () => {
+    const { page } = await createPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    await page.waitForSelector('#one', { timeout: 2000 });
+
+    changeFile('two');
+    await page.waitForSelector('#two', { timeout: 10000 });
+    await expect(page.$('#one')).resolves.toBeNull();
+
+    changeFile('three');
+    await page.waitForSelector('#three', { timeout: 10000 });
+    await expect(page.$('#one')).resolves.toBeNull();
+    await expect(page.$('#two')).resolves.toBeNull();
+
+    await page.close();
+  });
+});

--- a/packages/spec/integration/hot-module-reload/index.js
+++ b/packages/spec/integration/hot-module-reload/index.js
@@ -1,0 +1,3 @@
+import { render } from 'hops-react';
+import React from 'react';
+export default render(<h1 id="one">hello</h1>);

--- a/packages/spec/integration/hot-module-reload/package.json
+++ b/packages/spec/integration/hot-module-reload/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fixture-hot-module-reload",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">= 8.10"
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js",
+    "setupTestFrameworkScriptFile": "../../jest.setup.js"
+  },
+  "scripts": {
+    "start": "hops start",
+    "build": "hops build"
+  },
+  "dependencies": {
+    "hops": "*",
+    "hops-preset-defaults": "*",
+    "hops-react": "*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,10 +1551,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@untool/core@1.0.0-rc.4", "@untool/core@^1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@untool/core/-/core-1.0.0-rc.4.tgz#0eb621070ab0c9793e998af2d19217468ca488a5"
-  integrity sha512-VBdJhxEsSAaSjRC9uD+5UMvA6r8VrPcbSMmKXY7cNH1gp/prt0JqDYhNsmU0ZpR8xnokBbsiTKPEt59+dAtHaw==
+"@untool/core@1.0.0-rc.5", "@untool/core@^1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@untool/core/-/core-1.0.0-rc.5.tgz#05d09e27d6b38008f1837489f1e49385269313a8"
+  integrity sha512-67kW0Er6dkPh/IiaZbXH55AwmCzjRVVdk6n5x5EgAsRG8bp/cpOpxmidYnVzkzucYmF/pxIbHz05FEUheb8HWA==
   dependencies:
     cosmiconfig "^5.0.5"
     debug "^4.0.0"
@@ -1568,13 +1568,13 @@
     mixinable "^4.0.0"
     supports-color "^5.4.0"
 
-"@untool/express@1.0.0-rc.4", "@untool/express@^1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@untool/express/-/express-1.0.0-rc.4.tgz#d5b2fbbd630eb45b4048347ac228ed5e355204b3"
-  integrity sha512-SgxqHliyh+PsRkpANyWd1Z+76c2pFpaE4V2+zjV+oxGN7l5RUomp3xWI49VO+eqOzGA2XUpO5zzcPctbS8aMXQ==
+"@untool/express@1.0.0-rc.5", "@untool/express@^1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@untool/express/-/express-1.0.0-rc.5.tgz#c3eeb1a376ef43b5dde6a0d596ef44d528a85971"
+  integrity sha512-PYJTFCLjDUbNhmVVjXRWKLIRksNr4cytUPDTCIpEKmS9Wo+BIgzYIJPz/d2h7vA3z2D64WdP0yHINVpz43LjBQ==
   dependencies:
-    "@untool/core" "1.0.0-rc.4"
-    "@untool/yargs" "1.0.0-rc.4"
+    "@untool/core" "1.0.0-rc.5"
+    "@untool/yargs" "1.0.0-rc.5"
     debug "^4.0.0"
     directory-index "^0.1.0"
     express "^4.16.2"
@@ -1586,31 +1586,31 @@
     portfinder "^1.0.17"
     supports-color "^5.4.0"
 
-"@untool/react@^1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@untool/react/-/react-1.0.0-rc.4.tgz#785f8aba6bd9e3a8514ed1640bad929e886fb955"
-  integrity sha512-pawHF2VmZmYy7KC/KSc+UVn8CgF1bN02pHBPzug0FSYK3WAITfZV7nyVQeMISvqes1hpxEg+l3FAsUjoNOI5HQ==
+"@untool/react@^1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@untool/react/-/react-1.0.0-rc.5.tgz#b9f10310b1481ec53d8fa69bda24775d4084b5c1"
+  integrity sha512-ghZzCBd9TFnNEO/xs0Lg+5fMZTlxw26JQ8zFuNvR0CrGDHfiobQFJz3GKdFwZgurHHmXbVGEeyu04+lWNrG9Ow==
   dependencies:
     "@babel/preset-react" "^7.0.0"
-    "@untool/core" "1.0.0-rc.4"
+    "@untool/core" "1.0.0-rc.5"
     babel-plugin-transform-react-remove-prop-types "^0.4.13"
     clone "^2.1.2"
     mixinable "^4.0.0"
     prop-types "^15.6.2"
     serialize-javascript "^1.4.0"
 
-"@untool/webpack@^1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@untool/webpack/-/webpack-1.0.0-rc.4.tgz#8b7fcaf79afb5186dbfdb014d45775d0d2da5119"
-  integrity sha512-jrWRC/gghU8iTAn70ijV7ARNwdd4IIzG+Zy2XE2G8QpT9gVzva5pslLvxnm1JlJtqc4Xcdq8cFvODZTBxUNwFQ==
+"@untool/webpack@^1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@untool/webpack/-/webpack-1.0.0-rc.5.tgz#79bb87b27730c4736693fa0d73c3327a67fbb43b"
+  integrity sha512-LWtBTG6wAf7eoTiAJk9YpiuHP9BsSpdIBnsOFv1mExIpkbPKo6Uaw3ILNrpiSEwuxrvWh6w1nA8nQyEN3zDloA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-syntax-dynamic-import" "^7.0.0"
     "@babel/polyfill" "^7.0.0"
     "@babel/preset-env" "^7.0.0"
-    "@untool/core" "1.0.0-rc.4"
-    "@untool/express" "1.0.0-rc.4"
-    "@untool/yargs" "1.0.0-rc.4"
+    "@untool/core" "1.0.0-rc.5"
+    "@untool/express" "1.0.0-rc.5"
+    "@untool/yargs" "1.0.0-rc.5"
     babel-loader "8"
     babel-plugin-dynamic-import-node "^2.0.0"
     browserslist-useragent "^2.0.1"
@@ -1622,6 +1622,7 @@
     loader-utils "^1.1.0"
     memory-fs "^0.4.1"
     mixinable "^4.0.0"
+    pathifist "^0.0.2"
     require-from-string "^2.0.1"
     rimraf "^2.6.2"
     source-map-support "^0.5.6"
@@ -1633,12 +1634,12 @@
     webpack-hot-middleware "^2.22.2"
     webpack-sources "^1.1.0"
 
-"@untool/yargs@1.0.0-rc.4", "@untool/yargs@^1.0.0-rc.4":
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@untool/yargs/-/yargs-1.0.0-rc.4.tgz#a56ca24cdbf4b01e32c6f00d211543a014f27e40"
-  integrity sha512-C1kcWZ0OPhp2MSTNpj8+GZgYtKR5qXYGRZw06j5pxyfZwgsookiu7B64sF98+DmOiqxlZQkkNkgnrNuGLWtjng==
+"@untool/yargs@1.0.0-rc.5", "@untool/yargs@^1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@untool/yargs/-/yargs-1.0.0-rc.5.tgz#9cedd6ada8c3303ddf4d52d59e2b31510b4a20e8"
+  integrity sha512-qPfX3TvRDt6vtuZ7Ch+Td0qCBK3fAQO3ShUo81EEeTdvjgObr0lZw00vDcoH1uFUpEQ5h1a287AdrzchGMuAyA==
   dependencies:
-    "@untool/core" "1.0.0-rc.4"
+    "@untool/core" "1.0.0-rc.5"
     mixinable "^4.0.0"
     pretty-ms "^4.0.0"
     yargs "^12.0.0"
@@ -8610,6 +8611,11 @@ path-type@^3.0.0:
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+pathifist@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/pathifist/-/pathifist-0.0.2.tgz#e6254383377bd7c2cd9affe585a6579c128768b9"
+  integrity sha512-U3A85WGFi1zJi1OiL9jU5XZiX25qTrCTnVwu1evIXbSqDXxOPh2Sh/WEmGQwf7A4fidNIu1FaXHdGlcMiIUHyg==
 
 pbkdf2@^3.0.3:
   version "3.0.17"


### PR DESCRIPTION
Reload currently does not work after a file has been changed.
This PR will fix it with an untool upgrade after [this PR](https://github.com/untool/untool/pull/189) or another fix has been merged and released.

I've already written basic tests. The second one should immediately be green after the upgrade. (Tried it with modified node_modules folder) 