### PR TITLE
fix: use default browser matrix in templates

### DIFF
--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -4,9 +4,6 @@
   "main": "src/app.js",
   "license": "MIT",
   "hops": {
-    "browsers": [
-      "last 1 Chrome versions"
-    ],
     "locations": [
       "/"
     ],

--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -4,9 +4,6 @@
   "main": "src/app.js",
   "license": "MIT",
   "hops": {
-    "browsers": [
-      "last 1 Chrome versions"
-    ],
     "locations": [
       "/",
       "/counter"

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -4,9 +4,6 @@
   "main": "src/app.js",
   "license": "MIT",
   "hops": {
-    "browsers": [
-      "last 1 Chrome versions"
-    ],
     "locations": [
       "/",
       "/counter"


### PR DESCRIPTION
…for `@babel/preset-env`. This fixes insufficient transpiling/polyfilling of the build artifact, that users might actually not be aware of.