### PR TITLE
Improve renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true
   },
   "semanticCommitType": "chore",
-  "semanticCommitScope": "dependencies",
+  "semanticCommitScope": null,
   "packageRules": [
     {
       "packagePatterns": ["^@untool/"],
@@ -15,8 +15,7 @@
     },
     {
       "depTypeList": ["dependencies", "peerDependencies"],
-      "semanticCommitType": "fix",
-      "semanticCommitScope": "dependencies"
+      "semanticCommitType": "fix"
     },
     {
       "depTypeList": ["peerDependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "packageRules": [
     {
       "packagePatterns": ["^@untool/"],
+      "packageNames": ["untool"],
       "groupName": "Update untool monorepo packages"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", "schedule:nonOfficeHours"],
+  "extends": ["config:base"],
   "pinVersions": false,
   "prCreation": "not-pending",
   "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "dependencies",
   "packageRules": [
     {
       "packagePatterns": ["^@untool/"],
@@ -12,11 +14,18 @@
       "groupName": "Update untool monorepo packages"
     },
     {
+      "depTypeList": ["dependencies", "peerDependencies"],
       "semanticCommitType": "fix",
-      "semanticCommitScope": "dependencies",
-      "depTypeList": ["dependencies", "peerDependencies"]
+      "semanticCommitScope": "dependencies"
+    },
+    {
+      "depTypeList": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "updateTypes": ["major", "minor"],
+      "rangeStrategy": "bump"
     }
-  ],
-  "semanticCommitType": "chore",
-  "semanticCommitScope": "dependencies"
+  ]
 }


### PR DESCRIPTION
Pimp our renovate config with more specific rules:

- add "untool" as package to the untool monorepo group filter
- **peerDependencies** should be "widened (ie: `"react": "15 || 16"` instead of upgrading to `16`)
- **devDependencies** should be bumped (ie: an update from `prettier@^1.0.0` to `prettier@1.1.0` which would normally fall under our version range, should be updated to the new range: `"prettier": "^1.1.0"`)
- **devDependencies in the root `package.json`** should be auto merged if they are a minor or patch upgrade