### PR TITLE
chore: disable canarist for now because foosbyte's tests are flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ before_script:
 
 script:
   - './node_modules/.bin/jest --maxWorkers=2 --ci'
-  - yarn canarist


### PR DESCRIPTION
Right now the tests in the foosbyte repository which we are using to run
our canarist tests against, are failing randomly, therefore we will
disable canarist temporarily until the tests are fixed and stable again.