### PR TITLE
Add second parameter "location" to actions in "actionCreators"

### DIFF
--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -88,6 +88,8 @@ When server-side rendering/data fetching is enabled, this will dispatch matching
 
 On the client-side by default this will dispatch matching actions only on client-side navigation (can be overriden by setting `alwaysDispatchActionsOnClient` to `true`).
 
+Actions receive two parameters: `params` (see [URL Parameters](https://reacttraining.com/react-router/web/example/url-params) in the react-router docs) and `location` (the react router [`location`](https://reacttraining.com/react-router/web/api/location) object).
+
 ```javascript
 export default render(<MyApp />, {
   redux: {
@@ -100,7 +102,7 @@ export default render(<MyApp />, {
       },
       {
         path: '/users/:id',
-        action: fetchUser,
+        action: id => fetchUser(id),
       },
     ],
   },

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -88,7 +88,7 @@ When server-side rendering/data fetching is enabled, this will dispatch matching
 
 On the client-side by default this will dispatch matching actions only on client-side navigation (can be overriden by setting `alwaysDispatchActionsOnClient` to `true`).
 
-Actions receive two parameters: `params` (see [URL Parameters](https://reacttraining.com/react-router/web/example/url-params) in the react-router docs) and `location` (the react router [`location`](https://reacttraining.com/react-router/web/api/location) object).
+Actions receive two parameters: `params` (see [URL Parameters](https://reacttraining.com/react-router/web/example/url-params) in the react-router docs) and an object containing `location` (the react router [`location`](https://reacttraining.com/react-router/web/api/location) object) and [`match`]((https://reacttraining.com/react-router/web/api/match).
 
 ```javascript
 export default render(<MyApp />, {

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -102,7 +102,7 @@ export default render(<MyApp />, {
       },
       {
         path: '/users/:id',
-        action: id => fetchUser(id),
+        action: ({ id }) => fetchUser(id),
       },
     ],
   },

--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -69,7 +69,7 @@ class ReduxActionCreatorRuntimeMixin extends Mixin {
         if (!match) {
           return Promise.resolve();
         }
-        return store.dispatch(action(match.params));
+        return store.dispatch(action(match.params, location));
       })
     );
   }

--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -69,7 +69,7 @@ class ReduxActionCreatorRuntimeMixin extends Mixin {
         if (!match) {
           return Promise.resolve();
         }
-        return store.dispatch(action(match.params, location));
+        return store.dispatch(action(match.params, { location, match }));
       })
     );
   }

--- a/packages/redux/action-creator-dispatcher/mixin.server.js
+++ b/packages/redux/action-creator-dispatcher/mixin.server.js
@@ -25,7 +25,7 @@ class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
 
   async fetchData(data) {
     if (this.canPrefetchOnServer().every(value => value)) {
-      await this.dispatchAll(createLocation(this.request.path));
+      await this.dispatchAll(createLocation(this.request.originalUrl));
       this.prefetchedOnServer = true;
     }
     return data;

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -30,75 +30,77 @@ describe('redux developmet server', () => {
     await page.close();
   });
 
-  it('executes route-matching action creators', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/increment', { waitUntil: 'networkidle2' });
+  describe('route matching action creators', () => {
+    it('will be executed if the route matches', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/increment', { waitUntil: 'networkidle2' });
 
-    const count = await getInnerText('counter');
+      const count = await getInnerText('counter');
 
-    expect(count).toBe('1');
+      expect(count).toBe('1');
 
-    await page.close();
-  });
-
-  it('executes route-matching action creators also if a search query or hash is present', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/increment?foo=bar#hash', {
-      waitUntil: 'networkidle2',
+      await page.close();
     });
 
-    const count = await getInnerText('counter');
+    it('will be executed if a search query or hash is present', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/increment?foo=bar#hash', {
+        waitUntil: 'networkidle2',
+      });
 
-    expect(count).toBe('1');
+      const count = await getInnerText('counter');
 
-    await page.close();
-  });
+      expect(count).toBe('1');
 
-  it('executes route-matching action creators with fetch', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/increment-fetch', { waitUntil: 'networkidle2' });
-
-    const count = await getInnerText('counter');
-
-    expect(count).toBe('42');
-
-    await page.close();
-  });
-
-  it('executes route-matching action creators with url-params as their first argument', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/param/foo', { waitUntil: 'networkidle2' });
-
-    const param = await getInnerText('value');
-
-    expect(param).toBe('foo');
-
-    await page.close();
-  });
-
-  it('executes route-matching action creators with react-router-location as part of their second argument', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/location-test?foo=bar', {
-      waitUntil: 'networkidle2',
+      await page.close();
     });
 
