### PR TITLE
feat: create context extender api

### DIFF
--- a/packages/apollo-mock-server/context-extender.js
+++ b/packages/apollo-mock-server/context-extender.js
@@ -1,0 +1,1 @@
+module.exports = context => context;

--- a/packages/apollo-mock-server/lib/mock-server-middleware.js
+++ b/packages/apollo-mock-server/lib/mock-server-middleware.js
@@ -4,6 +4,8 @@ import express from 'express';
 import hopsConfig from 'hops-config';
 // eslint-disable-next-line node/no-extraneous-import
 import schema from 'hops-apollo-mock-server/schema';
+// eslint-disable-next-line node/no-extraneous-import
+import extendContext from 'hops-apollo-mock-server/context-extender';
 
 const apolloAppPromise = Promise.resolve(
   typeof schema === 'function' ? schema() : schema
@@ -18,7 +20,7 @@ const apolloAppPromise = Promise.resolve(
         'request.credentials': 'same-origin',
       },
     },
-    context: context => ({ ...context, config: hopsConfig }),
+    context: context => extendContext({ ...context, config: hopsConfig }),
   });
 
   server.applyMiddleware({

--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -52,6 +52,12 @@ class GraphQLMixin extends Mixin {
       ] = require.resolve(this.config.graphqlMockSchemaFile);
     }
 
+    if (exists(this.config.graphqlMockContextExtenderFile)) {
+      webpackConfig.resolve.alias[
+        'hops-apollo-mock-server/context-extender'
+      ] = require.resolve(this.config.graphqlMockContextExtenderFile);
+    }
+
     if (target === 'graphql-mock-server') {
       webpackConfig.externals.push(
         'apollo-server-express',

--- a/packages/apollo-mock-server/preset.js
+++ b/packages/apollo-mock-server/preset.js
@@ -17,5 +17,8 @@ module.exports = {
     graphqlMockServerPath: {
       type: 'string',
     },
+    graphqlMockContextExtenderFile: {
+      type: 'string',
+    },
   },
 };


### PR DESCRIPTION
This allows users of the mock server to extend the graphql context by a function.
