### PR TITLE
Typescript changes

### DIFF
--- a/packages/spec/integration/typescript/package.json
+++ b/packages/spec/integration/typescript/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "hops": "*",
-    "hops-typescript": "*"
+    "hops-typescript": "*",
+    "typescript": "*"
   }
 }

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -26,7 +26,7 @@ Check out this [integration test](https://github.com/xing/hops/tree/master/packa
 
 The only required configuration is a `tsconfig.json` in your project root.
 
-This preset contains a [minimal `tsconfig.json`](https://github.com/xing/hops/blob/master/packages/typescript/tsconfig.json) file which you can extend or overwrite in your tsconfig.json:
+This preset contains a [minimal `tsconfig.json`](https://github.com/xing/hops/blob/master/packages/typescript/tsconfig.json) file which we recommend you extend in your `tsconfig.json`:
 
 Example:
 
@@ -35,6 +35,8 @@ Example:
   "extends": "hops-typescript/tsconfig.json"
 }
 ```
+
+Whether you extend the given TS config or completely provide your own — please take care to not overwrite the properties `compilerOptions.moduleResolution` and `compilerOptions.target`, because those are vital for Hops to work properly!
 
 ### Using static assets
 

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -5,8 +5,12 @@ const { Mixin } = require('hops-mixin');
 const chalk = require('chalk');
 
 class TypescriptMixin extends Mixin {
-  configureBuild(webpackConfig, { jsLoaderConfig, allLoaderConfigs }) {
+  configureBuild(webpackConfig, { jsLoaderConfig, allLoaderConfigs }, target) {
     const { loader, options, exclude } = jsLoaderConfig;
+    const targetDevelop = target === 'develop';
+    const compilerOptions = targetDevelop
+      ? { compilerOptions: { isolatedModules: true } }
+      : undefined;
 
     allLoaderConfigs.unshift({
       test: /\.tsx?$/,
@@ -18,6 +22,10 @@ class TypescriptMixin extends Mixin {
         },
         {
           loader: require.resolve('ts-loader'),
+          options: {
+            ...compilerOptions,
+            transpileOnly: targetDevelop,
+          },
         },
       ],
     });

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -43,6 +43,21 @@ class TypescriptMixin extends Mixin {
 {cyan ${tsConfigContent}}
 `;
     }
+
+    const hopsTsConfig = require(join(__dirname, 'tsconfig.json'));
+    const tsConfig = require(tsConfigPath);
+
+    for (let property of ['target', 'moduleResolution']) {
+      if (
+        tsConfig.compilerOptions &&
+        tsConfig.compilerOptions[property] !==
+          hopsTsConfig.compilerOptions[property]
+      ) {
+        return chalk.red(
+          `Please do not overwrite the value "compilerOptions.${property}" in your "tsconfig.json", otherwise Hops will not work as expected.`
+        );
+      }
+    }
   }
 }
 

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -1,6 +1,8 @@
 const { existsSync } = require('fs');
 const { join } = require('path');
 const { Mixin } = require('hops-mixin');
+// eslint-disable-next-line node/no-unpublished-require
+const chalk = require('chalk');
 
 class TypescriptMixin extends Mixin {
   configureBuild(webpackConfig, { jsLoaderConfig, allLoaderConfigs }) {
@@ -23,14 +25,23 @@ class TypescriptMixin extends Mixin {
   }
 
   diagnose() {
-    const tsConfigPath = join(this.config.rootDir, 'tsconfig.json');
-    /* eslint-disable node/no-extraneous-require */
-    const exampleTsConfigPath = require.resolve(
-      'hops-typescript/tsconfig.json'
-    );
-    /* eslint-enable node/no-extraneous-require */
+    const { rootDir } = this.config;
+    const tsConfigPath = join(rootDir, 'tsconfig.json');
+
     if (!existsSync(tsConfigPath)) {
-      return `No "tsconfig.json" file found in your project root directory ("${this.config.rootDir}").\nAs a starting point you can copy our minimal example config file: "cp ${exampleTsConfigPath} ${this.config.rootDir}/tsconfig.json"`;
+      const tsConfigContent = JSON.stringify(
+        {
+          extends: 'hops-typescript/tsconfig.json',
+        },
+        null,
+        2
+      );
+
+      return chalk`
+{red No "tsconfig.json" file found in your project root directory ("${rootDir}").}
+{red To get started, create a "tsconfig.json" file in your project's root with the following content:}
+{cyan ${tsConfigContent}}
+`;
     }
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -22,6 +22,7 @@
     "typescript": "^3.7.0"
   },
   "devDependencies": {
+    "chalk": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/typescript#readme"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -2847,6 +2852,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
+  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -3969,6 +3982,14 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -4132,12 +4153,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==


### PR DESCRIPTION
- strongly recommend to extend `hops-typescript`'s `tsconfig.json`
- check, that the `compilerOptions` `target`- and `moduleResolution`-properties aren't overwritten by the user
- speed up incremental builds by setting `transpileOnly` and `compilerOptions.isolatedModules` to `true` for the dev-server

I'm overall not happy with how the checks are done in the `diagnosis()`-hook & don't lead to an error. Does anyone have a good idea to improve that?

Also the `transpileOnly`-feature doesn't lead to `compilerOptions.isolatedModules` being set to `true` anymore since [this PR](https://github.com/TypeStrong/ts-loader/pull/569), that apparently fixed [this issue](https://github.com/TypeStrong/ts-loader/issues/568). Maybe we don't want to enable it either, but I'm not able to decide this now. 😑