### PR TITLE
chore: remove master branch restriction for tag deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ deploy:
   provider: script
   script: './node_modules/.bin/conventional-github-releaser -p angular'
   on:
-    branch: master
     tags: true


### PR DESCRIPTION
During the last deployment the deployment script failed with a message
that it is not currently on any branch.
Therefore we will try to remove the branch restriction, because we use
tags only for releases anyway.

Unfortunately we need to merge this PR into master and do a release
before we can verify that this change works as intended, because we can
not test travis's deployment provider any other way.