### PR TITLE
fix(template): Fix jest bugs in react template

### DIFF
--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -25,7 +25,9 @@
     "react-router-dom": "^5.0.0"
   },
   "devDependencies": {
-    "jest": "^23.4.2",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^24.8.0",
+    "jest": "^24.8.0",
     "jest-preset-hops": "^11.7.1",
     "react-test-renderer": "^16.4.2"
   },


### PR DESCRIPTION
This pull request closes issue # (_put the issue number here_)

<!-- This is a template. Feel free to remove the parts you do not need! Start with this line, for example -->

## Current state

```npm init hops-app my-hops-app```
```cd my-hops-app```
```npm test```

```ssh
Requires Babel "^7.0.0-0", but was loaded with "6.26.3". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading th
e wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel.
```

## Changes introduced here

How to fix:
`npx babel-upgrade --write --install`
`npm audit fix --force`

> **NOTE** And commit `pakage-lock.json` or `yarn.lock` to git for keeping versions locked and not introduce unexpected errors for end users

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [x] Necessary unit tests are added in order to ensure correct behavior
- [x] Documentation has been added
