### PR TITLE
fix(jest-preset): allow to use ?global for css imports

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -5,7 +5,7 @@ module.exports = {
     '^.+\\.(png|gif|jpe?g|webp|html|svg|((o|t)tf)|woff2?|ico)$':
       'jest-preset-hops/mocks/file.js',
     '^.+\\.tpl$': 'jest-preset-hops/mocks/tpl.js',
-    '^.+\\.css$': 'identity-obj-proxy',
+    '^.+\\.css(\\?global)?$': 'identity-obj-proxy',
     '^hops$': 'hops/lib/runtime.js',
   },
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'ts', 'tsx'],

--- a/packages/spec/integration/jest-preset/__tests__/preset.js
+++ b/packages/spec/integration/jest-preset/__tests__/preset.js
@@ -13,4 +13,14 @@ describe('jest-preset', () => {
     const hops = require('hops');
     expect(hops.render).toBeDefined();
   });
+
+  it('allows to import global css inside a js module', () => {
+    // if it does not throw it appears to work
+    require('./setup/global-css');
+  });
+
+  it('allows to import local css inside a js module', () => {
+    const css = require('./setup/local-css');
+    expect(css.default.foo).toBe('foo');
+  });
 });

--- a/packages/spec/integration/jest-preset/__tests__/setup/global-css.js
+++ b/packages/spec/integration/jest-preset/__tests__/setup/global-css.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
+import './syle.css?global';

--- a/packages/spec/integration/jest-preset/__tests__/setup/local-css.js
+++ b/packages/spec/integration/jest-preset/__tests__/setup/local-css.js
@@ -1,0 +1,3 @@
+import style from './style.css';
+
+export default style;

--- a/packages/spec/integration/jest-preset/__tests__/setup/style.css
+++ b/packages/spec/integration/jest-preset/__tests__/setup/style.css
@@ -1,0 +1,3 @@
+.foo {
+  color: blue;
+}


### PR DESCRIPTION
It currently fails with `Cannot find module './yostyle.css?global'` when running tests that require js modules that import css files with `?global`.