### PR TITLE
fix(graphql): resolve core-js version collision

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,7 +22,7 @@
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.4.3",
     "apollo-link-http": "^1.5.5",
-    "apollo-server-express": "^2.2.0",
+    "apollo-server-express": ">=2.2.0 <=2.4.5",
     "cookie-parser": "^1.4.3",
     "cross-fetch": "^3.0.0",
     "express": "^4.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,17 +2070,17 @@ apollo-engine-reporting-protobuf@0.2.1:
   dependencies:
     protobufjs "^6.8.6"
 
-apollo-engine-reporting@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-1.0.7.tgz#d326b51b12b1f71a40885b8189dbcd162171c953"
-  integrity sha512-mFsXvd+1/o5jSa9tI2RoXYGcvCLcwwcfLwchjSTxqUd4ViB8RbqYKynzEZ+Omji7PBRM0azioBm43f7PSsQPqA==
+apollo-engine-reporting@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-1.0.4.tgz#312aa7c1ff3d7fb3169fd254434a4da59e7a5602"
+  integrity sha512-gxLrKl3gUMbtHnxSaCRHwkuLx7qCIg0tXBAUshlpMtA/a5vuiX6TUeeAyWTQfAKhf5mbh/hV9LV9bo4qfJeh2w==
   dependencies:
     apollo-engine-reporting-protobuf "0.2.1"
     apollo-graphql "^0.1.0"
-    apollo-server-core "2.4.8"
+    apollo-server-core "2.4.4"
     apollo-server-env "2.2.0"
     async-retry "^1.2.1"
-    graphql-extensions "0.5.7"
+    graphql-extensions "0.5.4"
 
 apollo-env@0.3.3:
   version "0.3.3"
@@ -2133,24 +2133,24 @@ apollo-server-caching@0.3.1:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@2.4.8:
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.4.8.tgz#47e503a345e314222725597c889773e018d8c67a"
-  integrity sha512-N+5UOzHhMOnHizEiArJtNvEe/cGhSHQyTn5tlU4RJ36FDBJ/WlYZfPbGDMLISSUCJ6t+aP8GLL4Mnudt9d2PDQ==
+apollo-server-core@2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.4.4.tgz#9119764b41d06ccc4b1606c7d418a910def68e91"
+  integrity sha512-2aZeQQXu2xdEJZDZiNGTZEqbry/k8+mDxnGCHXoObJVrCdiK2YXosrg2jkhX+uFNBxK2INwaHNA8c/Loik57cw==
   dependencies:
     "@apollographql/apollo-tools" "^0.3.3"
     "@apollographql/graphql-playground-html" "^1.6.6"
     "@types/ws" "^6.0.0"
     apollo-cache-control "0.5.2"
     apollo-datasource "0.3.1"
-    apollo-engine-reporting "1.0.7"
+    apollo-engine-reporting "1.0.4"
     apollo-server-caching "0.3.1"
     apollo-server-env "2.2.0"
     apollo-server-errors "2.2.1"
-    apollo-server-plugin-base "0.3.7"
+    apollo-server-plugin-base "0.3.4"
     apollo-tracing "0.5.2"
     fast-json-stable-stringify "^2.0.0"
-    graphql-extensions "0.5.7"
+    graphql-extensions "0.5.4"
     graphql-subscriptions "^1.0.0"
     graphql-tag "^2.9.2"
     graphql-tools "^4.0.0"
@@ -2172,10 +2172,10 @@ apollo-server-errors@2.2.1:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz#f68a3f845929768057da7e1c6d30517db5872205"
   integrity sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g==
 
-apollo-server-express@^2.2.0:
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.4.8.tgz#ec9eb61a87324555d49097e9fade3c7d142eb6cb"
-  integrity sha512-i60l32mfVe33jnKDPNYgUKUKu4Al0xEm2HLOSMgtJ9Wbpe/MbOx5X8M5F27fnHYdM+G5XfAErsakAyRGnQJ48Q==
+"apollo-server-express@>=2.2.0 <=2.4.5":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.4.5.tgz#d3bc8da7cde8ed9dcd1ba03c242c55139319fe8d"
+  integrity sha512-rQ2dzJHgcBAoUxzNvQoOGpcaQ7OSdJ8IF9d6a6692NWn1uN7VZBd40RmHfaIukM01e+ur8LzdQNDXibE+c/M5w==
   dependencies:
     "@apollographql/graphql-playground-html" "^1.6.6"
     "@types/accepts" "^1.3.5"
@@ -2183,17 +2183,17 @@ apollo-server-express@^2.2.0:
     "@types/cors" "^2.8.4"
     "@types/express" "4.16.1"
     accepts "^1.3.5"
-    apollo-server-core "2.4.8"
+    apollo-server-core "2.4.4"
     body-parser "^1.18.3"
     cors "^2.8.4"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"
     type-is "^1.6.16"
 
