### PR TITLE
feat(react): provide hooks for config & server-data contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,11 +599,19 @@ Similarily, to test the `error`-state of the lazy-loading placeholder component,
 
 A component wrapped with this HoC (higher order component) will receive a prop called `config` which contains all [settings](#settings). Use this to pass custom settings to your application, for example to [make environment variables available](#environment-variables).
 
+###### `useConfig(): Config`
+
+React hook for accessing the `config`-property from inside a functional component.
+
 ###### `withServerData(Component)`
 
 A component wrapped with this HoC gets access to "server data" via a prop called `serverData` which is useful to share data from code that runs on the server to the front-end.
 
 This HoC is usually only useful for implementers of additional Hops presets.
+
+###### `useServerData(): ServerData`
+
+React hook for accessing the `serverData`-property from inside a functional component.
 
 ##### Options
 

--- a/packages/hops/lib/runtime.d.ts
+++ b/packages/hops/lib/runtime.d.ts
@@ -57,13 +57,17 @@ declare module 'hops' {
 
   export const ConfigContext: React.Context<Config>;
 
-  export function withServerData<P, C = ServerData,>(
+  export function withServerData<P, C = ServerData>(
     Component: React.ComponentType<P & { serverData: C }>
   ): React.ComponentType<P>;
+
+  export function useServerData<C = ServerData>(): C;
 
   export function withConfig<P, C = Config>(
     Component: React.ComponentType<P & { config: C }>
   ): React.ComponentType<P>;
+
+  export function useConfig<C = Config>(): C;
 
   export class Mixin {}
 

--- a/packages/hops/lib/runtime.js
+++ b/packages/hops/lib/runtime.js
@@ -8,8 +8,10 @@ const {
   Status,
   ServerDataContext,
   withServerData,
+  useServerData,
   ConfigContext,
   withConfig,
+  useConfig,
 } = require('hops-react');
 
 const { Mixin, strategies } = require('hops-mixin');
@@ -22,8 +24,10 @@ module.exports = {
   render,
   ServerDataContext,
   withServerData,
+  useServerData,
   ConfigContext,
   withConfig,
+  useConfig,
   Mixin,
   strategies,
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,9 +51,13 @@ This side-effect component can be used to set specific HTTP status codes for ser
 
 Wrap your component with this HoC to get access to the prop `serverData` which contains all values of mixins that have implemented the `enhanceServerData` hook.
 
+##### `useServerData(): ServerData`
+
+React hook for accessing the `serverData`-property from inside a functional component.
+
 ##### `<ServerDataContext.Consumer>{data => /* render something */}</ServerDataContext.Consumer>`
 
-If you don't want to use the above mentioned HoC you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
+If you don't want to use the above mentioned HoC or React hook you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
 
 ### Configuration
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,7 +57,19 @@ React hook for accessing the `serverData`-property from inside a functional comp
 
 ##### `<ServerDataContext.Consumer>{data => /* render something */}</ServerDataContext.Consumer>`
 
-If you don't want to use the above mentioned HoC or React hook you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook.
+If you don't want to use the above mentioned HoC or React hook you can also use this React Context consumer instead. It will accept a function as a child component and pass the `serverData` object to it. You can also use `ServerDataContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in the [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) React hook.
+
+##### `withConfig(Component): HigherOrderComponent`
+
+Wrap your component with this HoC to get access to the prop `config` which contains all [settings](https://github.com/xing/hops#settings).
+
+##### `useConfig(): Config`
+
+React hook for accessing the `config`-property from inside a functional component.
+
+##### `<ConfigContext.Consumer>{data => /* render something */}</ConfigContext.Consumer>`
+
+If you don't want to use the above mentioned HoC or React hook you can also use this React Context consumer instead. It will accept a function as a child component and pass the `config` object to it. You can also use `ConfigContext` as [`contextType`](https://reactjs.org/docs/context.html#classcontexttype) or in the [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) React hook.
 
 ### Configuration
 

--- a/packages/react/config/use-config.js
+++ b/packages/react/config/use-config.js
@@ -1,0 +1,8 @@
+const React = require('react');
+const ConfigContext = require('./context');
+
+function useConfig() {
+  return React.useContext(ConfigContext);
+}
+
+module.exports = useConfig;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -7,9 +7,11 @@ const {
 } = require('@untool/react/lib/runtime');
 const ServerDataContext = require('./server-data/context');
 const withServerData = require('./server-data/with-server-data');
+const useServerData = require('./server-data/use-server-data');
 
 const ConfigContext = require('./config/context');
 const withConfig = require('./config/with-config');
+const useConfig = require('./config/use-config');
 
 module.exports = {
   Header,
@@ -19,6 +21,8 @@ module.exports = {
   render,
   ServerDataContext,
   withServerData,
+  useServerData,
   ConfigContext,
   withConfig,
+  useConfig,
 };

--- a/packages/react/server-data/use-server-data.js
+++ b/packages/react/server-data/use-server-data.js
@@ -1,0 +1,8 @@
+const React = require('react');
+const ServerDataContext = require('./context');
+
+function useServerData() {
+  return React.useContext(ServerDataContext);
+}
+
+module.exports = useServerData;

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -72,15 +72,18 @@ describe('react development server', () => {
     await page.close();
   });
 
-  it('passes server data through context', async () => {
-    const { page, getInnerText } = await createPage();
-    await page.goto(url);
+  it.each(['hook', 'hoc'])(
+    'passes server data through the %s',
+    async approach => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(urlJoin(url, `/server-data-${approach}`));
 
-    const method = await getInnerText('output');
-    expect(method).toBe('GET');
+      const method = await getInnerText('output');
+      expect(method).toBe('GET');
 
-    await page.close();
-  });
+      await page.close();
+    }
+  );
 
   it('allows to use flow', async () => {
     const text = await fetch(urlJoin(url, '/flow')).then(r => r.text());
@@ -106,22 +109,13 @@ describe('react development server', () => {
     await page.close();
   });
 
-  it('renders config with hoc', async () => {
+  it.each(['hook', 'hoc'])('renders config with %s', async approach => {
     const { page } = await createPage();
-    await page.goto(urlJoin(url, '/config-hoc'), { waitUntil: 'networkidle2' });
-
-    expect(await page.content()).toMatch('hoc-test-value');
-
-    await page.close();
-  });
-
-  it('passes config through context', async () => {
-    const { page } = await createPage();
-    await page.goto(urlJoin(url, '/config-context'), {
+    await page.goto(urlJoin(url, `/config-${approach}`), {
       waitUntil: 'networkidle2',
     });
 
-    expect(await page.content()).toMatch('context-test-value');
+    expect(await page.content()).toMatch(`${approach}-test-value`);
 
     await page.close();
   });

--- a/packages/spec/integration/react/index.js
+++ b/packages/spec/integration/react/index.js
@@ -3,25 +3,40 @@ import {
   importComponent,
   Miss,
   render,
-  ServerDataContext,
+  withServerData,
+  useServerData,
   Status,
-  ConfigContext,
   withConfig,
+  useConfig,
 } from 'hops';
 
 import React from 'react';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
 import FlowText from './flow-text';
+
 const Text = importComponent(() => import('./text'));
 
-const Config = withConfig(({ config: { hoc } }) => <h1>{hoc}</h1>);
+const ServerDataHoC = withServerData(({ serverData }) => (
+  <output>{serverData.method}</output>
+));
+
+const ServerDataHook = () => {
+  const serverData = useServerData();
+
+  return <output>{serverData.method}</output>;
+};
+
+const ConfigHoC = withConfig(({ config: { hoc } }) => <h1>{hoc}</h1>);
+
+const ConfigHook = () => {
+  const config = useConfig();
+
+  return <h1>{config.hook}</h1>;
+};
 
 export default render(
   <div>
     <Link to="/two">Link to two</Link>
-    <ServerDataContext.Consumer>
-      {({ method }) => <output>{method}</output>}
-    </ServerDataContext.Consumer>
     <Switch>
       <Route path="/" exact render={() => <h1>home</h1>} />
       <Route path="/two" exact render={() => <h1>two</h1>} />
@@ -34,16 +49,10 @@ export default render(
       />
       <Route path="/flow" exact render={() => <FlowText text="flow" />} />
       <Route path="/import" exact render={() => <Text text="imported" />} />
-      <Route path="/config-hoc" exact render={() => <Config />} />
-      <Route
-        path="/config-context"
-        exact
-        render={() => (
-          <ConfigContext.Consumer>
-            {({ context }) => <h1>{context}</h1>}
-          </ConfigContext.Consumer>
-        )}
-      />
+      <Route path="/server-data-hoc" exact component={ServerDataHoC} />
+      <Route path="/server-data-hook" exact component={ServerDataHook} />
+      <Route path="/config-hoc" exact component={ConfigHoC} />
+      <Route path="/config-hook" exact component={ConfigHook} />
       <Miss />
     </Switch>
   </div>

--- a/packages/spec/integration/react/package.json
+++ b/packages/spec/integration/react/package.json
@@ -10,10 +10,10 @@
       "./"
     ],
     "hoc": "hoc-test-value",
-    "context": "context-test-value",
+    "hook": "hook-test-value",
     "browserWhitelist": {
       "hoc": true,
-      "context": true
+      "hook": true
     }
   },
   "jest": {


### PR DESCRIPTION
btw: why don't we lint files in `packages/spec`??

~~And I would propose to deprecate the exports of `ConfigContext` & `ServerDataContext` and eventually make them private in Hops 13. They're imho our private turf & users should not directly interact with them, but rather with the API wrappers we provide — HoCs & hooks.~~