### PR TITLE
chore: pin Node versions to major LTS ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
 
 matrix:
   include:
-    - node_js: '8.10'
-      name: 'Test on Node.js 8.10'
+    - node_js: '8'
+      name: 'Test on Node.js 8'
       before_script: 'yarn lint'
       script: 'yarn test --maxWorkers=2 --ci'
     - node_js: '10'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0",
+    "node": "^8 || ^10",
     "yarn": ">=1.10.1"
   },
   "contributors": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext:main": "browser.js",

--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "bin": {
     "create-hops-app": "./index.js",

--- a/packages/development-proxy/package.json
+++ b/packages/development-proxy/package.json
@@ -7,7 +7,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "repository": {
     "type": "git",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext": "index.js",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "repository": {
     "type": "git",

--- a/packages/hops/package.json
+++ b/packages/hops/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "bin": {
     "hops": "bin.js"

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "scripts": {
     "test": "jest"

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "repository": {
     "type": "git",

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext": "index.js",

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext": "index.js",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "node.js",
   "browser": "dom.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext": "index.js",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "main": "index.js",
   "esnext": "index.js",

--- a/packages/spec/integration/create-hops-app/package.json
+++ b/packages/spec/integration/create-hops-app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/development-proxy/package.json
+++ b/packages/spec/integration/development-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "browser": "browser.js",
   "server": "server.js",

--- a/packages/spec/integration/graphql-mock-server/package.json
+++ b/packages/spec/integration/graphql-mock-server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "hops": {
     "shouldPrefetchOnServer": false,

--- a/packages/spec/integration/graphql/package.json
+++ b/packages/spec/integration/graphql/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "hops": {
     "graphqlUri": "https://www.graphqlhub.com/graphql"

--- a/packages/spec/integration/hot-module-reload/package.json
+++ b/packages/spec/integration/hot-module-reload/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/jest-preset/package.json
+++ b/packages/spec/integration/jest-preset/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "preset": "jest-preset-hops",

--- a/packages/spec/integration/lambda/package.json
+++ b/packages/spec/integration/lambda/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/postcss/package.json
+++ b/packages/spec/integration/postcss/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/pwa/package.json
+++ b/packages/spec/integration/pwa/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "hops": {
     "workerFile": "<rootDir>/service-worker.js",

--- a/packages/spec/integration/react/package.json
+++ b/packages/spec/integration/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "hops": {
     "mixins": ["./"],

--- a/packages/spec/integration/redux/package.json
+++ b/packages/spec/integration/redux/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/styled-components/package.json
+++ b/packages/spec/integration/styled-components/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/integration/typescript/package.json
+++ b/packages/spec/integration/typescript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">= 8.10"
+    "node": "^8 || ^10"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "devDependencies": {
     "create-hops-app": "^11.2.0",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "repository": {
     "type": "git",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": "^8 || ^10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hops currently only requires a minimum Node version, namely `8.10`. But this is actually not what we want, because that includes the non-LTS versions `9` and `11`.

So this PR introduces the more specific requirement of `^8 || ^10` for all packages.