### PR TITLE
alias core-js in jest-preset to correct version

### DIFF
--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "^7.7.0",
     "babel-jest": "^24.9.0",
     "babel-plugin-dynamic-import-node": "^2.3.0",
+    "core-js": "^3.2.1",
     "hops": "^12.0.0-alpha.5",
     "identity-obj-proxy": "^3.0.0",
     "jest-config": "^24.9.0",

--- a/packages/jest-preset/transforms/babel.js
+++ b/packages/jest-preset/transforms/babel.js
@@ -1,4 +1,5 @@
-var babelJest = require('babel-jest');
+const babelJest = require('babel-jest');
+const { dirname } = require('path');
 
 module.exports = babelJest.createTransformer({
   presets: [
@@ -14,6 +15,7 @@ module.exports = babelJest.createTransformer({
     '@babel/preset-react',
   ],
   plugins: [
+    pluginRenameCoreJS,
     require.resolve('../helpers/babel-plugin-import-component'),
     require.resolve('@babel/plugin-transform-flow-strip-types'),
     require.resolve('babel-plugin-dynamic-import-node'),
@@ -21,3 +23,34 @@ module.exports = babelJest.createTransformer({
   ],
   babelrc: false,
 });
+
+function pluginRenameCoreJS() {
+  function replaceSource(source) {
+    source.value = source.value.replace(
+      /^core-js/,
+      dirname(require.resolve('core-js/package.json'))
+    );
+  }
+
+  function isRequire(path) {
+    if (!path.get('callee').isIdentifier({ name: 'require' })) return false;
+    if (path.node.arguments.length === 0) return false;
+    if (!path.get('arguments.0').isStringLiteral()) return false;
+    return true;
+  }
+
+  const visitor = {
+    ImportDeclaration(path) {
+      replaceSource(path.node.source);
+    },
+    CallExpression(path) {
+      if (isRequire(path)) {
+        replaceSource(path.node.arguments[0]);
+      }
+    },
+  };
+
+  return {
+    visitor,
+  };
+}


### PR DESCRIPTION
Not sure if we should wait for https://github.com/babel/babel/pull/10146
to be released until we release this?