### PR TITLE
feat(react): export entire ServerDataContext instead Consumer only

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -5,7 +5,7 @@ const {
   Miss,
   Status,
 } = require('@untool/react/lib/runtime');
-const { Consumer } = require('./server-data/context');
+const ServerDataContext = require('./server-data/context');
 const withServerData = require('./server-data/with-server-data');
 
 const ConfigContext = require('./config/context');
@@ -17,7 +17,7 @@ module.exports = {
   Miss,
   Status,
   render,
-  ServerDataContextConsumer: Consumer,
+  ServerDataContext,
   withServerData,
   ConfigContext,
   withConfig,

--- a/packages/spec/integration/react/index.js
+++ b/packages/spec/integration/react/index.js
@@ -3,7 +3,7 @@ import {
   Import,
   Miss,
   render,
-  ServerDataContextConsumer,
+  ServerDataContext,
   Status,
   ConfigContext,
   withConfig,
@@ -18,9 +18,9 @@ const Config = withConfig(({ config: { hoc } }) => <h1>{hoc}</h1>);
 export default render(
   <div>
     <Link to="/two">Link to two</Link>
-    <ServerDataContextConsumer>
+    <ServerDataContext.Consumer>
       {({ method }) => <output>{method}</output>}
-    </ServerDataContextConsumer>
+    </ServerDataContext.Consumer>
     <Switch>
       <Route path="/" exact render={() => <h1>home</h1>} />
       <Route path="/two" exact render={() => <h1>two</h1>} />


### PR DESCRIPTION
React features like [`Component.contextType`](https://reactjs.org/docs/context.html\#classcontexttype)
and [`useContext`](https://reactjs.org/docs/hooks-reference.html\#usecontext) need the entire Context object to work

This is technically a breaking change, but it seems we're the only ones using the Consumer yet and we're still in `rc`, so I guess it is fine to do it now.