### PR TITLE
chore(react): remove obsolete babel plugin

### DIFF
--- a/packages/react/mixin.core.js
+++ b/packages/react/mixin.core.js
@@ -4,8 +4,7 @@ class ReactCoreMixin extends Mixin {
   configureBuild(webpackConfig, { jsLoaderConfig }) {
     jsLoaderConfig.options.plugins.push(
       require.resolve('@babel/plugin-transform-flow-strip-types'),
-      require.resolve('@babel/plugin-proposal-class-properties'),
-      require.resolve('@babel/plugin-proposal-object-rest-spread')
+      require.resolve('@babel/plugin-proposal-class-properties')
     );
 
     const untoolImportPluginIndex = jsLoaderConfig.options.plugins.findIndex(

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@untool/core": "^1.0.0-rc.5",


### PR DESCRIPTION
## Current state

We include `plugin-proposal-object-rest-spread`, although `syntax-object-rest-spread` is included in @babel/preset-env since v7.

https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/available-plugins.js#L3

## Changes introduced here

Remove `plugin-proposal-object-rest-spread`.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added