### PR TITLE
chore(hops-graphql): improve error message

### DIFF
--- a/packages/graphql/schema.js
+++ b/packages/graphql/schema.js
@@ -1,3 +1,3 @@
 throw new Error(
-  'This file should never be used directly. Did you forget to configure "config.graphqlMockSchemaFile"?'
+  'Please use an absolute path for setting "config.graphqlMockSchemaFile", like e.g. "<rootDir>/schema.js".'
 );


### PR DESCRIPTION
The former error message was imho a little misleading, since there's only one way the `hops-graphql/schema.js` gets loaded: when the user names their schema file `schema.js`, too, and configures it by using a relative path. In this case the module resolving erroneously ends up at `hops-graphql/schema.js`. Then again telling the user they should not load this file directly is really confusing.

Did I miss a possible scenario?