### PR TITLE
Fix ServerDataContext docs

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,7 +51,7 @@ This side-effect component can be used to set specific HTTP status codes for ser
 
 Wrap your component with this HoC to get access to the prop `serverData` which contains all values of mixins that have implemented the `getServerData` hook.
 
-##### `<ServerDataContextConsumer>{data => /* render something */}</ServerDataContextConsumer>`
+##### `<ServerDataContext.Consumer>{data => /* render something */}</ServerDataContext.Consumer>`
 
 This is a convenience export. If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,7 +53,7 @@ Wrap your component with this HoC to get access to the prop `serverData` which c
 
 ##### `<ServerDataContext.Consumer>{data => /* render something */}</ServerDataContext.Consumer>`
 
-If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in `[useContext]`(https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
+If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
 
 ### Configuration
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,7 +53,7 @@ Wrap your component with this HoC to get access to the prop `serverData` which c
 
 ##### `<ServerDataContext.Consumer>{data => /* render something */}</ServerDataContext.Consumer>`
 
-This is a convenience export. If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it.
+If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in `[useContext]`(https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
 
 ### Configuration
 


### PR DESCRIPTION
the docs still documented the state where we only exported the Consumer. 
Nowadays we export the entire context to allow it being used in `contextTypes` and hooks. :) 