### PR TITLE
chore: remove Eslint warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
       "plugin:react/recommended",
       "plugin:prettier/recommended"
     ],
+    "settings": {
+      "react": {
+        "version": "detect"
+      }
+    },
     "plugins": [
       "node"
     ],


### PR DESCRIPTION
...by having it detect the current React version automatically. Because nobody wants to see this warning. 🤷‍♂️