### PR TITLE
fix: babel ts-loader output

### DIFF
--- a/packages/spec/integration/typescript/__tests__/develop.js
+++ b/packages/spec/integration/typescript/__tests__/develop.js
@@ -1,4 +1,4 @@
-describe('typescript developmet server', () => {
+describe('typescript development server', () => {
   let url;
 
   beforeAll(async () => {
@@ -9,6 +9,14 @@ describe('typescript developmet server', () => {
     const { page } = await createPage();
     await page.goto(url);
     expect(await page.content()).toMatch('<h1>test</h1>');
+
+    await page.close();
+  });
+
+  it('supports code-splitting', async () => {
+    const { page } = await createPage();
+    await page.goto(url);
+    expect(await page.content()).toMatch('<p>lorem ipsum.</p>');
 
     await page.close();
   });

--- a/packages/spec/integration/typescript/content.tsx
+++ b/packages/spec/integration/typescript/content.tsx
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export default () => <p>lorem ipsum.</p>;

--- a/packages/spec/integration/typescript/headline.js
+++ b/packages/spec/integration/typescript/headline.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Headline = () => <h1>test</h1>;
+
+export default Headline;

--- a/packages/spec/integration/typescript/index.tsx
+++ b/packages/spec/integration/typescript/index.tsx
@@ -1,11 +1,13 @@
 import { render, importComponent } from 'hops';
 import * as React from 'react';
 
+import Headline from './headline';
+
 const Content = importComponent('./content');
 
 export default render(
   <>
-    <h1>test</h1>
+    <Headline />
     <Content />
   </>
 );

--- a/packages/spec/integration/typescript/index.tsx
+++ b/packages/spec/integration/typescript/index.tsx
@@ -1,4 +1,11 @@
-import { render } from 'hops';
+import { render, importComponent } from 'hops';
 import * as React from 'react';
 
-export default render(<h1>test</h1>);
+const Content = importComponent('./content');
+
+export default render(
+  <>
+    <h1>test</h1>
+    <Content />
+  </>
+);

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -2,7 +2,7 @@ const { Mixin } = require('hops-mixin');
 
 class TypescriptMixin extends Mixin {
   configureBuild(webpackConfig, { jsLoaderConfig }) {
-    jsLoaderConfig.test.push(/\.tsx?$/);
+    jsLoaderConfig.test = [/\.tsx?$/];
     jsLoaderConfig.use = [
       {
         loader: jsLoaderConfig.loader,

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -1,13 +1,21 @@
 const { Mixin } = require('hops-mixin');
 
 class TypescriptMixin extends Mixin {
-  configureBuild(webpackConfig, { allLoaderConfigs }) {
-    webpackConfig.resolve.extensions.unshift('.ts', '.tsx');
+  configureBuild(webpackConfig, { jsLoaderConfig }) {
+    jsLoaderConfig.test.push(/\.tsx?$/);
+    jsLoaderConfig.use = [
+      {
+        loader: jsLoaderConfig.loader,
+        options: { ...jsLoaderConfig.options },
+      },
+      {
+        loader: require.resolve('ts-loader'),
+      },
+    ];
+    delete jsLoaderConfig.loader;
+    delete jsLoaderConfig.options;
 
-    allLoaderConfigs.unshift({
-      test: /\.tsx?$/,
-      use: [{ loader: require.resolve('ts-loader') }],
-    });
+    webpackConfig.resolve.extensions.push('.ts', '.tsx');
   }
 }
 

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -1,20 +1,22 @@
 const { Mixin } = require('hops-mixin');
 
 class TypescriptMixin extends Mixin {
-  configureBuild(webpackConfig, { jsLoaderConfig }) {
-    jsLoaderConfig.test = [/\.tsx?$/];
-    jsLoaderConfig.use = [
-      {
-        loader: jsLoaderConfig.loader,
-        options: { ...jsLoaderConfig.options },
-      },
-      {
-        loader: require.resolve('ts-loader'),
-      },
-    ];
-    delete jsLoaderConfig.loader;
-    delete jsLoaderConfig.options;
+  configureBuild(webpackConfig, { jsLoaderConfig, allLoaderConfigs }) {
+    const { loader, options, exclude } = jsLoaderConfig;
 
+    allLoaderConfigs.unshift({
+      test: /\.tsx?$/,
+      exclude,
+      use: [
+        {
+          loader,
+          options,
+        },
+        {
+          loader: require.resolve('ts-loader'),
+        },
+      ],
+    });
     webpackConfig.resolve.extensions.push('.ts', '.tsx');
   }
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react",
     "sourceMap": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true
   }
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -6,7 +6,6 @@
     "jsx": "react",
     "sourceMap": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "allowJs": true
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
This fixes two issues related to the current setup of hops-typescript:

 - compiled Typescript code is not processed by `babel-polyfill`
 - code-splitting with the `importComponent` function does not work in Typescript

refs #765 