### PR TITLE
chore: add scope "dependencies" to allowed commitlint scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
         2,
         "always",
         [
+          "dependencies",
           "config",
           "create-hops-app",
           "development-proxy",


### PR DESCRIPTION
This is needed for renovate, which commits with
`fix(dependencies): xxx` or
`chore(dependencies): xxx`.