### PR TITLE
docs(styled-components): change above to below

### DIFF
--- a/packages/styled-components/README.md
+++ b/packages/styled-components/README.md
@@ -40,7 +40,7 @@ This preset has no preset configuration options.
 
 #### Render Options
 
-This preset has only a single runtime option which can be passed to the `render()` options inside the `styled` key (see example above).
+This preset has only a single runtime option which can be passed to the `render()` options inside the `styled` key (see example below).
 
 | Name           | Type     | Default | Required | Description                                                  |
 | -------------- | -------- | ------- | -------- | ------------------------------------------------------------ |


### PR DESCRIPTION
as the example is indeed below the text