### PR TITLE
fix(graphql): lazily instantiate client to free up bootstrap hook

### DIFF
--- a/packages/graphql/mixin.browser.js
+++ b/packages/graphql/mixin.browser.js
@@ -23,8 +23,11 @@ class GraphQLMixin extends Mixin {
     this.options = options;
   }
 
-  bootstrap() {
-    this.client = this.createClient(this.options);
+  getApolloClient() {
+    if (this.client) {
+      return this.client;
+    }
+    return (this.client = this.createClient(this.options));
   }
 
   createClient(options) {
@@ -70,7 +73,7 @@ class GraphQLMixin extends Mixin {
   enhanceElement(reactElement) {
     return React.createElement(
       ApolloProvider,
-      { client: this.client },
+      { client: this.getApolloClient() },
       reactElement
     );
   }

--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -45,8 +45,11 @@ class GraphQLMixin extends Mixin {
     }
   }
 
-  bootstrap() {
-    this.client = this.createClient(this.options);
+  getApolloClient() {
+    if (this.client) {
+      return this.client;
+    }
+    return (this.client = this.createClient(this.options));
   }
 
   createClient(options) {
@@ -94,7 +97,7 @@ class GraphQLMixin extends Mixin {
         globals: {
           ...(data.globals || {}),
           APOLLO_FRAGMENT_TYPES: introspectionResult,
-          APOLLO_STATE: this.client.cache.extract(),
+          APOLLO_STATE: this.getApolloClient().cache.extract(),
         },
       };
     });
@@ -125,7 +128,7 @@ class GraphQLMixin extends Mixin {
   enhanceElement(reactElement) {
     return React.createElement(
       ApolloProvider,
-      { client: this.client },
+      { client: this.getApolloClient() },
       reactElement
     );
   }


### PR DESCRIPTION
In some cases we may need to obtain information from the request,
response or other hooks through the "bootstrap" hook and want to use
that data during the instantiation of the apollo client.
At the moment the apollo client will be instantiated in the bootstrap
hook and therefore prevents us from using that scenario.

With this change we only instantiate the client at the last possible
time and therefore we can use the bootstrap and getApolloLink hooks to
overwrite them and inject additional data.

Example:
```javascript
class MyMixin extends Mixin {
  bootstrap(req, res) {
    this.language = res.locals.language;
  }

  getApolloLink() {
    return new HttpLink({
      uri: this.config.graphqlUri,
      headers: {
        'Accept-Language': this.language,
      },
    });
  }
}
```