### PR TITLE
test(spec): include tsconfig directly to stabilize tests

### DIFF
--- a/packages/spec/integration/jest-preset/tsconfig.json
+++ b/packages/spec/integration/jest-preset/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../../../node_modules/hops-typescript/tsconfig.json"
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
 }

--- a/packages/spec/integration/typescript/tsconfig.json
+++ b/packages/spec/integration/typescript/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../../../node_modules/hops-typescript/tsconfig.json"
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
 }


### PR DESCRIPTION
Until now we used to extend the tsconfig.json that is shipped with
hops-typescript from inside our integration tests.
This resulted in having to use brittle relative paths inside the
integration tests and will break for example when we use Hops inside
our citgm tool.