### PR TITLE
feat(typescript): update typescript to v3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,12 @@
           "yarn test"
         ]
       }
-    ]
+    ],
+    "rootManifest": {
+      "resolutions": {
+        "styled-components" : "4.4.1"
+      }
+    }
   },
   "husky": {
     "hooks": {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -19,10 +19,10 @@
     "ts-loader": "^6.2.0"
   },
   "peerDependencies": {
-    "typescript": "^3.6.0"
+    "typescript": "^3.7.0"
   },
   "devDependencies": {
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/typescript#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12709,10 +12709,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.6.5"


### PR DESCRIPTION
FYI: I decided to make this an implicit, follow-up breaking change in order to not pollute the Hops 12 changelog with redundant messages. What do you think?