### PR TITLE
fix(create-hops-app): use user-defined version range

### DIFF
--- a/packages/create-hops-app/lib/package-manager.js
+++ b/packages/create-hops-app/lib/package-manager.js
@@ -36,8 +36,7 @@ function installPackages(packages, type, options) {
   var command = null;
 
   if (isYarnAvailable() && !options.npm) {
-    command =
-      packages.length === 0 ? ['yarn', 'install'] : ['yarn', 'add', '--exact'];
+    command = packages.length === 0 ? ['yarn', 'install'] : ['yarn', 'add'];
     if (type === 'dev') {
       command.push('--dev');
     }
@@ -45,12 +44,7 @@ function installPackages(packages, type, options) {
     command =
       packages.length === 0
         ? ['npm', 'install']
-        : [
-            'npm',
-            'install',
-            type === 'dev' ? '--save-dev' : '--save',
-            '--save-exact',
-          ];
+        : ['npm', 'install', type === 'dev' ? '--save-dev' : '--save'];
   }
   if (options.verbose) {
     command.push('--verbose');


### PR DESCRIPTION
...when installing the Hops base package. I thought about make it configurable via CLI, but I guess there's no real need for that.