### PR TITLE
Clean up create-hops-app package

### DIFF
--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -11,8 +11,7 @@
     "node": ">=8.10.0"
   },
   "bin": {
-    "create-hops-app": "./index.js",
-    "create-hops-app@next": "./index.js"
+    "create-hops-app": "./index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -18,7 +18,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "hops": "^11.5.0",
     "load-json-file": "^5.1.0",
     "tar": "^4.4.6",
     "validate-npm-package-name": "^3.0.0",


### PR DESCRIPTION
This PR removes the workaround for "yarn create hops-app@next" hack
https://github.com/xing/hops/pull/708
And it also removes an unused dependency to "hops" which led to
peerDependency warnings when installing / using create-hops-app globally

Technically this could be considered a breaking change, because it
removes the `create-hops-app@next` binary, but since it was a hack and
was probably only used while we were working on the Hops 11 RC, I think
we could argue to remove it.