### PR TITLE
feat: add typescript typings for runtime API and options

### DIFF
--- a/packages/graphql/index.d.ts
+++ b/packages/graphql/index.d.ts
@@ -1,0 +1,16 @@
+import { ApolloClientOptions } from 'apollo-client';
+import { ApolloLink } from 'apollo-link';
+import { ApolloCache } from 'apollo-cache';
+import { Omit } from 'hops';
+
+declare module 'hops-graphql' {
+  interface ApolloClientOptionsHops<TCacheShape>
+    extends Omit<Omit<ApolloClientOptions<TCacheShape>, 'link'>, 'cache'> {
+    link?: ApolloLink;
+    cache?: ApolloCache<TCacheShape>;
+  }
+
+  export interface HopsGraphqlOptions<TCacheShape = any> {
+    graphql?: ApolloClientOptionsHops<TCacheShape>;
+  }
+}

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -13,6 +13,7 @@
   "engines": {
     "node": ">=8.10.0"
   },
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/xing/hops.git"

--- a/packages/hops/lib/runtime.d.ts
+++ b/packages/hops/lib/runtime.d.ts
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { BrowserRouterProps } from 'react-router-dom';
+
+declare module 'hops' {
+  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+  export class Miss extends React.Component {}
+
+  export interface StatusProps {
+    code: number;
+  }
+  export class Status extends React.Component<StatusProps> {}
+
+  export interface HeaderProps {
+    name: string;
+    value: string;
+  }
+
+  export class Header extends React.Component<HeaderProps> {}
+
+  export interface ImportComponentRenderOptions<Props> {
+    Component: React.ComponentType<Props>;
+    error: boolean;
+    loading: boolean;
+  }
+
+  export interface ImportComponentOptions<Props> {
+    loader?: (load: Promise<any>) => Promise<any>;
+    render?: (
+      options: ImportComponentRenderOptions<Props> & Props
+    ) => React.ReactNode;
+  }
+
+  export function importComponent<Props>(
+    load: () => Promise<{ default: React.ComponentType<Props> }>
+  ): React.ComponentType<ImportComponentOptions<Props> & Props>;
+
+  export function importComponent<Props, Exports>(
+    load: () => Promise<Exports>,
+    resolver: (exports: Exports) => React.ComponentType<Props>
+  ): React.ComponentType<ImportComponentOptions<Props> & Props>;
+
+  export function importComponent<Props>(
+    module: string,
+    exportName?: string
+  ): React.ComponentType<ImportComponentOptions<Props>>;
+
+  export interface ServerData {
+    [key: string]: any;
+  }
+
+  export interface Config {
+    [key: string]: any;
+  }
+
+  export const ServerDataContext: React.Context<ServerData>;
+
+  export const ConfigContext: React.Context<Config>;
+
+  export function withServerData<
+    P extends { serverData: C },
+    C = ServerData,
+    R = Omit<P, 'serverData'>
+  >(Component: React.ComponentType<P>): React.ComponentType<R>;
+
+  export function withConfig<
+    P extends { config: C },
+    C = Config,
+    R = Omit<P, 'config'>
+  >(Component: React.ComponentType<P>): React.ComponentType<R>;
+
+  export class Mixin {}
+
+  export const strategies: any;
+
+  export interface HopsOptions {
+    router?: BrowserRouterProps;
+  }
+
+  export function render<Options = { [key: string]: any }, P = {}>(
+    reactElement: React.ReactElement<P>,
+    options?: Options & HopsOptions
+  ): void;
+}

--- a/packages/hops/package.json
+++ b/packages/hops/package.json
@@ -21,6 +21,7 @@
   "main": "lib/core.js",
   "browser": "lib/runtime.js",
   "server": "lib/runtime.js",
+  "types": "lib/runtime.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/xing/hops.git"
@@ -41,6 +42,8 @@
     "react-router-dom": "^4.3.1"
   },
   "devDependencies": {
+    "@types/react": "*",
+    "@types/react-router-dom": "*",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",

--- a/packages/pwa/index.d.ts
+++ b/packages/pwa/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'hops-pwa' {
+  function installServiceWorker(): Promise<ServiceWorkerRegistration>;
+
+  export default installServiceWorker;
+}

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -14,6 +14,7 @@
   },
   "main": "node.js",
   "browser": "dom.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/xing/hops.git"

--- a/packages/redux/index.d.ts
+++ b/packages/redux/index.d.ts
@@ -1,0 +1,20 @@
+import { Middleware, ReducersMapObject, Action as ActionCreator } from 'redux';
+import { ThunkAction } from 'redux-thunk';
+
+declare module 'hops-redux' {
+  interface HopsReduxActionCreator {
+    action: ActionCreator | ThunkAction<any, any, any, any>;
+    path: string;
+    exact?: boolean;
+    strict?: boolean;
+  }
+
+  export interface HopsReduxOptions {
+    redux: {
+      reducers: ReducersMapObject;
+      middlewares?: Middleware[];
+      actionCreators?: HopsReduxActionCreator[];
+      alwaysDispatchActionsOnClient?: boolean;
+    };
+  }
+}

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -15,6 +15,7 @@
   },
   "main": "index.js",
   "esnext": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/xing/hops.git"

--- a/packages/styled-components/index.d.ts
+++ b/packages/styled-components/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'hops-styled-components' {
+  export interface HopsStyledComponentsOptions<
+    T extends object = {},
+    U extends object = T
+  > {
+    styled?: {
+      theme?: T | ((theme: U) => T);
+    };
+  }
+}

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -12,6 +12,7 @@
   "engines": {
     "node": ">=8.10.0"
   },
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/xing/hops.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,6 +1546,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/history@*":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
 "@types/jest@^23.3.12":
   version "23.3.14"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
@@ -1571,6 +1576,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.27.tgz#eb3843f15d0ba0986cc7e4d734d2ee8b50709ef8"
   integrity sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg==
 
+"@types/prop-types@*":
+  version "15.5.9"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.9.tgz#f2d14df87b0739041bc53a7d75e3d77d726a3ec0"
+  integrity sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ==
+
 "@types/q@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
@@ -1580,6 +1590,31 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/react-router-dom@*":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.1.tgz#71fe2918f8f60474a891520def40a63997dafe04"
+  integrity sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.4.tgz#4dbd5588ea6024e0c04519bd8aabe74c0a2b77e5"
+  integrity sha512-TZVfpT6nvUv/lbho/nRtckEtgkhspOQr3qxrnpXixwgQRKKyg5PvDfNKc8Uend/p/Pi70614VCmC0NPAKWF+0g==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.5.tgz#03b9a6597bc20f6eaaed43f377a160f7e41c2b90"
+  integrity sha512-8LRySaaSJVLNZb2dbOGvGmzn88cbAfrgDpuWy+6lLgQ0OJFgHHvyuaCX4/7ikqJlpmCPf4uazJAZcfTQRdJqdQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/serve-static@*":
   version "1.13.2"
@@ -3991,6 +4026,11 @@ cssstyle@^1.0.0:
   integrity sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.2.tgz#3043d5e065454579afc7478a18de41909c8a2f01"
+  integrity sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This commit adds TypeScript typings for runtime API in `hops` and
`hops-pwa` packages.


This pull request closes issue #360