### PR TITLE
Redux middlwares

### DIFF
--- a/packages/redux/mixin.browser.js
+++ b/packages/redux/mixin.browser.js
@@ -1,25 +1,18 @@
 const React = require('react');
-const {
-  compose,
-  combineReducers,
-  createStore,
-  applyMiddleware,
-} = require('redux');
-const ReduxThunkMiddleware = require('redux-thunk').default;
+const { compose, combineReducers, createStore } = require('redux');
 const { Provider } = require('react-redux');
 const {
-  Mixin,
   strategies: {
     sync: { override },
   },
 } = require('hops-mixin');
+const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
 
 const ReduxCompose = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-class ReduxMixin extends Mixin {
+class ReduxMixin extends ReduxRuntimeCommonMixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
-    this.middlewares = options.middlewares;
     this.reducers = options.reducers || {};
   }
 
@@ -46,20 +39,6 @@ class ReduxMixin extends Mixin {
     return this.store;
   }
 
-  getReduxMiddlewares() {
-    return [
-      ReduxThunkMiddleware.withExtraArgument({
-        config: this.config,
-      }),
-    ];
-  }
-
-  applyMiddlewares() {
-    const middlewares = this.middlewares || this.getReduxMiddlewares();
-
-    return middlewares.map(m => applyMiddleware(m));
-  }
-
   composeEnhancers(...enhancers) {
     return ReduxCompose(...enhancers);
   }
