### PR TITLE
fix(styled-components): temporarily restrict babel plugin version

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "babel-plugin-styled-components": "^1.9.2",
+    "babel-plugin-styled-components": ">= 1.9.2 < 1.10.3",
     "hops-mixin": "^11.8.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,7 +3053,7 @@ babel-plugin-jest-hoist@^23.2.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.9.2:
+"babel-plugin-styled-components@>= 1", "babel-plugin-styled-components@>= 1.9.2 < 1.10.3":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.2.tgz#0d9af9521ec99cf8e14182685162e09b119de176"
   integrity sha512-gA67BkMbddFPkTjD2bBe7zE6NNEUNK/7A4uDxwSigA3h1+sL2b6mWhxPu9a5DKf+3TvmdoxvtJ4me2NE7k66Ng==


### PR DESCRIPTION
The `babel-plugin-styled-components` introduced a bug in v1.10.3 which
causes our builds to get stuck endlessly.

This commit temporarily restricts the version range of the babel plugin
to the safe versions until the bug is fixed upstream.

See this PR and its linked issue for more details:
https://github.com/styled-components/babel-plugin-styled-components/pull/233