### PR TITLE
fix(react): deep import react runtime components from @untool/react

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,4 +1,10 @@
-const { render, Header, Import, Miss, Status } = require('@untool/react');
+const {
+  render,
+  Header,
+  Import,
+  Miss,
+  Status,
+} = require('@untool/react/lib/runtime');
 const { Consumer } = require('./server-data/context');
 const withServerData = require('./server-data/with-server-data');
 


### PR DESCRIPTION
Because support for the browser and server entrypoints in package.json
is still not standardized. E. g. Jest does not support them by default.