### PR TITLE
fix(graphql): add react-dom as peer dependency for react-apollo

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -35,11 +35,13 @@
   "peerDependencies": {
     "graphql-tag": "^2.10.0",
     "react": "^16.4.0",
+    "react-dom": "^16.4.0",
     "react-apollo": "^2.2.3"
   },
   "devDependencies": {
     "graphql-tag": "^2.10.0",
     "react": "^16.4.2",
+    "react-dom": "^16.4.2",
     "react-apollo": "^2.2.3"
   }
 }


### PR DESCRIPTION
`warning "workspace-aggregator-4739a636-8576-4a88-9914-8301a646242a > hops-graphql > react-apollo@2.4.1" has unmet peer dependency "react-dom@^15.0.0 || ^16.0.0".`