### PR TITLE
feat(jest-preset-hops): enable *.tsx test files

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -9,6 +9,11 @@ module.exports = {
     '^hops$': 'hops/lib/runtime.js',
   },
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'ts', 'tsx'],
+  testMatch: [
+    ...defaults.testMatch,
+    '**/__tests__/**/*.ts?(x)',
+    '**/?(*.)+(spec|test).ts?(x)',
+  ],
   transform: {
     '^.+\\.(js|jsx|mjs)$': 'jest-preset-hops/transforms/babel.js',
     '^.+\\.(ts|tsx)$': 'ts-jest',

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@types/jest": "^23.3.12",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "babel-plugin-dynamic-import-node": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,6 +1452,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/jest@^23.3.12":
+  version "23.3.12"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.12.tgz#7e0ced251fa94c3bc2d1023d4b84b2992fa06376"
+  integrity sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q==
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"


### PR DESCRIPTION
This PR introduces the ability to `jest-preset-hops` to run tests written in `*.tsx?`. Currently Jest only runs tests written in Javascript (while it's already possible to import `*.tsx?`-modules into tests).

For the Typescript compiler to know what all those `describe()`, `it()`, etc. "gibberish" is all about, `@types/jest` is included as a dependency.

PS: with Jest v24 comes Typescript support out of the box. I guess all the changes of this PR will then be obsolete.