### PR TITLE
fix: rename "browsers" option for postcss to silence deprecation warning

### DIFF
--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -39,6 +39,9 @@ const getCSSLoaderConfig = (browsers, additionalLoader) => {
             postcssImportPlugin(),
             postcssPresetEnv({
               browsers,
+              autoprefixer: {
+                overrideBrowserslist: browsers,
+              },
               stage: 2,
               features: {
                 'nesting-rules': true,


### PR DESCRIPTION
![browserslist](https://user-images.githubusercontent.com/249542/59366270-5da19180-8d3a-11e9-81bf-9922f9dab3cf.png)
