### PR TITLE
test: correct test setup for windows

### DIFF
--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -113,11 +113,11 @@ class FixtureEnvironment extends NodeEnvironment {
 
   async teardown() {
     await super.teardown();
-    await this.removeWorkingDir();
     await this.closeBrowser();
     if (this.killServer) {
       await this.killServer();
     }
+    await this.removeWorkingDir();
   }
 }
 

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -26,9 +26,9 @@ const startServer = ({ cwd, command, argv = [] }) =>
 
     const hopsBin = resolveFrom(cwd, 'hops/bin');
 
-    const args = [command].concat(argv);
+    const args = [hopsBin, command].concat(argv);
     debug('Spawning server', [hopsBin, ...args].join(' '));
-    const started = spawn(hopsBin, args, {
+    const started = spawn(process.argv[0], args, {
       cwd,
     });
     const teardown = () => {


### PR DESCRIPTION
* The workdir of the tests can only be deleted if the server process is
terminated. Therefore we shift this cleanup to a later step.
* The spawned test process need to be run explicitly with node, since
shebangs are not valid in the windows world.
