### PR TITLE
Fix dependency issues (minimum required versions, peer dependencies, etc)

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -19,27 +19,27 @@
   },
   "dependencies": {
     "@untool/webpack": "^1.0.0-rc.13",
-    "apollo-cache-inmemory": "^1.2.6",
-    "apollo-client": "^2.3.5",
-    "apollo-link-http": "^1.3.2",
-    "apollo-server-express": "^2.0.3",
+    "apollo-cache-inmemory": "^1.3.6",
+    "apollo-client": "^2.4.3",
+    "apollo-link-http": "^1.5.5",
+    "apollo-server-express": "^2.2.0",
     "cookie-parser": "^1.4.3",
     "cross-fetch": "^2.2.2",
     "express": "^4.16.3",
-    "graphql": "^14.0.0",
+    "graphql": "^14.0.2",
     "graphql-tools": "^4.0.0",
     "hops-config": "11.0.0-rc.50",
     "hops-mixin": "11.0.0-rc.50",
     "strip-indent": "^2.0.0"
   },
   "peerDependencies": {
-    "graphql-tag": "^2.5.0",
+    "graphql-tag": "^2.10.0",
     "react": "^16.4.0",
-    "react-apollo": "^2.0.0"
+    "react-apollo": "^2.2.3"
   },
   "devDependencies": {
-    "graphql-tag": "^2.5.0",
+    "graphql-tag": "^2.10.0",
     "react": "^16.4.2",
-    "react-apollo": "^2.1.9"
+    "react-apollo": "^2.2.3"
   }
 }

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -27,6 +27,6 @@
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.0.0",
     "style-loader": "^0.23.0",
-    "webpack": "^4.16.5"
+    "webpack": "^4.23.0"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -25,7 +25,7 @@
     "file-loader": "^2.0.0",
     "hops-mixin": "11.0.0-rc.50",
     "pathifist": "^1.0.0",
-    "webpack": "^4.16.5",
+    "webpack": "^4.23.0",
     "webpack-sources": "^1.1.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@untool/core": "^1.0.0-rc.13",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "react": "^16.4.0",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.2.0"

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -31,7 +31,7 @@
     "jest": "^23.4.2",
     "jest-environment-node": "^23.4.0",
     "mktemp": "^0.4.0",
