### PR TITLE
chore: move jest dependency to root manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.9.1",
     "husky": "^1.0.0",
+    "jest": "^23.4.2",
     "lerna": "^3.0.3",
     "lint-staged": "^8.0.0",
     "prettier": "^1.14.0"

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -28,7 +28,6 @@
     "create-hops-app": "^11.2.0-rc.1",
     "cross-fetch": "^3.0.0",
     "fs-extra": "^7.0.0",
-    "jest": "^23.4.2",
     "jest-environment-node": "^23.4.0",
     "mktemp": "^0.4.0",
     "puppeteer": "^1.11.0",


### PR DESCRIPTION
because the cli is being run from the workspace root rather than from
inside the spec/ folder.