-    const param = await getInnerText('value');
+    it('will be awaited if they are promises', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/increment-fetch', { waitUntil: 'networkidle2' });
 
-    expect(param).toBe('?foo=bar');
+      const count = await getInnerText('counter');
 
-    await page.close();
-  });
+      expect(count).toBe('42');
 
-  it('executes route-matching action creators with react-router-match as part of their second argument', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url + '/match-test/foobar', {
-      waitUntil: 'networkidle2',
+      await page.close();
     });
 
-    const param = await getInnerText('value');
+    it('will be provided with expected "param" string', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/param-test/foo', { waitUntil: 'networkidle2' });
 
-    expect(param).toBe('foobar');
+      const param = await getInnerText('value');
 
-    await page.close();
+      expect(param).toBe('foo');
+
+      await page.close();
+    });
+
+    it('will be provided with the expected "location" object', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/location-test?foo=bar', {
+        waitUntil: 'networkidle2',
+      });
+
+      const param = await getInnerText('value');
+
+      expect(param).toBe('?foo=bar');
+
+      await page.close();
+    });
+
+    it('will be provided with the expected "match" object', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(url + '/match-test/foobar', {
+        waitUntil: 'networkidle2',
+      });
+
+      const param = await getInnerText('value');
+
+      expect(param).toBe('foobar');
+
+      await page.close();
+    });
   });
 });

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -83,9 +83,9 @@ describe('redux developmet server', () => {
         waitUntil: 'networkidle2',
       });
 
-      const param = await getInnerText('value');
+      const locationSearch = await getInnerText('value');
 
-      expect(param).toBe('?foo=bar');
+      expect(locationSearch).toBe('?foo=bar');
 
       await page.close();
     });
@@ -96,9 +96,9 @@ describe('redux developmet server', () => {
         waitUntil: 'networkidle2',
       });
 
-      const param = await getInnerText('value');
+      const matchParam = await getInnerText('value');
 
-      expect(param).toBe('foobar');
+      expect(matchParam).toBe('foobar');
 
       await page.close();
     });

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -41,6 +41,19 @@ describe('redux developmet server', () => {
     await page.close();
   });
 
