### PR TITLE
chore(apollo-mock-server): remove redundant warning

### DIFF
--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -1,4 +1,3 @@
-const { existsSync } = require('fs');
 const { Mixin } = require('hops-mixin');
 const {
   internal: { createWebpackMiddleware, StatsFilePlugin },
@@ -78,12 +77,6 @@ class GraphQLMixin extends Mixin {
 
   diagnose({ detectDuplicatePackages }) {
     detectDuplicatePackages('graphql');
-    if (!existsSync(this.config.fragmentsFile)) {
-      return [
-        `Could not find a graphql introspection query result at "${this.config.fragmentsFile}".`,
-        'You might need to execute "hops graphql introspect"',
-      ];
-    }
   }
 }
 


### PR DESCRIPTION
This check is also happening in `hops-react-apollo`, where the command for executing the introspection query is located, too.