### PR TITLE
chore: remove trailing slash from workspace to un-confuse lerna publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   ],
   "workspaces": [
     "packages/*",
-    "spec/"
+    "spec"
   ],
   "jest": {
     "projects": [


### PR DESCRIPTION
Before `lerna publish` would fail after publishing the packages with the
following message:
```
lerna ERR! Error: Command failed: git checkout -- spec//package.json
lerna ERR! error: pathspec 'spec//package.json' did not match any file(s) known to git
lerna ERR!
lerna ERR!     at makeError (./node_modules/@lerna/child-process/node_modules/execa/index.js:174:9)
lerna ERR!     at Promise.all.then.arr (./node_modules/@lerna/child-process/node_modules/execa/index.js:278:16)
lerna ERR! lerna Command failed: git checkout -- spec//package.json
lerna ERR! lerna error: pathspec 'spec//package.json' did not match any file(s) known to git
lerna ERR! lerna
error Command failed with exit code 1.
```
In order to avoid this problem we remove the trailing slash from the
`spec` workspace configuration (which also is not present in the yarn
docs: https://yarnpkg.com/lang/en/docs/workspaces/#toc-how-to-use-it).