### PR TITLE
[RFC]: refactor: use "untool" dist package instead of discrete packages

### DIFF
--- a/packages/config/browser.js
+++ b/packages/config/browser.js
@@ -1,1 +1,1 @@
-module.exports = require('@untool/core').internal.getConfig();
+module.exports = require('untool').internal.getConfig();

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -1,3 +1,3 @@
-module.exports = require('@untool/core').internal.getConfig({
+module.exports = require('untool').internal.getConfig({
   untoolNamespace: 'hops',
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,8 +17,19 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.6.2",
-    "@untool/webpack": "^1.6.2"
+    "untool": "^1.6.2"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "react-helmet": "^5.2.0",
+    "react-router-dom": "^4.3.1 || ^5.0.0"
+  },
+  "devDependencies": {
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2",
+    "react-helmet": "^5.2.0",
+    "react-router-dom": "^5.0.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/config#readme"
 }

--- a/packages/graphql/mixin.core.js
+++ b/packages/graphql/mixin.core.js
@@ -3,7 +3,7 @@ const { Mixin } = require('hops-mixin');
 const strip = require('strip-indent');
 const {
   internal: { createWebpackMiddleware, StatsFilePlugin },
-} = require('@untool/webpack');
+} = require('untool');
 
 function exists(path) {
   try {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -19,7 +19,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/webpack": "^1.6.2",
     "apollo-cache-inmemory": "^1.3.6",
     "apollo-client": "^2.5.1",
     "apollo-link-http": "^1.5.5",
@@ -31,7 +30,8 @@
     "graphql-tools": "^4.0.0",
     "hops-config": "^11.6.1",
     "hops-mixin": "^11.6.1",
-    "strip-indent": "^3.0.0"
+    "strip-indent": "^3.0.0",
+    "untool": "^1.6.2"
   },
   "peerDependencies": {
     "graphql-tag": "^2.10.0",

--- a/packages/hops/bin.js
+++ b/packages/hops/bin.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const path = require('path');
-const { configure } = require('@untool/yargs');
+const { configure } = require('untool');
 
 configure({
   untoolNamespace: 'hops',

--- a/packages/hops/package.json
+++ b/packages/hops/package.json
@@ -27,13 +27,10 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/express": "^1.6.2",
-    "@untool/info": "^1.6.2",
-    "@untool/webpack": "^1.6.2",
-    "@untool/yargs": "^1.6.2",
     "hops-express": "^11.6.1",
     "hops-mixin": "^11.6.1",
     "hops-react": "^11.6.1",
+    "untool": "^1.6.2",
     "webpack-bundle-analyzer": "^3.0.4"
   },
   "peerDependencies": {

--- a/packages/hops/preset.js
+++ b/packages/hops/preset.js
@@ -1,10 +1,3 @@
 module.exports = {
-  presets: [
-    '@untool/yargs',
-    '@untool/webpack',
-    '@untool/info',
-    '@untool/express',
-    'hops-express',
-    'hops-react',
-  ],
+  presets: ['untool', 'hops-express', 'hops-react'],
 };

--- a/packages/jest-preset/mocks/hops.js
+++ b/packages/jest-preset/mocks/hops.js
@@ -1,5 +1,7 @@
-/* eslint react/prop-types: 0 */
 const hops = require('hops/lib/runtime');
+const {
+  internal: { runtime },
+} = require('untool');
 const importComponent = require('../helpers/import-component');
 
-module.exports = Object.assign(hops, { importComponent });
+module.exports = Object.assign(hops, runtime, { importComponent });

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -33,7 +33,8 @@
     "hops": "^11.6.1",
     "identity-obj-proxy": "^3.0.0",
     "jest-config": "^23.0.0",
-    "ts-jest": "^23.1.2"
+    "ts-jest": "^23.1.2",
+    "untool": "^1.6.2"
   },
   "peerDependencies": {
     "jest": "^23.0.0",

--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -6,7 +6,7 @@ const serverlessHttp = require('serverless-http');
 const config = require('hops-config');
 const { trimSlashes } = require('pathifist');
 
-const app = require('@untool/express').createServer('serve');
+const app = require('untool').createServer('serve');
 
 const awsConfig = require('./lib/aws-config')(config);
 

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -18,8 +18,6 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.6.2",
-    "@untool/express": "^1.6.2",
     "archiver": "^3.0.0",
     "aws-sdk": "^2.286.2",
     "globby": "^9.0.0",
@@ -30,7 +28,8 @@
     "resolve-tree": "^0.1.13",
     "semver": "^6.0.0",
     "serverless-http": "^2.0.0",
-    "strip-indent": "^3.0.0"
+    "strip-indent": "^3.0.0",
+    "untool": "^1.6.2"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/lambda#readme"
 }

--- a/packages/mixin/index.js
+++ b/packages/mixin/index.js
@@ -1,7 +1,6 @@
-const { Mixin } = require('@untool/core');
-const { sync, async } = require('mixinable');
+const { Mixin, strategies } = require('untool');
 
 module.exports = {
   Mixin,
-  strategies: { sync, async },
+  strategies,
 };

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -18,8 +18,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.6.2",
-    "mixinable": "^4.0.0"
+    "untool": "^1.6.2"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/mixin#readme"
 }

--- a/packages/pwa/dom.js
+++ b/packages/pwa/dom.js
@@ -1,8 +1,6 @@
 /* eslint-env browser */
 
-const {
-  internal: { getConfig },
-} = require('@untool/core');
+const hopsConfig = require('hops-config');
 
 const isLocalHost = host => {
   return (
@@ -27,7 +25,7 @@ module.exports = function installServiceWorker() {
       isLocalHost(window.location.hostname)
     ) {
       window.addEventListener('load', () => {
-        resolve(navigator.serviceWorker.register(getConfig().workerPath));
+        resolve(navigator.serviceWorker.register(hopsConfig.workerPath));
       });
     }
   });

--- a/packages/pwa/lib/loader-shim.js
+++ b/packages/pwa/lib/loader-shim.js
@@ -1,1 +1,3 @@
-export { getConfig } from '@untool/core/lib/config';
+import hopsConfig from 'hops-config';
+
+export const getConfig = () => hopsConfig;

--- a/packages/pwa/mixin.core.js
+++ b/packages/pwa/mixin.core.js
@@ -34,7 +34,7 @@ class PWAMixin extends Mixin {
       webpackConfig.module.rules.push({
         test: require.resolve('./lib/loader-shim'),
         loader: configLoader.path,
-        options: { target: 'worker', config: this.config },
+        options: { type: 'worker', config: this.config },
       });
       webpackConfig.plugins.push(
         new ServiceWorkerPlugin({

--- a/packages/pwa/mixin.core.js
+++ b/packages/pwa/mixin.core.js
@@ -1,4 +1,7 @@
 const { Mixin } = require('hops-mixin');
+const {
+  internal: { configLoader },
+} = require('untool');
 const { join, trimSlashes } = require('pathifist');
 const ServiceWorkerPlugin = require('./lib/service-worker-plugin');
 
@@ -30,7 +33,7 @@ class PWAMixin extends Mixin {
       };
       webpackConfig.module.rules.push({
         test: require.resolve('./lib/loader-shim'),
-        loader: require.resolve('@untool/webpack/lib/utils/loader'),
+        loader: configLoader.path,
         options: { target: 'worker', config: this.config },
       });
       webpackConfig.plugins.push(

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^1.6.2",
-    "@untool/webpack": "^1.6.2",
     "app-manifest-loader": "^2.0.0",
     "file-loader": "^3.0.0",
+    "hops-config": "^11.6.1",
     "hops-mixin": "^11.6.1",
     "pathifist": "^1.0.0",
+    "untool": "^1.6.2",
     "webpack": "^4.23.0",
     "webpack-sources": "^1.1.0"
   },

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,10 +1,4 @@
-const {
-  render,
-  Header,
-  importComponent,
-  Miss,
-  Status,
-} = require('@untool/react/lib/runtime');
+const { render, Header, importComponent, Miss, Status } = require('untool');
 const ServerDataContext = require('./server-data/context');
 const withServerData = require('./server-data/with-server-data');
 

--- a/packages/react/mixin.core.js
+++ b/packages/react/mixin.core.js
@@ -1,9 +1,12 @@
 const { Mixin } = require('hops-mixin');
+const {
+  internal: { babelPlugin },
+} = require('untool');
 
 const getPluginName = plugin => (Array.isArray(plugin) ? plugin[0] : plugin);
 const getPluginConfig = plugin => (Array.isArray(plugin) ? plugin[1] : {});
-const isBabelPlugin = name => plugin =>
-  require.resolve(getPluginName(plugin)) === require.resolve(name);
+const isBabelPlugin = path => plugin =>
+  require.resolve(getPluginName(plugin)) === path;
 
 class ReactCoreMixin extends Mixin {
   configureBuild(webpackConfig, { jsLoaderConfig }) {
@@ -13,13 +16,13 @@ class ReactCoreMixin extends Mixin {
     );
 
     const untoolPluginIndex = jsLoaderConfig.options.plugins.findIndex(
-      isBabelPlugin('@untool/react/lib/babel')
+      isBabelPlugin(babelPlugin.path)
     );
 
     const untoolPlugin = jsLoaderConfig.options.plugins[untoolPluginIndex];
 
     jsLoaderConfig.options.plugins[untoolPluginIndex] = [
-      require.resolve('@untool/react/lib/babel'),
+      babelPlugin.path,
       {
         ...getPluginConfig(untoolPlugin),
         module: 'hops',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,9 +21,8 @@
     "@babel/core": "^7.4.0",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/plugin-transform-flow-strip-types": "^7.4.0",
-    "@untool/core": "^1.6.2",
-    "@untool/react": "^1.6.2",
-    "hops-mixin": "^11.6.1"
+    "hops-mixin": "^11.6.1",
+    "untool": "^1.6.2"
   },
   "peerDependencies": {
     "react": "^16.4.0",

--- a/packages/react/preset.js
+++ b/packages/react/preset.js
@@ -1,7 +1,6 @@
 const { join } = require('path');
 
 module.exports = {
-  presets: ['@untool/react'],
   mixins: [
     __dirname,
     join(__dirname, 'server-data'),

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
   },
   "packageRules": [
     {
-      "packagePatterns": ["^@untool/"],
-      "groupName": "Update untool monorepo packages"
-    },
-    {
       "semanticCommitType": "fix",
       "semanticCommitScope": "dependencies",
       "depTypeList": ["dependencies", "peerDependencies"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -12127,6 +12127,19 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+untool@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/untool/-/untool-1.6.2.tgz#9b2efcd2bdb79af3fdb263fa1d8b9ba635f67b44"
+  integrity sha512-0FVMHgtDJzFjnaMYCQ4mi9ptzl3VnK+2uenVs8cHc2S32he/h6xwBVZ/kFF2kc6C3L0Qu2CxISCdjgvx4fEMpg==
+  dependencies:
+    "@untool/core" "^1.6.2"
+    "@untool/express" "^1.6.2"
+    "@untool/info" "^1.6.2"
+    "@untool/react" "^1.6.2"
+    "@untool/webpack" "^1.6.2"
+    "@untool/yargs" "^1.6.2"
+    mixinable "^4.0.0"
+
 upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"


### PR DESCRIPTION
With this commit we replace all occurrences of @untool/* packages with
the special `untool` dist package to ensure Hops has only a single
dependency to untool.