@@ -75,7 +54,6 @@ class ReduxMixin extends Mixin {
 
 ReduxMixin.strategies = {
   getReduxStore: override,
-  getReduxMiddlewares: override,
 };
 
 module.exports = ReduxMixin;

--- a/packages/redux/mixin.browser.js
+++ b/packages/redux/mixin.browser.js
@@ -1,21 +1,9 @@
-const React = require('react');
 const { compose, combineReducers, createStore } = require('redux');
-const { Provider } = require('react-redux');
-const {
-  strategies: {
-    sync: { override },
-  },
-} = require('hops-mixin');
 const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
 
 const ReduxCompose = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 class ReduxMixin extends ReduxRuntimeCommonMixin {
-  constructor(config, element, { redux: options = {} } = {}) {
-    super(config);
-    this.reducers = options.reducers || {};
-  }
-
   createStore() {
     return createStore(
       combineReducers(this.reducers),
@@ -42,18 +30,6 @@ class ReduxMixin extends ReduxRuntimeCommonMixin {
   composeEnhancers(...enhancers) {
     return ReduxCompose(...enhancers);
   }
-
-  enhanceElement(reactElement) {
-    return React.createElement(
-      Provider,
-      { store: this.getReduxStore() },
-      reactElement
-    );
-  }
 }
-
-ReduxMixin.strategies = {
-  getReduxStore: override,
-};
 
 module.exports = ReduxMixin;

--- a/packages/redux/mixin.runtime-common.js
+++ b/packages/redux/mixin.runtime-common.js
@@ -1,0 +1,35 @@
+const { applyMiddleware } = require('redux');
+const ReduxThunkMiddleware = require('redux-thunk').default;
+const {
+  Mixin,
+  strategies: {
+    sync: { override },
+  },
+} = require('hops-mixin');
+
+class ReduxRuntimeCommonMixin extends Mixin {
+  constructor(config, element, { redux: options = {} } = {}) {
+    super(config);
+    this.middlewares = options.middlewares;
+  }
+
+  getReduxMiddlewares() {
+    return [
+      ReduxThunkMiddleware.withExtraArgument({
+        config: this.config,
+      }),
+    ];
+  }
+
+  applyMiddlewares() {
+    const middlewares = this.middlewares || this.getReduxMiddlewares();
+
+    return middlewares.map(m => applyMiddleware(m));
+  }
+}
+
+ReduxRuntimeCommonMixin.strategies = {
+  getReduxMiddlewares: override,
+};
+
+module.exports = ReduxRuntimeCommonMixin;

--- a/packages/redux/mixin.runtime-common.js
+++ b/packages/redux/mixin.runtime-common.js
@@ -1,3 +1,5 @@
+const React = require('react');
+const { Provider } = require('react-redux');
 const { applyMiddleware } = require('redux');
 const ReduxThunkMiddleware = require('redux-thunk').default;
 const {
@@ -11,6 +13,7 @@ class ReduxRuntimeCommonMixin extends Mixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
     this.middlewares = options.middlewares || [];
+    this.reducers = options.reducers || {};
   }
 
   getReduxMiddlewares() {
@@ -27,10 +30,19 @@ class ReduxRuntimeCommonMixin extends Mixin {
 
     return middlewares.map(m => applyMiddleware(m));
   }
+
+  enhanceElement(reactElement) {
+    return React.createElement(
+      Provider,
+      { store: this.getReduxStore() },
+      reactElement
+    );
+  }
 }
 
 ReduxRuntimeCommonMixin.strategies = {
   getReduxMiddlewares: override,
+  getReduxStore: override,
 };
 
 module.exports = ReduxRuntimeCommonMixin;

--- a/packages/redux/mixin.runtime-common.js
+++ b/packages/redux/mixin.runtime-common.js
@@ -10,11 +10,12 @@ const {
 class ReduxRuntimeCommonMixin extends Mixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
-    this.middlewares = options.middlewares;
+    this.middlewares = options.middlewares || [];
   }
 
   getReduxMiddlewares() {
     return [
+      ...this.middlewares,
       ReduxThunkMiddleware.withExtraArgument({
         config: this.config,
       }),
@@ -22,7 +23,7 @@ class ReduxRuntimeCommonMixin extends Mixin {
   }
 
   applyMiddlewares() {
-    const middlewares = this.middlewares || this.getReduxMiddlewares();
+    const middlewares = this.getReduxMiddlewares();
 
     return middlewares.map(m => applyMiddleware(m));
   }

--- a/packages/redux/mixin.server.js
+++ b/packages/redux/mixin.server.js
@@ -1,24 +1,16 @@
 const React = require('react');
-const {
-  createStore,
-  combineReducers,
-  applyMiddleware,
-  compose,
-} = require('redux');
-
-const ReduxThunkMiddleware = require('redux-thunk').default;
+const { createStore, combineReducers, compose } = require('redux');
 const { Provider } = require('react-redux');
 const {
-  Mixin,
   strategies: {
     sync: { override },
   },
 } = require('hops-mixin');
+const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
 
-class ReduxMixin extends Mixin {
+class ReduxMixin extends ReduxRuntimeCommonMixin {
   constructor(config, element, { redux: options = {} } = {}) {
     super(config);
-    this.middlewares = options.middlewares;
     this.reducers = options.reducers || {};
   }
 
@@ -37,20 +29,6 @@ class ReduxMixin extends Mixin {
 
     this.store = this.createStore();
     return this.store;
-  }
-
-  getReduxMiddlewares() {
-    return [
-      ReduxThunkMiddleware.withExtraArgument({
-        config: this.config,
-      }),
-    ];
-  }
-
-  applyMiddlewares() {
-    const middlewares = this.middlewares || this.getReduxMiddlewares();
-
-    return middlewares.map(m => applyMiddleware(m));
   }
 
   composeEnhancers(...enhancers) {
@@ -78,7 +56,6 @@ class ReduxMixin extends Mixin {
 
 ReduxMixin.strategies = {
   getReduxStore: override,
-  getReduxMiddlewares: override,
 };
 
 module.exports = ReduxMixin;

--- a/packages/redux/mixin.server.js
+++ b/packages/redux/mixin.server.js
@@ -1,19 +1,7 @@
-const React = require('react');
 const { createStore, combineReducers, compose } = require('redux');
-const { Provider } = require('react-redux');
-const {
-  strategies: {
-    sync: { override },
-  },
-} = require('hops-mixin');
 const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
 
 class ReduxMixin extends ReduxRuntimeCommonMixin {
-  constructor(config, element, { redux: options = {} } = {}) {
-    super(config);
-    this.reducers = options.reducers || {};
-  }
-
   createStore() {
     return createStore(
       combineReducers(this.reducers),
@@ -44,18 +32,6 @@ class ReduxMixin extends ReduxRuntimeCommonMixin {
       },
     };
   }
-
-  enhanceElement(reactElement) {
-    return React.createElement(
-      Provider,
-      { store: this.getReduxStore() },
-      reactElement
-    );
-  }
 }
-
-ReduxMixin.strategies = {
-  getReduxStore: override,
-};
 
 module.exports = ReduxMixin;


### PR DESCRIPTION
## Current state

By calling `render(app, { redux: { middlewares } })` it is possible to pass in your own redux middlewares however by doing so the `getReduxMiddlewares` mixin hook gets ignored.

This might not be a bug but at least makes it impossible to have mixins with redux middlewares combined with own middlewares.

## Changes introduced here

The middlewares coming from render are now added into the result of `getReduxMiddlewares` and `ReduxThunkMiddleware` comes last as this means that it does not break an existing thunk middlware. This works because you can only have one `ReduxThunkMiddleware` and the first in the list wins.
~I also introduce a `configureReduxThunkExtraArgument` here in order to make it easier to add more entries to the extra argument object.~

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added
