### PR TITLE
fix(development-proxy): allow empty proxy targets in config

### DIFF
--- a/packages/development-proxy/preset.js
+++ b/packages/development-proxy/preset.js
@@ -12,10 +12,18 @@ module.exports = {
           patternProperties: {
             '^/': {
               oneOf: [
+                { type: 'string', maxLength: 0 },
                 { type: 'string', format: 'uri' },
                 {
                   type: 'object',
-                  properties: { target: { type: 'string', format: 'uri' } },
+                  properties: {
+                    target: {
+                      oneOf: [
+                        { type: 'string', maxLength: 0 },
+                        { type: 'string', format: 'uri' },
+                      ],
+                    },
+                  },
                 },
               ],
             },


### PR DESCRIPTION
## Current state

We allow the proxy target to be empty in order to support a case where the proxy can get optionally enabled by providing an environment variable.

Example:
```js
  proxy: {
    '/my/api': '[PROXY_URL]',
  },
```

But that produces the following warning:
```
crate:warning Invalid configuration value(s) detected:
- config.proxy should be string
- config.proxy['/my/api'] should match format "uri"
- config.proxy['/my/api'] should be object
- config.proxy['/my/api'] should match exactly one schema in oneOf
- config.proxy should match exactly one schema in oneOf
```

## Changes introduced here

An empty string is also valid now.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)

