### PR TITLE
fix(development-proxy): Use NODE_ENV instead of mode to determine if proxy should run

### DIFF
--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -8,10 +8,10 @@ const {
 const proxy = require('http-proxy-middleware');
 
 class ProxyMixin extends Mixin {
-  configureServer(app, middlewares, mode) {
+  configureServer(app, middlewares) {
     const proxyConfig = this.config.proxy;
 
-    if (mode !== 'develop' || !proxyConfig) {
+    if (process.env.NODE_ENV === 'production' || !proxyConfig) {
       return;
     }
 


### PR DESCRIPTION
This is also how the graphql mock server determines if it should be used
