### PR TITLE
fix(graphql): align exists check and resolve algo for graphqlMockSchemaFile

### DIFF
--- a/packages/graphql/mixin.core.js
+++ b/packages/graphql/mixin.core.js
@@ -1,9 +1,17 @@
-const { existsSync: exists } = require('fs');
 const { Mixin } = require('hops-mixin');
 const strip = require('strip-indent');
 const {
   internal: { createWebpackMiddleware, StatsFilePlugin },
 } = require('@untool/webpack');
+
+function exists(path) {
+  try {
+    require.resolve(path);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 class GraphQLMixin extends Mixin {
   registerCommands(yargs) {


### PR DESCRIPTION
Using require.resolve enables to use mock files in other node packages easily
The current fs.existsSync check prevented that although it would actually already be possible
in the current implementation.