### PR TITLE
GraphQL middleware fixes

### DIFF
--- a/packages/graphql/lib/mock-server-middleware.js
+++ b/packages/graphql/lib/mock-server-middleware.js
@@ -4,31 +4,31 @@ import express from 'express';
 import hopsConfig from 'hops-config';
 import schema from 'hops-graphql/schema';
 
-const app = express();
-app.use(cookieParser());
-
-const schemaPromise = Promise.resolve(
+const apolloAppPromise = Promise.resolve(
   typeof schema === 'function' ? schema() : schema
-);
+).then(resolvedSchema => {
+  const app = express();
+  app.use(cookieParser());
+
+  const server = new ApolloServer({
+    schema: resolvedSchema,
+    context: context => ({ ...context, config: hopsConfig }),
+  });
+
+  server.applyMiddleware({
+    app,
+    path: hopsConfig.graphqlMockServerPath,
+    cors: {
+      credentials: true,
+      origin: true,
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      allowedHeaders: 'content-type',
+    },
+  });
+
+  return app;
+});
 
 export default (req, res, next) => {
-  schemaPromise.then(schema => {
-    const server = new ApolloServer({
-      schema,
-      context: ({ req }) => ({ req, config: hopsConfig }),
-    });
-
-    server.applyMiddleware({
-      app,
-      path: hopsConfig.graphqlMockServerPath,
-      cors: {
-        credentials: true,
-        origin: true,
-        methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-        allowedHeaders: 'content-type',
-      },
-    });
-
-    app.handle(req, res, next);
-  });
+  apolloAppPromise.then(app => app.handle(req, res, next), next);
 };

--- a/packages/graphql/mixin.core.js
+++ b/packages/graphql/mixin.core.js
@@ -63,12 +63,13 @@ class GraphQLMixin extends Mixin {
       return;
     }
 
-    middleware.preroutes.unshift(
-      createWebpackMiddleware(
+    middleware.initial.push({
+      path: this.config.graphqlMockServerPath,
+      handler: createWebpackMiddleware(
         this.getBuildConfig('graphql-mock-server', 'node'),
         true
-      )
-    );
+      ),
+    });
   }
 
   configureBuild(webpackConfig, loaderConfigs, target) {


### PR DESCRIPTION
## Current state

The Apollo server gets recreated for every request which is not needed. A weird side effect of that is that the request object never changes.

## Changes introduced here

As we know the path it is not required to have other phases before this handler. The Apollo server gets created only once now (initially and via every HMR).

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
