### PR TITLE
fix(postcss): filter conflicting order warnings

### DIFF
--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -1,6 +1,7 @@
 const postcssImportPlugin = require('postcss-import');
 const postcssPresetEnv = require('postcss-preset-env');
 const ExtractCSSPlugin = require('mini-css-extract-plugin');
+const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin');
 const { Mixin } = require('hops-mixin');
 const { join, trimSlashes } = require('pathifist');
@@ -88,6 +89,11 @@ class PostCSSMixin extends Mixin {
       getCSSLoaderConfig(this.config.browsers, ExtractCSSPlugin.loader)
     );
 
+    webpackConfig.plugins.unshift(
+      new FilterWarningsPlugin({
+        exclude: /\[mini-css-extract-plugin\][^]*Conflicting order between:/,
+      })
+    );
     webpackConfig.plugins.push(
       new ExtractCSSPlugin({
         filename: getAssetPath(

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -27,7 +27,8 @@
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.0.0",
     "style-loader": "^0.23.0",
-    "webpack": "^4.23.0"
+    "webpack": "^4.23.0",
+    "webpack-filter-warnings-plugin": "^1.2.1"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/postcss#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12452,6 +12452,11 @@ webpack-dev-middleware@^3.1.0:
     range-parser "^1.0.3"
     webpack-log "^2.0.0"
 
+webpack-filter-warnings-plugin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz#dc61521cf4f9b4a336fbc89108a75ae1da951cdb"
+  integrity sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==
+
 webpack-hot-middleware@^2.22.2:
   version "2.24.4"
   resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.24.4.tgz#0ae1eeca000c6ffdcb22eb574d0e6d7717672b0f"


### PR DESCRIPTION
...since they should not be relevant in the context of scoped CSS
modules. For more informations check out [sokra's comment](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-415345126)
and the surrounding content of the issue.