### PR TITLE
fix(dependencies): remove react-router-dom version range where not ne…

### DIFF
--- a/packages/hops/package.json
+++ b/packages/hops/package.json
@@ -48,6 +48,6 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0"
+    "react-router-dom": "^5.0.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0"
+    "react-router-dom": "^5.0.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/react#readme"
 }

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "react": "^16.4.2",
     "react-redux": "^6.0.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0",
+    "react-router-dom": "^5.0.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"
   },

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -25,7 +25,7 @@
     "react-apollo": "^2.2.3",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0"
+    "react-router-dom": "^5.0.0"
   },
   "devDependencies": {
     "jest": "^23.4.2",

--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -22,7 +22,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0"
+    "react-router-dom": "^5.0.0"
   },
   "devDependencies": {
     "jest": "^23.4.2",

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-redux": "^6.0.0",
-    "react-router-dom": "^4.3.1 || ^5.0.0",
+    "react-router-dom": "^5.0.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10139,7 +10139,7 @@ react-redux@^6.0.0:
     prop-types "^15.7.2"
     react-is "^16.8.2"
 
-"react-router-dom@^4.3.1 || ^5.0.0":
+react-router-dom@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
   integrity sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==


### PR DESCRIPTION
…eded

## Current state
A few `react-router-dom` dependencies and devDependencies are declared as `^4.3.1 || ^5.0.0` range, even though they will be always resolved as `^5.0.0`.

## Changes introduced here

Declare `react-router-dom` dependencies and devDependencies as `^5.0.0`.

## Checklist

- [X] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [ ] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
