### PR TITLE
Fix graphql tag loader

### DIFF
--- a/packages/apollo-mock-server/README.md
+++ b/packages/apollo-mock-server/README.md
@@ -8,10 +8,10 @@ This is a [preset for Hops](https://github.com/xing/hops/tree/master#presets) in
 
 ### Installation
 
-Add this preset to your existing Hops React project:
+Add this preset and its peer dependency `graphql-tag` to your existing Hops React project:
 
 ```bash
-npm install --save hops-apollo-mock-server
+npm install --save hops-apollo-mock-server graphql-tag
 ```
 
 If you don't already have an existing Hops project read this section [on how to set up your first Hops project.](https://github.com/xing/hops/tree/master#quick-start)

--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -34,10 +34,14 @@ class GraphQLMixin extends Mixin {
   configureBuild(webpackConfig, loaderConfigs, target) {
     const { allLoaderConfigs } = loaderConfigs;
 
-    allLoaderConfigs.splice(allLoaderConfigs.length - 1, 0, {
-      test: /\.(graphql|gql)$/,
-      loader: 'graphql-tag/loader',
-    });
+    if (
+      !allLoaderConfigs.find(({ loader }) => loader === 'graphql-tag/loader')
+    ) {
+      allLoaderConfigs.splice(allLoaderConfigs.length - 1, 0, {
+        test: /\.(graphql|gql)$/,
+        loader: 'graphql-tag/loader',
+      });
+    }
 
     webpackConfig.externals.push('encoding');
 

--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -32,6 +32,13 @@ class GraphQLMixin extends Mixin {
   }
 
   configureBuild(webpackConfig, loaderConfigs, target) {
+    const { allLoaderConfigs } = loaderConfigs;
+
+    allLoaderConfigs.splice(allLoaderConfigs.length - 1, 0, {
+      test: /\.(graphql|gql)$/,
+      loader: 'graphql-tag/loader',
+    });
+
     webpackConfig.externals.push('encoding');
 
     if (process.env.NODE_ENV === 'production') {

--- a/packages/apollo-mock-server/package.json
+++ b/packages/apollo-mock-server/package.json
@@ -30,5 +30,11 @@
     "hops-config": "^12.0.0-alpha.5",
     "hops-mixin": "^12.0.0-alpha.5"
   },
+  "peerDependencies": {
+    "graphql-tag": "^2.10.0"
+  },
+  "devDependencies": {
+    "graphql-tag": "^2.10.1"
+  },
   "homepage": "https://github.com/xing/hops/tree/master/packages/graphql#readme"
 }

--- a/packages/react-apollo/mixin.core.js
+++ b/packages/react-apollo/mixin.core.js
@@ -6,10 +6,14 @@ class GraphQLMixin extends Mixin {
   configureBuild(webpackConfig, loaderConfigs) {
     const { allLoaderConfigs } = loaderConfigs;
 
-    allLoaderConfigs.splice(allLoaderConfigs.length - 1, 0, {
-      test: /\.(graphql|gql)$/,
-      loader: 'graphql-tag/loader',
-    });
+    if (
+      !allLoaderConfigs.find(({ loader }) => loader === 'graphql-tag/loader')
+    ) {
+      allLoaderConfigs.splice(allLoaderConfigs.length - 1, 0, {
+        test: /\.(graphql|gql)$/,
+        loader: 'graphql-tag/loader',
+      });
+    }
   }
 
   registerCommands(yargs) {


### PR DESCRIPTION
This fixes a bug introduced in #997 

The issue is that we also need the `graphql-tag` configuration for the mock server because otherwise we can't import a `schema.graphql` file.