-apollo-server-plugin-base@0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.3.7.tgz#bfa4932fc9481bb36221545578d311db464af5a6"
-  integrity sha512-hW1jaLKf9qNOxMTwRq2CSqz3eqXsZuEiCc8/mmEtOciiVBq1GMtxFf19oIYM9HQuPvQU2RWpns1VrYN59L3vbg==
+apollo-server-plugin-base@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.3.4.tgz#dee83b1ae80fbe491a708a6f9df93614e5f6b338"
+  integrity sha512-iVufnqzSL8aqXhCn0nblrcW1bzZ4FItBkwQ5TjZhv9TLnn5+JzeGvc9ss6CD5sN84JIJplzQAWC9vaAROD6Pdw==
 
 apollo-tracing@0.5.2:
   version "0.5.2"
@@ -5573,13 +5573,6 @@ graphql-extensions@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.5.4.tgz#18a9674f9adb11aa6c0737485887ea8877914cff"
   integrity sha512-qLThJGVMqcItE7GDf/xX/E40m/aeqFheEKiR5bfra4q5eHxQKGjnIc20P9CVqjOn9I0FkEiU9ypOobfmIf7t6g==
-  dependencies:
-    "@apollographql/apollo-tools" "^0.3.3"
-
-graphql-extensions@0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.5.7.tgz#2b647e4e36997dc85b7f58ebd64324a5250fb2cf"
-  integrity sha512-HrU6APE1PiehZ46scMB3S5DezSeCATd8v+e4mmg2bqszMyCFkmAnmK6hR1b5VjHxhzt5/FX21x1WsXfqF4FwdQ==
   dependencies:
     "@apollographql/apollo-tools" "^0.3.3"
 


### PR DESCRIPTION
This PR fixes a current issue where it's not possible to start the local dev server due to errors.

### Steps to reproduce
- Create a graphql project: `yarn create hops-app --template hops-template-graphql my-new-hops-project
`
- Enter the project folder
- Remove `jest` and `jest-preset-hops` dependencies: `yarn remove jest jest-preset-hops`
- Start the app: `yarn start`
- See the errors in console

The problem is a (partial) dependency tree like this with the latest version of `apollo-server-express` (`2.4.8`):

```txt
$ yarn list --pattern core-js
├─ apollo-env@0.3.4
│  └─ core-js@3.0.0-beta.13
└─ core-js@2.6.5
```

The respective `yarn why`-output for `core-js` is:

<details>
<summary><b><code>$ yarn why core-js</code></b></summary>
<pre>
<code>
=> Found "core-js@2.6.5"
info Reasons this module exists
   - "hops#@untool#webpack#@babel#polyfill" depends on it
   - Hoisted from "hops#@untool#webpack#@babel#polyfill#core-js"
info Disk size without dependencies: "7.66MB"
info Disk size with unique dependencies: "7.66MB"
info Disk size with transitive dependencies: "7.66MB"
info Number of shared dependencies: 0
=> Found "apollo-env#core-js@3.0.0-beta.13"
info This module exists because "hops-graphql#apollo-server-express#apollo-server-core#@apollographql#apollo-tools#apollo-env" depends on it.
info Disk size without dependencies: "6.6MB"
info Disk size with unique dependencies: "6.6MB"
info Disk size with transitive dependencies: "6.6MB"
info Number of shared dependencies: 0
</code>
</pre>
</details>

---

With the version range for `apollo-server-express` introduced by this PR, the (partial) dependency tree looks like this:

```txt
$ yarn list --pattern core-js
├─ @babel/polyfill@7.2.5
│  └─ core-js@2.6.5
└─ core-js@3.0.0-beta.13
```

And the respective `yarn why`-output for `core-js` is:

<details>
<summary><b><code>$ yarn why core-js</code></b></summary>
<pre>
<code>
=> Found "core-js@3.0.0-beta.13"
info Reasons this module exists
   - "graphql-extensions#@apollographql#apollo-tools#apollo-env" depends on it
   - Hoisted from "graphql-extensions#@apollographql#apollo-tools#apollo-env#core-js"
info Disk size without dependencies: "6.6MB"
info Disk size with unique dependencies: "6.6MB"
info Disk size with transitive dependencies: "6.6MB"
info Number of shared dependencies: 0
=> Found "@babel/polyfill#core-js@2.6.5"
info This module exists because "hops#@untool#webpack#@babel#polyfill" depends on it.
info Disk size without dependencies: "7.66MB"
info Disk size with unique dependencies: "7.66MB"
info Disk size with transitive dependencies: "7.66MB"
info Number of shared dependencies: 0
</code>
</pre>
</details>

---

The two different versions of `core-js` basically swap places in the tree, which fixes the issue with the local dev server… 🙃🤪😭