### PR TITLE
fix(jest-preset): correctly specify peer dependencies

### DIFF
--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -38,11 +38,17 @@
   },
   "peerDependencies": {
     "jest": "^23.0.0",
-    "react": "^16.4.2"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "react-helmet": "^5.2.0",
+    "react-router-dom": "^4.3.1 || ^5.0.0"
   },
   "devDependencies": {
     "jest": "^23.4.2",
-    "react": "^16.4.2"
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2",
+    "react-helmet": "^5.2.0",
+    "react-router-dom": "^5.0.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/jest-preset#readme"
 }


### PR DESCRIPTION
Since the jest-preset depends on the `hops` package which expects
certain peerDependencies (such as react, react-dom, etc), we need to
re-declare these packages as peerDependencies on the jest-preset itself
to get rid of peer dependency warnings when the jest-preset is installed