### PR TITLE
test: fetch graphql data during ssr

### DIFF
--- a/packages/spec/integration/graphql-mock-server/package.json
+++ b/packages/spec/integration/graphql-mock-server/package.json
@@ -6,7 +6,7 @@
     "node": "^10.13 || ^12.13"
   },
   "hops": {
-    "shouldPrefetchOnServer": false,
+    "allowServerSideDataFetching": true,
     "port": "8029",
     "graphqlUri": "http://localhost:8029/graphql",
     "graphqlMockSchemaFile": "<rootDir>/mock-schema.js"


### PR DESCRIPTION
Apparently we have race conditions when we rely on the browser fetching
the graphql data in the untool canarist tests.
And since we test server and client-side fetching/rendering of graphql
data in the integration tests for graphql, we can switch to server-side
rendering in the graphql-mock-server-tests.

See: https://github.com/untool/untool/pull/523
and: https://travis-ci.org/untool/untool/jobs/633264357