### PR TITLE
chore: only run prettier check in precommit hook without writing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,10 @@
   },
   "lint-staged": {
     "*.{js,json,css}": [
-      "prettier --write",
-      "git add"
+      "prettier --list-different"
     ],
     "**/README.md": [
-      "prettier --write",
-      "git add"
+      "prettier --list-different"
     ]
   },
   "prettier": {


### PR DESCRIPTION
Running prettier and adding the file, will add the entire file
thus making patch-adding impossible

This can lead to unexpected and potentially broken commits.