### PR TITLE
Update code examples and documentation for `importComponent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ export default () => <p>This has been loaded lazily</p>;
 import { render, importComponent } from 'hops';
 import React from 'react';
 
-const MyLazyComponent = importComponent('./my-component');
+const MyLazyComponent = importComponent(() => import('./my-component'));
 
 export default render(
   <div>
@@ -471,7 +471,7 @@ import React from 'react';
 export default render(<Header name="X-Foo" value="my-value" />);
 ```
 
-###### `importComponent(module, [exportName])`
+###### `importComponent(moduleLoader, [exportResolver = (ns) => ns.default])`
 
 Using the `importComponent()` function you can asynchronously load modules as React components into your application to help you reduce bundle sizes.
 
@@ -480,7 +480,20 @@ It works similarly to [`react-loadable`](https://github.com/jamiebuilds/react-lo
 ```javascript
 import { render, importComponent } from 'hops';
 
-const Home = importComponent('./home');
+const Home = importComponent(() => import('./home'));
+
+export default render(<Home />);
+```
+
+In case you have a file that exports named components, you can use the second argument to `importComponent` to control which export should be used:
+
+```javascript
+import { render, importComponent } from 'hops';
+
+const Home = importComponent(
+  () => import('./home'),
+  namespace => namespace.Home
+);
 
 export default render(<Home />);
 ```
@@ -490,7 +503,7 @@ Components created using `importComponent` support some additional props to cont
 ```javascript
 import { render, importComponent } from 'hops';
 
-const About = importComponent('./about');
+const About = importComponent(() => import('./about'));
 
 const loader = load =>
   Promise.race([
@@ -514,6 +527,16 @@ export default render(<About loader={loader} render={renderAbout} />);
 ```
 
 Components (and their dependencies) imported using `importComponent` will be placed into separate chunks (i.e. asset files). Hops makes sure that all asset files containing modules used for server-side rendering are referenced in the initial HTML output.
+
+**Note about `importComponent(moduleName, [exportName])`:** We still support the "string" syntax, where you could just pass a string for the file name and another string for the export name to the `importComponent` function, but we are discouraging the use of it, because it is not compatible with type-checked code and does not provide editor integration (point & click to open the file).
+
+```javascript
+import { render, importComponent } from 'hops';
+
+const Home = importComponent('./home', 'Home');
+
+export default render(<Home />);
+```
 
 ###### `withConfig(Component)`
 

--- a/packages/spec/integration/react/index.js
+++ b/packages/spec/integration/react/index.js
@@ -12,7 +12,7 @@ import {
 import React from 'react';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
 import FlowText from './flow-text';
-const Text = importComponent('./text');
+const Text = importComponent(() => import('./text'));
 
 const Config = withConfig(({ config: { hoc } }) => <h1>{hoc}</h1>);
 

--- a/packages/spec/integration/typescript/index.tsx
+++ b/packages/spec/integration/typescript/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import Headline from './headline';
 
-const Content = importComponent('./content');
+const Content = importComponent(() => import('./content'));
 
 export default render(
   <>


### PR DESCRIPTION
After [these changes](https://github.com/untool/untool/pull/271) were
released in untool, we can now optionally use arrow-functions as
arguments to `importComponent` which makes it a bit more user-friendly
by having additional editor support and support for type-checking.

This PR updates the usage examples and documentation to reflect that
change.