### PR TITLE
replace shouldPrefetchOnServer with canPrefetchOnServer hook

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -222,10 +222,10 @@ Hook to return a custom [ApolloCache](https://www.apollographql.com/docs/react/a
 
 Allows to get the [fragment matcher](https://www.apollographql.com/docs/react/advanced/fragments.html) that needs to be passed to the `ApolloCache`. Useful if you plan to override `getApolloCache`.
 
-#### `shouldPrefetchOnServer(): boolean` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride)) **server**
+#### `canPrefetchOnServer(): boolean` ([sequence](https://github.com/untool/mixinable/blob/master/README.md#defineparallel)) **server**
 
-This is an overrideable hook that can be used to customize the behavior of when Hops should prefetch data during server-side rendering. E.g. execute GraphQL queries during initial render.
+This is a hook that can be used to customize the behavior of when Hops can prefetch data during server-side rendering. E.g. execute GraphQL queries during initial render. If any function of this sequence returns false it prevents server fetching for this request.
 
-By default it returns whatever is configured in the [`shouldPrefetchOnServer` preset option](#shouldprefetchonserver) or `true` if the config is not set.
+By default it returns whatever is configured in the [`shouldPrefetchOnServer` preset option](#shouldPrefetchOnServer).
 
 In case you need more control over the server-side rendering you can implement this method and provide your own implementation that decides if data should be prefetched during server-side rendering.

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -3,7 +3,7 @@ const { existsSync, readFileSync } = require('fs');
 const {
   Mixin,
   strategies: {
-    sync: { override, callable },
+    sync: { override, callable, sequence },
   },
 } = require('hops-mixin');
 
@@ -101,16 +101,15 @@ class GraphQLMixin extends Mixin {
   }
 
   prefetchData(element) {
-    return this.shouldPrefetchOnServer()
-      ? getDataFromTree(element)
-      : Promise.resolve();
+    const prefetchOnServer = this.canPrefetchOnServer().every(value => value);
+
+    return prefetchOnServer ? getDataFromTree(element) : Promise.resolve();
   }
 
-  shouldPrefetchOnServer() {
+  canPrefetchOnServer() {
     const { shouldPrefetchOnServer } = this.config;
-    return typeof shouldPrefetchOnServer === 'boolean'
-      ? shouldPrefetchOnServer
-      : true;
+
+    return shouldPrefetchOnServer !== false;
   }
 
   getTemplateData(data) {
@@ -136,7 +135,7 @@ GraphQLMixin.strategies = {
   getApolloLink: override,
   getApolloCache: override,
   createFragmentMatcher: callable,
-  shouldPrefetchOnServer: override,
+  canPrefetchOnServer: sequence,
 };
 
 module.exports = GraphQLMixin;

--- a/packages/graphql/preset.js
+++ b/packages/graphql/preset.js
@@ -1,8 +1,9 @@
 module.exports = {
+  mixins: [__dirname],
   fragmentsFile: '<rootDir>/fragmentTypes.json',
   graphqlUri: '',
   graphqlSchemaFile: '',
   graphqlMockSchemaFile: '',
   graphqlMockServerPath: '/graphql',
-  mixins: [__dirname],
+  shouldPrefetchOnServer: true,
 };

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -144,10 +144,10 @@ const incrementFetch = () => (dispatch, getState, { fetch }) => {
 };
 ```
 
-#### `shouldPrefetchOnServer(): boolean` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride)) **server**
+#### `canPrefetchOnServer(): boolean` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride)) **server**
 
-This is an overrideable hook that can be used to customize the behavior of when Hops should prefetch data during server-side rendering. E.g. execute route-bound action creators during initial render.
+This is a hook that can be used to customize the behavior of when Hops can prefetch data during server-side rendering. E.g. execute route-bound action creators during initial render. If any function of this sequence returns false it prevents server fetching for this request.
 
-By default it returns whatever is configured in the [`shouldPrefetchOnServer` preset option](#shouldprefetchonserver) or `true` if the config is not set.
+By default it returns whatever is configured in the [`shouldPrefetchOnServer` preset option](#shouldprefetchonserver).
 
 In case you need more control over the server-side rendering you can implement this method and provide your own implementation that decides if data should be prefetched during server-side rendering.

--- a/packages/redux/preset.js
+++ b/packages/redux/preset.js
@@ -1,4 +1,5 @@
 const path = require('path');
 module.exports = {
   mixins: [__dirname, path.join(__dirname, 'action-creator-dispatcher')],
+  shouldPrefetchOnServer: true,
 };


### PR DESCRIPTION
Instead of asking just one mixin whether it is ok to prefetch or not, we can now ask all relevant mixins and if at least one mixin disagrees we prevent prefetching.