### PR TITLE
chore(development-proxy): remove non-existing routes option

### DIFF
--- a/packages/development-proxy/mixin.core.js
+++ b/packages/development-proxy/mixin.core.js
@@ -56,7 +56,7 @@ class ProxyMixin extends Mixin {
       debug('Using proxy object version', proxyConfig);
 
       Object.entries(proxyConfig).forEach(([path, config]) => {
-        const { target, routes } =
+        const { target } =
           typeof config === 'string' ? { target: config } : config;
 
         if (target === '') {
@@ -72,7 +72,6 @@ class ProxyMixin extends Mixin {
           proxy(path, {
             ...options,
             target,
-            routes,
           })
         );
       });


### PR DESCRIPTION
The http-proxy-middleware option is called [`router`](https://github.com/chimurai/http-proxy-middleware#http-proxy-middleware-options) not `routes`.
But as that feature isn't documented nor in use I propose to just delete it for now.