### PR TITLE
[WIP]: Resolve webpack externals relative to their context

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -31,6 +31,7 @@
     "graphql-tools": "^4.0.0",
     "hops-config": "^11.6.2",
     "hops-mixin": "^11.6.2",
+    "resolve-from": "^5.0.0",
     "strip-indent": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Sometimes externals are inside nested `node_modules` folders, for example,
if `apollo-server-express` is not in the top-level
`node_modules` folder, but instead in
`node_modules/hops-graphql/apollo-server-express`.

Before this change we would just declare them as externals and then the 
node process would try to `require('apollo-server-express')` which does not
work, because `apollo-server-express` is deeper nested. Therefore the
`require` should look like this:
`require('hops-graphql/node_modules/apollo-server-express')` in order to
actually resolve to the package.

This commit changes the externals definitions from simple strings to a 
function which does exactly that.