### PR TITLE
fix(create-hops-app): remove superfluous hops-version option

### DIFF
--- a/packages/create-hops-app/index.js
+++ b/packages/create-hops-app/index.js
@@ -18,11 +18,6 @@ const options = yargs
       'a different template',
     default: 'hops-template-react',
   })
-  .option('hops-version', {
-    type: 'string',
-    describe: 'Which version (or npm dist-tag) of hops to use',
-    default: 'latest',
-  })
   .option('verbose', {
     type: 'boolean',
     describe: 'Increase verbosity of command',

--- a/packages/create-hops-app/lib/create-app.js
+++ b/packages/create-hops-app/lib/create-app.js
@@ -3,8 +3,6 @@ const path = require('path');
 const validatePackageName = require('validate-npm-package-name');
 const { sync: writePkg } = require('write-pkg');
 
-const pm = require('./package-manager');
-
 function validateName(name) {
   const validationResult = validatePackageName(name);
   if (!validationResult.validForNewPackages) {
@@ -53,6 +51,5 @@ module.exports = function init(options, root) {
     private: true,
   });
   process.chdir(appDir);
-  pm.installPackages(['hops@' + options.hopsVersion], 'prod', options);
   require('./init').init(root, name, options);
 };

--- a/packages/create-hops-app/lib/create-app.js
+++ b/packages/create-hops-app/lib/create-app.js
@@ -50,6 +50,7 @@ module.exports = function init(options, root) {
     version: '1.0.0',
     private: true,
   });
+
   process.chdir(appDir);
   require('./init').init(root, name, options);
 };

--- a/packages/create-hops-app/lib/init.js
+++ b/packages/create-hops-app/lib/init.js
@@ -69,7 +69,6 @@ function init(root, appName, options) {
   const pathToPackageManifest = path.resolve(appRoot, 'package.json');
   const oldPackageManifest = readPkg(pathToPackageManifest);
   let tarball = null;
-  options.npm = options.npm || !pm.hasBeenInstalledViaYarn(appRoot);
 
   if (template) {
     tarball = pm.getTarball(template, options);
@@ -104,13 +103,13 @@ function init(root, appName, options) {
         console.log('Your project has been successfully created.');
         console.log(
           `You should \`cd ${appName}\` to change into its directory and execute`,
-          '`' + (pm.hasBeenInstalledViaYarn(appRoot) ? 'yarn' : 'npm'),
+          '`' + (pm.hasBeenInstalledViaYarn(options) ? 'yarn' : 'npm'),
           'start`',
           'to fire up a development server with hot module reloading.'
         );
         console.log(
           'To see a list of available commands through Hops presets execute:',
-          pm.hasBeenInstalledViaYarn(appRoot) ? '`yarn hops`' : '`npx hops`'
+          pm.hasBeenInstalledViaYarn(options) ? '`yarn hops`' : '`npx hops`'
         );
       })
       .catch(error => {

--- a/packages/create-hops-app/lib/package-manager.js
+++ b/packages/create-hops-app/lib/package-manager.js
@@ -1,7 +1,4 @@
 'use strict';
-
-var fs = require('fs');
-var path = require('path');
 var execSync = require('child_process').execSync;
 
 function execIgnoreStdError(command, options) {
@@ -27,15 +24,15 @@ function isYarnAvailable() {
 }
 module.exports.isYarnAvailable = isYarnAvailable;
 
-function hasBeenInstalledViaYarn(projectPath) {
-  return fs.existsSync(path.join(projectPath, 'yarn.lock'));
+function hasBeenInstalledViaYarn(options) {
+  return isYarnAvailable() && !options.npm;
 }
 module.exports.hasBeenInstalledViaYarn = hasBeenInstalledViaYarn;
 
 function installPackages(packages, type, options) {
   var command = null;
 
-  if (isYarnAvailable() && !options.npm) {
+  if (hasBeenInstalledViaYarn(options)) {
     command = packages.length === 0 ? ['yarn', 'install'] : ['yarn', 'add'];
     if (type === 'dev') {
       command.push('--dev');

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -14,11 +14,7 @@ describe('create-hops-app', () => {
 
   it('initializes a Hops app with yarn', () => {
     const name = 'my-app-yarn';
-    const args = [
-      name,
-      `--hops-version ${version}`,
-      `--template ${template}@${version}`,
-    ].join(' ');
+    const args = [name, `--template ${template}@${version}`].join(' ');
 
     execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 
@@ -30,12 +26,7 @@ describe('create-hops-app', () => {
 
   it('initializes a Hops app with npm', () => {
     const name = 'my-app-npm';
-    const args = [
-      name,
-      `--hops-version ${version}`,
-      `--template ${template}@${version}`,
-      `--npm`,
-    ].join(' ');
+    const args = [name, `--template ${template}@${version}`, `--npm`].join(' ');
 
     execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 


### PR DESCRIPTION
I'm not sure if I'm missing something here, but I think by moving the bootstrap code into the `create-hops-app` package, we made `hops-version` obsolete.

The package is indeed installed, but as far as I can see never used. 
Installing the package also causes the peerDependency warnings described in #783  

You can still choose the hops version by running 

```
npx create-hops-app@myversion --template hops-template-react@myversion my-app
```