### PR TITLE
fix(apollo-mock-server): let webpack know about the mock data file

### DIFF
--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -61,6 +61,12 @@ class GraphQLMixin extends Mixin {
       ] = require.resolve(this.config.graphqlMockContextExtenderFile);
     }
 
+    if (exists(this.config.graphqlMockDataFile)) {
+      webpackConfig.resolve.alias[
+        'hops-apollo-mock-server/mock-data'
+      ] = require.resolve(this.config.graphqlMockDataFile);
+    }
+
     if (target === 'graphql-mock-server') {
       webpackConfig.externals.push(
         'apollo-server-express',


### PR DESCRIPTION
Otherwise we can't import the file from within the webpack context.