### PR TITLE
chore: remove pinned ts-loader workaround from canarist

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,7 @@
           "yarn test"
         ]
       }
-    ],
-    "rootManifest": {
-      "resolutions": {
-        "ts-loader": "5.3.3"
-      }
-    }
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
With this we can remove the workaround from untool:
https://github.com/untool/untool/blob/master/package.json#L95-L99