+  it('executes route-matching action creators also if a search query or hash is present', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url + '/increment?foo=bar#hash', {
+      waitUntil: 'networkidle2',
+    });
+
+    const count = await getInnerText('counter');
+
+    expect(count).toBe('1');
+
+    await page.close();
+  });
+
   it('executes route-matching action creators with fetch', async () => {
     const { page, getInnerText } = await createPage();
     await page.goto(url + '/increment-fetch', { waitUntil: 'networkidle2' });
@@ -65,13 +78,13 @@ describe('redux developmet server', () => {
 
   it('executes route-matching action creators with react-router-location as part of their second argument', async () => {
     const { page, getInnerText } = await createPage();
-    await page.goto(url + '/location-test', {
+    await page.goto(url + '/location-test?foo=bar', {
       waitUntil: 'networkidle2',
     });
 
     const param = await getInnerText('value');
 
-    expect(param).toBe('/location-test');
+    expect(param).toBe('?foo=bar');
 
     await page.close();
   });

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -9,7 +9,7 @@ describe('redux developmet server', () => {
     const { page, getInnerText } = await createPage();
     await page.goto(url, { waitUntil: 'networkidle2' });
 
-    const count = await getInnerText('output');
+    const count = await getInnerText('counter');
 
     expect(count).toBe('0');
 
@@ -23,7 +23,7 @@ describe('redux developmet server', () => {
     await page.click('button');
     await page.click('button');
 
-    const count = await getInnerText('output');
+    const count = await getInnerText('counter');
 
     expect(count).toBe('2');
 
@@ -34,7 +34,7 @@ describe('redux developmet server', () => {
     const { page, getInnerText } = await createPage();
     await page.goto(url + '/increment', { waitUntil: 'networkidle2' });
 
-    const count = await getInnerText('output');
+    const count = await getInnerText('counter');
 
     expect(count).toBe('1');
 
@@ -45,9 +45,46 @@ describe('redux developmet server', () => {
     const { page, getInnerText } = await createPage();
     await page.goto(url + '/increment-fetch', { waitUntil: 'networkidle2' });
 
-    const count = await getInnerText('output');
+    const count = await getInnerText('counter');
 
     expect(count).toBe('42');
+
+    await page.close();
+  });
+
+  it('executes route-matching action creators with url-params as their first argument', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url + '/param/foo', { waitUntil: 'networkidle2' });
+
+    const param = await getInnerText('value');
+
+    expect(param).toBe('foo');
+
+    await page.close();
+  });
+
+  it('executes route-matching action creators with react-router-location as part of their second argument', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url + '/location-test', {
+      waitUntil: 'networkidle2',
+    });
+
+    const param = await getInnerText('value');
+
+    expect(param).toBe('/location-test');
+
+    await page.close();
+  });
+
+  it('executes route-matching action creators with react-router-match as part of their second argument', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url + '/match-test/foobar', {
+      waitUntil: 'networkidle2',
+    });
+
+    const param = await getInnerText('value');
+
+    expect(param).toBe('foobar');
 
     await page.close();
   });

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -34,10 +34,10 @@ const incrementFetch = () => dispatch => {
 
 const setParam = ({ param }) => ({ type: 'SET_VALUE', payload: param });
 
-const setLocationPathname = (params, { location: { pathname } }) => {
+const setLocationPathname = (params, { location: { search } }) => {
   return {
     type: 'SET_VALUE',
-    payload: pathname,
+    payload: search,
   };
 };
 

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -74,7 +74,7 @@ export default render(<ConnectedCounter />, {
         action: incrementFetch,
       },
       {
-        path: '/param/:param',
+        path: '/param-test/:param',
         action: setParam,
       },
       {

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -12,6 +12,14 @@ const reducers = {
         return state;
     }
   },
+  value(state = null, action) {
+    switch (action.type) {
+      case 'SET_VALUE':
+        return action.payload;
+      default:
+        return state;
+    }
+  },
 };
 
 const increment = () => ({ type: 'INCREMENT', payload: 1 });
@@ -24,15 +32,32 @@ const incrementFetch = () => dispatch => {
     });
 };
 
-const Counter = ({ count, increment }) => (
+const setParam = ({ param }) => ({ type: 'SET_VALUE', payload: param });
+
+const setLocationPathname = (params, { location: { pathname } }) => {
+  return {
+    type: 'SET_VALUE',
+    payload: pathname,
+  };
+};
+
+const setMatchParam = (params, { match: { params: matchParams } }) => {
+  return {
+    type: 'SET_VALUE',
+    payload: matchParams.test,
+  };
+};
+
+const Counter = ({ count, increment, val }) => (
   <React.Fragment>
     <button onClick={increment}>+</button>
-    <output>{count}</output>
+    <counter>{count}</counter>
+    <value>{val}</value>
   </React.Fragment>
 );
 
 const ConnectedCounter = connect(
-  ({ counter }) => ({ count: counter }),
+  ({ counter, value }) => ({ count: counter, val: value }),
   { increment }
 )(Counter);
 
@@ -47,6 +72,18 @@ export default render(<ConnectedCounter />, {
       {
         path: '/increment-fetch',
         action: incrementFetch,
+      },
+      {
+        path: '/param/:param',
+        action: setParam,
+      },
+      {
+        path: '/location-test',
+        action: setLocationPathname,
+      },
+      {
+        path: '/match-test/:test',
+        action: setMatchParam,
       },
     ],
   },


### PR DESCRIPTION
This pull request closes issue #821 

As already discussed and proposed in #821 this could be a very useful feature.

## Current state

Currently actions in the `actionCreators` array only receive one parameter (`params`). 

## Changes introduced here

Actions will receive an additional parameter: an object containing the `location` and `match` objects from `react-router`. This enables the action creator to access to the search query, the current pathname, matched path etc.

`createLocation` utility gets now called with [`request.originalUrl`](https://expressjs.com/en/api.html#req.originalUrl) instead of the original [`request.path`](https://expressjs.com/en/api.html#req.path).

I also added a new paragraph to the documentation to explain the (currently undocumented) parameters that actions receive in `actionCreators`. The code-example has also been updated to make the use of the `params` more explicit.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [x] Documentation has been added
