### PR TITLE
Update tooling (changelog releases, renovate)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,8 @@
   "command": {
     "publish": {
       "message": "chore: release %s",
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "githubRelease": true
     }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,6 @@
 {
   "extends": ["config:base", "schedule:nonOfficeHours"],
   "pinVersions": false,
-  "ignorePaths": ["packages/build-config/shims/", "packages/spec/mock/"],
-  "semanticPrefix": "chore:",
-  "dependencies": {
-    "semanticPrefix": "chore:"
-  },
   "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true
@@ -14,6 +9,13 @@
     {
       "packagePatterns": ["^@untool/"],
       "groupName": "Update untool monorepo packages"
+    },
+    {
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "dependencies",
+      "depTypeList": ["dependencies", "peerDependencies"]
     }
-  ]
+  ],
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "dependencies"
 }


### PR DESCRIPTION
This PR will enable `--github-release` for lerna to automatically push
the release notes to the github releases page and
update the renovate configuration to use the prefix `fix` for
dependencies and peerDependencies and `chore` for devDependencies.

**Edit:** This requires the environment variable `GH_TOKEN` to be set: https://github.com/lerna/lerna/tree/master/commands/version#--github-release