### PR TITLE
fix(create-hops-app): make yarn create work with @next tagged version

### DIFF
--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -11,7 +11,8 @@
     "node": ">=8.10.0"
   },
   "bin": {
-    "create-hops-app": "./index.js"
+    "create-hops-app": "./index.js",
+    "create-hops-app@next": "./index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When you run the yarn create command, we propose in the readme:

```
yarn create hops-app@next --hops-version next --template hops-template-react@next my-awesome-project
```

you receive the following error:

```
success Installed "create-hops-app@11.0.0-rc.46" with binaries:
      - create-hops-app
/bin/sh: /usr/local/bin/create-hops-app@next: No such file or directory
error Command failed.
Exit code: 127
Command: /usr/local/bin/create-hops-app@next
Arguments: --hops-version next --template hops-template-react@next my-awesome-project
Directory: /Users/robin/Development
```

yarn create usually works by installing the `create-something` package and then invoking the eponymous binary. 
In our case, it tries to find the `create-hops-app@next` binary, which obviously does not exist.

This seems to be a bug in yarn and I might give a fix a go. But there will still be people with older yarn versions around and this workaround seems to suffice. I tried it with a test package (that I have already unpublished again) and it worked.