### PR TITLE
feat(typescript): make typescript a peer dependency

### DIFF
--- a/packages/spec/integration/typescript/tsconfig.json
+++ b/packages/spec/integration/typescript/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "jsx": "react",
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
-  }
+  "extends": "hops-typescript/tsconfig.json"
 }

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -11,7 +11,7 @@ This is a [preset for Hops](https://github.com/xing/hops/tree/master#presets) th
 Add this preset to your existing Hops React project:
 
 ```bash
-npm install --save hops-typescript
+npm install --save hops-typescript typescript
 ```
 
 If you don't already have an existing Hops project read this section [on how to set up your first Hops project.](https://github.com/xing/hops/tree/master#quick-start)
@@ -32,11 +32,9 @@ Example:
 
 ```json
 {
-  "extends": "./node_modules/hops-typescript/tsconfig.json"
+  "extends": "hops-typescript/tsconfig.json"
 }
 ```
-
-Unfortunately `"extends"` only supports file relative paths at the moment. See https://github.com/Microsoft/TypeScript/issues/18865 for more information.
 
 ### Using static assets
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,8 +16,13 @@
   },
   "dependencies": {
     "hops-mixin": "^11.9.0",
-    "ts-loader": "^6.0.0",
-    "typescript": "^3.2.1"
+    "ts-loader": "^6.0.0"
+  },
+  "peerDependencies": {
+    "typescript": "^3.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^3.2.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/typescript#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12686,7 +12686,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.1:
+typescript@^3.2.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==


### PR DESCRIPTION
BREAKING CHANGE:

In order to improve flexibility we changed TypeScript to be a peer dependency now.
Please install at least v3.6.0 of the `typescript` package.