-    "puppeteer": "1.11.0",
+    "puppeteer": "^1.11.0",
     "resolve-from": "^4.0.0",
     "rimraf": "^2.6.2",
     "url-join": "^4.0.0"

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "babel-plugin-styled-components": "1.9.2",
+    "babel-plugin-styled-components": "^1.9.2",
     "hops-mixin": "11.0.0-rc.50"
   },
   "peerDependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -22,10 +22,12 @@
   },
   "peerDependencies": {
     "react": "^16.4.0",
+    "react-dom": "^16.4.0",
     "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "react": "^16.4.2",
+    "react-dom": "^16.4.0",
     "styled-components": "^4.0.0"
   }
 }

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -19,14 +19,14 @@
     "serve": "hops serve"
   },
   "dependencies": {
-    "graphql-tag": "^2.6.1",
+    "graphql-tag": "^2.10.0",
     "hops-graphql": "11.0.0-rc.50",
     "hops-postcss": "11.0.0-rc.50",
     "hops-preset-defaults": "11.0.0-rc.50",
     "hops-react": "11.0.0-rc.50",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
-    "react-apollo": "^2.1.9",
+    "react-apollo": "^2.2.3",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.6",

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -35,7 +35,6 @@
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
-    "babel-core": "^7.0.0-0",
     "hops": "11.0.0-rc.50",
     "jest": "^23.4.2",
     "jest-preset-hops": "11.0.0-rc.50",

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -29,7 +29,7 @@
     "react-apollo": "^2.2.3",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"

--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -29,7 +29,6 @@
     "react-router-dom": "^4.3.1"
   },
   "devDependencies": {
-    "babel-core": "^7.0.0-0",
     "hops": "11.0.0-rc.50",
     "jest": "^23.4.2",
     "jest-preset-hops": "11.0.0-rc.50",

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -27,7 +27,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -33,7 +33,6 @@
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
-    "babel-core": "^7.0.0-0",
     "hops": "11.0.0-rc.50",
     "jest": "^23.4.2",
     "jest-preset-hops": "11.0.0-rc.50",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "hops-mixin": "11.0.0-rc.50",
     "ts-loader": "^5.0.0",
-    "typescript": "^3.0.0"
+    "typescript": "^3.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,7 +2417,7 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-core@^7.0.0-0:
+babel-core@^7.0.0-0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,7 +2417,7 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-core@^7.0.0-0, babel-core@^7.0.0-bridge.0:
+babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9909,7 +9909,7 @@ react-apollo@^2.2.3:
     lodash.isequal "^4.5.0"
     prop-types "^15.6.0"
 
-react-dom@^16.4.2:
+react-dom@^16.4.0, react-dom@^16.4.2:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
   integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,7 +2503,7 @@ babel-plugin-jest-hoist@^23.2.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
-babel-plugin-styled-components@1.9.2, "babel-plugin-styled-components@>= 1":
+"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.2.tgz#0e6a6587454dcb1c9a362a8fd31fc0b075ccd260"
   integrity sha512-McnheW8RkBkur/mQw7rEwQO/oUUruQ/nIIj5LIRpsVL8pzG1oo1Y53xyvAYeOfamIrl4/ta7g1G/kuTR1ekO3A==
@@ -9800,7 +9800,7 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@1.11.0:
+puppeteer@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
   integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
@@ -9939,7 +9939,7 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^5.0.6, react-redux@^5.0.7:
+react-redux@^5.0.7:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.1.tgz#88e368682c7fa80e34e055cd7ac56f5936b0f52f"
   integrity sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==
@@ -11575,7 +11575,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.0.0:
+typescript@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
   integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
@@ -11948,7 +11948,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.16.5, webpack@^4.23.0:
+webpack@^4.23.0:
   version "4.26.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.26.1.tgz#ff3a9283d363c07b3494dfa702d08f4f2ef6cb39"
   integrity sha512-i2oOvEvuvLLSuSCkdVrknaxAhtUZ9g+nLSoHCWV0gDzqGX2DXaCrMmMUpbRsTSSLrUqAI56PoEiyMUZIZ1msug==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,7 +1919,7 @@ apollo-cache-control@0.3.3:
     apollo-server-env "2.2.0"
     graphql-extensions "0.3.3"
 
-apollo-cache-inmemory@^1.2.6:
+apollo-cache-inmemory@^1.3.6:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.11.tgz#6cb8f24ec812715169f9acbb0b67833f9a19ec90"
   integrity sha512-fSoyjBV5RV57J3i/VHDDB74ZgXc0PFiogheNFHEhC0mL6rg5e/DjTx0Vg+csIBk23gvlzTvV+eypx7Q2NJ+dYg==
@@ -1935,7 +1935,7 @@ apollo-cache@1.1.21, apollo-cache@^1.1.21:
   dependencies:
     apollo-utilities "^1.0.26"
 
-apollo-client@^2.3.5:
+apollo-client@^2.4.3:
   version "2.4.7"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.4.7.tgz#b6712fd4c9ba346e3c44cfec7e6868e532b6a957"
   integrity sha512-6aAm+16AFBYZhJF8eKxrup6AbYni01InDiwTfZhMMTP2xaXQWjsQnfaHbI2oE+hd3+AZFy1drkse8RZKghR/WQ==
@@ -1998,7 +1998,7 @@ apollo-link-http-common@^0.2.6:
   dependencies:
     apollo-link "^1.2.4"
 
-apollo-link-http@^1.3.2:
+apollo-link-http@^1.5.5:
   version "1.5.7"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.7.tgz#098615c427a910ec8c5817476bbabe68c586b339"
   integrity sha512-EZ9nynHjwYCpGYP5IsRrZGTWidUVpshk7MuSG4joqGtJMwpFCgMQz+y3BHdUhowHtfAd9z60XmeOTG9FJolb8A==
@@ -2021,10 +2021,10 @@ apollo-server-caching@0.2.1:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.2.5.tgz#bf1538c10213be38a37dd8e6461461f7b808c57e"
-  integrity sha512-obz6VSJI7vSR+pEAZFwqOe/HAOuF4l1fYU9WNtVcQvxaKhykDgcu+byO0sXrOf/iB7uUIyaFdhinwzuwkqB8XQ==
+apollo-server-core@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.2.6.tgz#33031a3e1156d4cd0ad3c5c49de263173f521b32"
+  integrity sha512-hC3+Y9A4rN4W2X2cWqjrWWHkjKaG/jUQjtAVpQteDW+7n3bLKHCrpDFiFad++lq0ymRVW8diAaYDS4myJwjmoA==
   dependencies:
     "@apollographql/apollo-tools" "^0.2.6"
     "@apollographql/apollo-upload-server" "^5.0.3"
@@ -2036,9 +2036,9 @@ apollo-server-core@2.2.5:
     apollo-server-caching "0.2.1"
     apollo-server-env "2.2.0"
     apollo-server-errors "2.2.0"
-    apollo-server-plugin-base "0.1.5"
+    apollo-server-plugin-base "0.1.6"
     apollo-tracing "0.3.3"
-    graphql-extensions "0.3.5"
+    graphql-extensions "0.3.6"
     graphql-subscriptions "^1.0.0"
     graphql-tag "^2.9.2"
     graphql-tools "^4.0.0"
@@ -2060,10 +2060,10 @@ apollo-server-errors@2.2.0:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz#5b452a1d6ff76440eb0f127511dc58031a8f3cb5"
   integrity sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg==
 
-apollo-server-express@^2.0.3:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.2.5.tgz#9d27d68b3b1cf2f96a107a3091ecdea4012745a2"
-  integrity sha512-2SNlY8CNmYlbRJfn0iK4wesjqX3X9YIFhyok4sQ80n/gm24QMwZkFcPP+NLv+1lxvwyJYMwEFQPIBvkLRoUFXQ==
+apollo-server-express@^2.2.0:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.2.6.tgz#2c0c5bdab6eccf63ab138ad4b6d6836aeb723540"
+  integrity sha512-+zajJDcJLhWdkW8f0D5KQfDsaxgx7fQ3ULGDT1eZgL0UY5pazWBOnXqeRoVKRl+r1WcrwN1SMfBVnAKWv6CyVw==
   dependencies:
     "@apollographql/apollo-upload-server" "^5.0.3"
     "@apollographql/graphql-playground-html" "^1.6.6"
@@ -2072,17 +2072,17 @@ apollo-server-express@^2.0.3:
     "@types/cors" "^2.8.4"
     "@types/express" "4.16.0"
     accepts "^1.3.5"
-    apollo-server-core "2.2.5"
+    apollo-server-core "2.2.6"
     body-parser "^1.18.3"
     cors "^2.8.4"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"
     type-is "^1.6.16"
 
-apollo-server-plugin-base@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.1.5.tgz#899c4d7bc0d9a6d9f1181cc83a791479409086f8"
-  integrity sha512-be77TaN9l16ZVG1tBl8Re3lJfUZ6B2T3DdEXnu6fjQwUuBdu3Y4MQR6B1TLhbuTb9DUkcSKZ3h5C55dIjvb2Vg==
+apollo-server-plugin-base@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.1.6.tgz#56932c0e3a0366e03952a6e2805efe5fa2e046bf"
+  integrity sha512-nh6I2+mgSL5cYxqYXymAr8xBZ/ju8nunPjHp/21+/mgbF4Is0xtM9oDq5Qf0Q/cGh/djF6YcBuB1yUG+68gJXw==
 
 apollo-tracing@0.3.3:
   version "0.3.3"
@@ -5585,10 +5585,10 @@ graphql-extensions@0.3.3:
   dependencies:
     "@apollographql/apollo-tools" "^0.2.6"
 
-graphql-extensions@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.3.5.tgz#95b742185d0016a9d65385a7a9e10753eadf0537"
-  integrity sha512-jpWSUIr27iOTR5JYu+dEMz74oZhOj8Xy+6lNopluiIu+ObEVSHW0czb2Jlcy3rOSTEPcibnpStO4F4/64IBqeQ==
+graphql-extensions@0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.3.6.tgz#9ddb294b4b3303df4bbfd8258f10ad402e290dba"
+  integrity sha512-QGnDQ0TkF1YpVE/ZvKVl3bZ1PfwSbynVBcNU5U1DPU56pLkltETORiFL4TQ/Tt7RzagBX/xVaI3q0xJC6h9M5w==
   dependencies:
     "@apollographql/apollo-tools" "^0.2.6"
 
@@ -5599,7 +5599,7 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.2.1"
 
-graphql-tag@^2.5.0, graphql-tag@^2.6.1, graphql-tag@^2.9.2:
+graphql-tag@^2.10.0, graphql-tag@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"
   integrity sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==
@@ -5615,7 +5615,7 @@ graphql-tools@^4.0.0:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^14.0.0:
+graphql@^14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
   integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
@@ -9897,7 +9897,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@^2.1.9:
+react-apollo@^2.2.3:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.3.2.tgz#b8e287d2813722b9e0a886cabf8149ab3b84a3b7"
   integrity sha512-3lU9iqmj4KMIZvlWWSuLihxMGLEAL6oNmnSTWrb3/mRP36Zy0zJD4rdaonDx4WzqFYQAnUPaOiFnHGp0UQUTwA==


### PR DESCRIPTION
A couple of Hops packages have incorrect dependency versions in their
package.json files and some packages are missing required peer
dependencies.

This PR adds missing peer dependencies and increases the minimum
required versions of other dependencies to remove all peer dependency
warnings in Hops.