### PR TITLE
Proxy improvements

### DIFF
--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -15,7 +15,9 @@ class ProxyMixin extends Mixin {
       return;
     }
 
-    const hooks = {
+    const options = {
+      changeOrigin: true,
+      logLevel: 'warn',
       onProxyReq: this.onProxyReq,
       onProxyRes: this.onProxyRes,
       onError: this.onProxyError,
@@ -31,14 +33,10 @@ class ProxyMixin extends Mixin {
               req.headers.accept && !req.headers.accept.includes('text/html')
             );
           },
-          Object.assign(
-            {
-              target: proxyConfig,
-              changeOrigin: true,
-              logLevel: 'warn',
-            },
-            hooks
-          )
+          {
+            ...options,
+            target: proxyConfig,
+          }
         )
       );
     }
@@ -48,17 +46,10 @@ class ProxyMixin extends Mixin {
 
       Object.entries(proxyConfig).forEach(([path, { target }]) => {
         middlewares.initial.push(
-          proxy(
-            path,
-            Object.assign(
-              {
-                changeOrigin: true,
-                logLevel: 'warn',
-                target,
-              },
-              hooks
-            )
-          )
+          proxy(path, {
+            ...options,
+            target,
+          })
         );
       });
     }

--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -7,6 +7,8 @@ const {
 } = require('hops-mixin');
 const proxy = require('http-proxy-middleware');
 
+const checkUrl = url => /^https?:\/\//.test(url);
+
 class ProxyMixin extends Mixin {
   configureServer(app, middlewares) {
     const proxyConfig = this.config.proxy;
@@ -24,13 +26,15 @@ class ProxyMixin extends Mixin {
     };
 
     if (typeof proxyConfig === 'string') {
-      if (proxyConfig === '') {
-        console.warn('The proxy target is empty, disabling feature');
+      if (!checkUrl(proxyConfig)) {
+        console.warn(
+          `The proxy target '${proxyConfig}' is invalid, disabling feature`
+        );
 
         return;
       }
 
-      debug('Using proxy string version: ', proxyConfig);
+      debug('Using proxy string version', proxyConfig);
 
       middlewares.initial.push(
         proxy(
@@ -55,7 +59,10 @@ class ProxyMixin extends Mixin {
           typeof config === 'string' ? { target: config } : config;
 
         if (target === '') {
-          console.warn('The proxy target is empty, ignoring path', path);
+          console.warn(
+            `The proxy target '${target}' is invalid, ignoring path`,
+            path
+          );
 
           return;
         }

--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -24,6 +24,12 @@ class ProxyMixin extends Mixin {
     };
 
     if (typeof proxyConfig === 'string') {
+      if (proxyConfig === '') {
+        console.warn('The proxy target is empty, disabling feature');
+
+        return;
+      }
+
       debug('Using proxy string version: ', proxyConfig);
 
       middlewares.initial.push(
@@ -47,6 +53,12 @@ class ProxyMixin extends Mixin {
       Object.entries(proxyConfig).forEach(([path, config]) => {
         const { target, routes } =
           typeof config === 'string' ? { target: config } : config;
+
+        if (target === '') {
+          console.warn('The proxy target is empty, ignoring path', path);
+
+          return;
+        }
 
         middlewares.initial.push(
           proxy(path, {

--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -44,11 +44,15 @@ class ProxyMixin extends Mixin {
     if (typeof proxyConfig === 'object') {
       debug('Using proxy object version', proxyConfig);
 
-      Object.entries(proxyConfig).forEach(([path, { target }]) => {
+      Object.entries(proxyConfig).forEach(([path, config]) => {
+        const { target, routes } =
+          typeof config === 'string' ? { target: config } : config;
+
         middlewares.initial.push(
           proxy(path, {
             ...options,
             target,
+            routes,
           })
         );
       });

--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -39,9 +39,11 @@ class ProxyMixin extends Mixin {
       middlewares.initial.push(
         proxy(
           (pathName, req) => {
-            return (
-              req.headers.accept && !req.headers.accept.includes('text/html')
-            );
+            const nonhtml =
+              req.headers.accept && !req.headers.accept.includes('text/html');
+            const xhr = req.headers['x-requested-with'] === 'XMLHttpRequest';
+
+            return nonhtml || xhr;
           },
           {
             ...options,


### PR DESCRIPTION
## Changes introduced here

There is now a new way to configure the proxy: `proxy: { '/foo': 'target' }`
And it is also possible now to have an empty proxy target. This allows something like `proxy: '[PROXY_URL]'` to work even when the `PROXY_URL` env is not defined. But it produces a warning though.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
