### PR TITLE
Simplify `fetchData`

### DIFF
--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -91,16 +91,7 @@ class GraphQLMixin extends Mixin {
   }
 
   fetchData(data = {}, element) {
-    return this.prefetchData(element).then(() => {
-      return {
-        ...data,
-        globals: {
-          ...(data.globals || {}),
-          APOLLO_FRAGMENT_TYPES: introspectionResult,
-          APOLLO_STATE: this.getApolloClient().cache.extract(),
-        },
-      };
-    });
+    return this.prefetchData(element).then(() => data);
   }
 
   prefetchData(element) {
@@ -120,7 +111,8 @@ class GraphQLMixin extends Mixin {
       ...data,
       globals: {
         ...data.globals,
-        ...(data.fetchedData || {}).globals,
+        APOLLO_FRAGMENT_TYPES: introspectionResult,
+        APOLLO_STATE: this.getApolloClient().cache.extract(),
       },
     };
   }

--- a/packages/redux/action-creator-dispatcher/mixin.server.js
+++ b/packages/redux/action-creator-dispatcher/mixin.server.js
@@ -25,22 +25,11 @@ class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
   }
 
   async fetchData(data) {
-    const _hopsPrefetchedOnServer = this.canPrefetchOnServer().every(
-      value => value
-    );
-
-    if (_hopsPrefetchedOnServer) {
+    if (this.canPrefetchOnServer().every(value => value)) {
       await this.dispatchAll(createLocation(this.request.path));
       this.prefetchedOnServer = true;
     }
-
-    return {
-      ...data,
-      globals: {
-        ...data.globals,
-        _hopsPrefetchedOnServer,
-      },
-    };
+    return data;
   }
 
   getTemplateData(data) {
@@ -48,7 +37,7 @@ class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
       ...data,
       globals: {
         ...data.globals,
-        ...(data.fetchedData || {}).globals,
+        _hopsPrefetchedOnServer: this.prefetchedOnServer,
       },
     };
   }


### PR DESCRIPTION
This PR follows up on the discussion in https://github.com/untool/untool/pull/261.

## Current state

We currently rely on the `fetchedData` property of the object passed to the `getTemplateData` hook to pass data between mixinstance methods. This appears to be rather indirect and brittle.

## Changes introduced here

In this PR, I proposed removing that indirection and instead rely on instance props (or module scoped variables).

## Outlook

At some point down the road (`untool` v2) we might want to look into getting rid of the `data` argument of `fetchData` altogether since it does not appear all that useful any longer...

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [X] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] ~Necessary unit tests are added in order to ensure correct behavior~
- [ ] ~Documentation has been added~