### PR TITLE
fix(graphql): do not require mock schema file

### DIFF
--- a/packages/graphql/preset.js
+++ b/packages/graphql/preset.js
@@ -18,7 +18,6 @@ module.exports = {
     },
     graphqlMockSchemaFile: {
       type: 'string',
-      absolutePath: true,
     },
     graphqlMockServerPath: {
       type: 'string',


### PR DESCRIPTION
...to be an absolute path, because it is consumed via `require.resolve`
and can thus be a module identifier, too.