### PR TITLE
docs: add proper home page urls

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,5 +19,6 @@
   "dependencies": {
     "@untool/core": "^1.0.0",
     "@untool/webpack": "^1.0.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/config#readme"
 }

--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -25,5 +25,7 @@
     "validate-npm-package-name": "^3.0.0",
     "write-pkg": "^3.2.0",
     "yargs": "^13.0.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/create-hops-app#readme"
+
 }

--- a/packages/development-proxy/package.json
+++ b/packages/development-proxy/package.json
@@ -17,5 +17,7 @@
     "debug": "^4.0.0",
     "hops-mixin": "^11.2.0",
     "http-proxy-middleware": "^0.19.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/development-proxy#readme"
+
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -19,5 +19,7 @@
   "dependencies": {
     "compression": "^1.7.3",
     "hops-mixin": "^11.2.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/express#readme"
+
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -43,5 +43,7 @@
     "react": "^16.4.2",
     "react-apollo": "^2.2.3",
     "react-dom": "^16.4.2"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/graphql#readme"
+
 }

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -40,5 +40,6 @@
   },
   "devDependencies": {
     "jest": "^23.4.2"
-  }
-}
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/jest-preset#readme"
+} 

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -31,5 +31,6 @@
     "semver": "^5.5.0",
     "serverless-http": "^1.6.0",
     "strip-indent": "^2.0.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/lambda#readme"
 }

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -20,5 +20,6 @@
   "dependencies": {
     "@untool/core": "^1.0.0",
     "mixinable": "^4.0.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/mixin#readme"
 }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -28,5 +28,6 @@
     "postcss-preset-env": "^6.0.0",
     "style-loader": "^0.23.0",
     "webpack": "^4.23.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/postcss#readme"
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -27,5 +27,6 @@
     "pathifist": "^1.0.0",
     "webpack": "^4.23.0",
     "webpack-sources": "^1.1.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/pwa#readme"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,5 +36,6 @@
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/react#readme"
 }

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -37,5 +37,6 @@
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/redux#readme"
 }

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -29,5 +29,6 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.0",
     "styled-components": "^4.0.0"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/styled-components#readme"
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -18,5 +18,6 @@
     "hops-mixin": "^11.2.0",
     "ts-loader": "^5.0.0",
     "typescript": "^3.2.1"
-  }
+  },
+  "homepage": "https://github.com/xing/hops/tree/master/packages/typescript#readme"
 }


### PR DESCRIPTION
Add homepage field for each package so that `npm docs hops-package` will
lead to the the appropriate readme instead of the main entry.

I deliberately omitted `hops`, because I think the main readme makes sense their.
The templates are used as, well, templates so I did not think adding our repo as homepage makes sense there either.
