### PR TITLE
fix(redux): always set prefetchedOnServer member variable

### DIFF
--- a/packages/redux/action-creator-dispatcher/mixin.server.js
+++ b/packages/redux/action-creator-dispatcher/mixin.server.js
@@ -9,6 +9,11 @@ const {
 const ReduxActionCreatorCommonMixin = require('./mixin.runtime-common');
 
 class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
+  constructor(...args) {
+    super(...args);
+    this.prefetchedOnServer = false;
+  }
+
   bootstrap(request) {
     this.request = request;
   }
@@ -26,6 +31,7 @@ class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
 
     if (_hopsPrefetchedOnServer) {
       await this.dispatchAll(createLocation(this.request.path));
+      this.prefetchedOnServer = true;
     }
 
     return {


### PR DESCRIPTION
This fixes a bug that were introduced by #703 

The `prefetchedOnServer` member variable is used in [`packages/redux/action-creator-dispatcher/mixin.runtime-common.js`](https://github.com/xing/hops/blob/1b4b8eaa7c9f5c792ee3ce5ddc5638b4aa7d68a9/packages/redux/action-creator-dispatcher/mixin.runtime-common.js#L84)