### PR TITLE
Return error

### DIFF
--- a/packages/graphql/mixin.server.js
+++ b/packages/graphql/mixin.server.js
@@ -29,7 +29,7 @@ const wrapNetworkError = error => {
   const fetchError = Object.assign(new Error(message), {
     response: error.networkError.response,
   });
-  throw fetchError;
+  return fetchError;
 };
 
 class GraphQLMixin extends Mixin {

--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -57,4 +57,14 @@ describe('graphql development client', () => {
       expect(text).toContain('<pre>Error: Bad Request');
     });
   });
+
+  describe('/blocked', () => {
+    it('should render a 500 error page for status 429 response', async () => {
+      const response = await fetch(`${url}blocked`);
+      const text = await response.text();
+
+      expect(response.status).toBe(500);
+      expect(text).toContain('<pre>Error: Too Many Request');
+    });
+  });
 });

--- a/packages/spec/integration/graphql/index.js
+++ b/packages/spec/integration/graphql/index.js
@@ -65,6 +65,11 @@ const App = () => (
       render={() => <TestQuery suffix="failed" />}
     />
     <Route
+      path="/blocked"
+      exact={true}
+      render={() => <TestQuery suffix="blocked" />}
+    />
+    <Route
       path="/erroneous"
       exact={true}
       render={() => <TestQuery suffix="erroneous" />}

--- a/packages/spec/integration/graphql/mixin.core.js
+++ b/packages/spec/integration/graphql/mixin.core.js
@@ -49,6 +49,11 @@ class GraphQlMixin extends Mixin {
       method: 'post',
       handler: (_, res) => res.send('<h1>Moini!</h1>'),
     });
+    middlewares.initial.push({
+      path: '/graphql/blocked',
+      method: 'post',
+      handler: (_, res) => res.status(429).send('Too many requests'),
+    });
 
     return app;
   }


### PR DESCRIPTION
`wrapNetworkError` should return the error instead of throwing it.

Thanks @herschel666 

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [x] Necessary unit tests are added in order to ensure correct behavior
