### PR TITLE
test: add favicon to all test cases

### DIFF
--- a/packages/spec/integration/graphql-mock-server/index.js
+++ b/packages/spec/integration/graphql-mock-server/index.js
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 import { render } from 'hops';
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 import { Query } from 'react-apollo';
 
 const query = gql`
@@ -15,26 +16,31 @@ const query = gql`
 `;
 
 export default render(
-  <Query query={query}>
-    {({ loading, error, data: { chirpById } = {} }) => {
-      if (loading) return <strong id="loading">loading...</strong>;
-      if (error)
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <Query query={query}>
+      {({ loading, error, data: { chirpById } = {} }) => {
+        if (loading) return <strong id="loading">loading...</strong>;
+        if (error)
+          return (
+            <strong id="error">
+              Error: {error.message}
+              <pre>{JSON.stringify(error, null, 2)}</pre>
+            </strong>
+          );
         return (
-          <strong id="error">
-            Error: {error.message}
-            <pre>{JSON.stringify(error, null, 2)}</pre>
-          </strong>
+          <div>
+            <blockquote>
+              <p>{chirpById.text}</p>
+              <footer>
+                by <cite>{chirpById.author.email}</cite>
+              </footer>
+            </blockquote>
+          </div>
         );
-      return (
-        <div>
-          <blockquote>
-            <p>{chirpById.text}</p>
-            <footer>
-              by <cite>{chirpById.author.email}</cite>
-            </footer>
-          </blockquote>
-        </div>
-      );
-    }}
-  </Query>
+      }}
+    </Query>
+  </>
 );

--- a/packages/spec/integration/graphql/index.js
+++ b/packages/spec/integration/graphql/index.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import { render } from 'hops';
+import { Helmet } from 'react-helmet-async';
 import { Switch, Route } from 'react-router-dom';
 import React from 'react';
 import { Query } from 'react-apollo';
@@ -28,53 +29,58 @@ const commits = gql`
 `;
 
 const App = () => (
-  <Switch>
-    <Route
-      path="/"
-      exact={true}
-      render={() => (
-        <Query query={commits}>
-          {({ loading, error, data }) => {
-            if (loading) return <b id="loading">loading commits...</b>;
-            if (error) return <b id="error">Error: {error.message}</b>;
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <Switch>
+      <Route
+        path="/"
+        exact={true}
+        render={() => (
+          <Query query={commits}>
+            {({ loading, error, data }) => {
+              if (loading) return <b id="loading">loading commits...</b>;
+              if (error) return <b id="error">Error: {error.message}</b>;
 
-            if (!data.showCommits) {
-              return null;
-            }
-            return (
-              <ul id="commits">
-                {data.github.repo.commits.map(commit => (
-                  <li key={commit.sha}>
-                    {commit.message} by <b>{commit.author.login}</b>
-                  </li>
-                ))}
-              </ul>
-            );
-          }}
-        </Query>
-      )}
-    />
-    <Route
-      path="/html"
-      exact={true}
-      render={() => <TestQuery suffix="html" />}
-    />
-    <Route
-      path="/failed"
-      exact={true}
-      render={() => <TestQuery suffix="failed" />}
-    />
-    <Route
-      path="/blocked"
-      exact={true}
-      render={() => <TestQuery suffix="blocked" />}
-    />
-    <Route
-      path="/erroneous"
-      exact={true}
-      render={() => <TestQuery suffix="erroneous" />}
-    />
-  </Switch>
+              if (!data.showCommits) {
+                return null;
+              }
+              return (
+                <ul id="commits">
+                  {data.github.repo.commits.map(commit => (
+                    <li key={commit.sha}>
+                      {commit.message} by <b>{commit.author.login}</b>
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+          </Query>
+        )}
+      />
+      <Route
+        path="/html"
+        exact={true}
+        render={() => <TestQuery suffix="html" />}
+      />
+      <Route
+        path="/failed"
+        exact={true}
+        render={() => <TestQuery suffix="failed" />}
+      />
+      <Route
+        path="/blocked"
+        exact={true}
+        render={() => <TestQuery suffix="blocked" />}
+      />
+      <Route
+        path="/erroneous"
+        exact={true}
+        render={() => <TestQuery suffix="erroneous" />}
+      />
+    </Switch>
+  </>
 );
 
 export default render(<App />, {

--- a/packages/spec/integration/hops/index.js
+++ b/packages/spec/integration/hops/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { importComponent, render } from 'hops';
+import { Helmet } from 'react-helmet-async';
 
 const Text = importComponent('./text');
 
@@ -11,7 +12,14 @@ const renderText = ({ Component, loading, ...props }) => {
 };
 
 export function App() {
-  return <Text loader={loader} render={renderText} subject="world" />;
+  return (
+    <>
+      <Helmet>
+        <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+      </Helmet>
+      <Text loader={loader} render={renderText} subject="world" />
+    </>
+  );
 }
 
 export default render(<App />);

--- a/packages/spec/integration/hops/index.js
+++ b/packages/spec/integration/hops/index.js
@@ -12,14 +12,14 @@ const renderText = ({ Component, loading, ...props }) => {
 };
 
 export function App() {
-  return (
-    <>
-      <Helmet>
-        <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-      </Helmet>
-      <Text loader={loader} render={renderText} subject="world" />
-    </>
-  );
+  return <Text loader={loader} render={renderText} subject="world" />;
 }
 
-export default render(<App />);
+export default render(
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <App />
+  </>
+);

--- a/packages/spec/integration/hot-module-reload/index.js
+++ b/packages/spec/integration/hot-module-reload/index.js
@@ -1,3 +1,12 @@
 import { render } from 'hops';
 import React from 'react';
-export default render(<h1 id="one">hello</h1>);
+import { Helmet } from 'react-helmet-async';
+
+export default render(
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <h1 id="one">hello</h1>
+  </>
+);

--- a/packages/spec/integration/lambda/index.js
+++ b/packages/spec/integration/lambda/index.js
@@ -1,4 +1,12 @@
 import { render } from 'hops';
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
-export default render(<h1>hello lambda</h1>);
+export default render(
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <h1>hello lambda</h1>
+  </>
+);

--- a/packages/spec/integration/postcss/index.js
+++ b/packages/spec/integration/postcss/index.js
@@ -1,5 +1,6 @@
 import { render } from 'hops';
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 import styles from './styles.css';
 /* eslint-disable import/no-unresolved */
 import './global.css?global';
@@ -7,5 +8,10 @@ import 'animate.css/animate.min.css?global';
 /* eslint-enable import/no-unresolved */
 
 export default render(
-  <h1 className={`${styles.headline} fancy-headline animated`}>hello</h1>
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <h1 className={`${styles.headline} fancy-headline animated`}>hello</h1>
+  </>
 );

--- a/packages/spec/integration/pwa/index.js
+++ b/packages/spec/integration/pwa/index.js
@@ -10,6 +10,7 @@ installServiceWorker();
 export default render(
   <>
     <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
       <link rel="manifest" href={manifest} />
     </Helmet>
     <h1>hello</h1>

--- a/packages/spec/integration/react/index.js
+++ b/packages/spec/integration/react/index.js
@@ -12,6 +12,7 @@ import {
 
 import React from 'react';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import FlowText from './flow-text';
 
 const Text = importComponent(() => import('./text'));
@@ -35,25 +36,30 @@ const ConfigHook = () => {
 };
 
 export default render(
-  <div>
-    <Link to="/two">Link to two</Link>
-    <Switch>
-      <Route path="/" exact render={() => <h1>home</h1>} />
-      <Route path="/two" exact render={() => <h1>two</h1>} />
-      <Route path="/status" exact render={() => <Status code={418} />} />
-      <Route path="/redirect" exact render={() => <Redirect to="/two" />} />
-      <Route
-        path="/header"
-        exact
-        render={() => <Header name="X-Foo" value="Bar" />}
-      />
-      <Route path="/flow" exact render={() => <FlowText text="flow" />} />
-      <Route path="/import" exact render={() => <Text text="imported" />} />
-      <Route path="/server-data-hoc" exact component={ServerDataHoC} />
-      <Route path="/server-data-hook" exact component={ServerDataHook} />
-      <Route path="/config-hoc" exact component={ConfigHoC} />
-      <Route path="/config-hook" exact component={ConfigHook} />
-      <Miss />
-    </Switch>
-  </div>
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <div>
+      <Link to="/two">Link to two</Link>
+      <Switch>
+        <Route path="/" exact render={() => <h1>home</h1>} />
+        <Route path="/two" exact render={() => <h1>two</h1>} />
+        <Route path="/status" exact render={() => <Status code={418} />} />
+        <Route path="/redirect" exact render={() => <Redirect to="/two" />} />
+        <Route
+          path="/header"
+          exact
+          render={() => <Header name="X-Foo" value="Bar" />}
+        />
+        <Route path="/flow" exact render={() => <FlowText text="flow" />} />
+        <Route path="/import" exact render={() => <Text text="imported" />} />
+        <Route path="/server-data-hoc" exact component={ServerDataHoC} />
+        <Route path="/server-data-hook" exact component={ServerDataHook} />
+        <Route path="/config-hoc" exact component={ConfigHoC} />
+        <Route path="/config-hook" exact component={ConfigHook} />
+        <Miss />
+      </Switch>
+    </div>
+  </>
 );

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -2,6 +2,7 @@ import { render } from 'hops';
 import React from 'react';
 import { connect } from 'react-redux';
 import fetch from 'cross-fetch';
+import { Helmet } from 'react-helmet-async';
 
 const reducers = {
   counter(state = 0, action) {
@@ -49,11 +50,14 @@ const setMatchParam = (params, { match: { params: matchParams } }) => {
 };
 
 const Counter = ({ count, increment, val }) => (
-  <React.Fragment>
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
     <button onClick={increment}>+</button>
     <counter>{count}</counter>
     <value>{val}</value>
-  </React.Fragment>
+  </>
 );
 
 const ConnectedCounter = connect(

--- a/packages/spec/integration/styled-components/index.js
+++ b/packages/spec/integration/styled-components/index.js
@@ -1,9 +1,17 @@
 import { render } from 'hops';
 import React from 'react';
 import styled from 'styled-components';
+import { Helmet } from 'react-helmet-async';
 
 const H1 = styled.h1`
   position: sticky;
 `;
 
-export default render(<H1>hello</H1>);
+export default render(
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <H1>hello</H1>
+  </>
+);

--- a/packages/spec/integration/typescript/index.tsx
+++ b/packages/spec/integration/typescript/index.tsx
@@ -1,5 +1,6 @@
 import { render, importComponent } from 'hops';
 import * as React from 'react';
+import { Helmet } from 'react-helmet-async';
 
 import Headline from './headline';
 
@@ -7,6 +8,9 @@ const Content = importComponent(() => import('./content'));
 
 export default render(
   <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
     <Headline />
     <Content />
   </>

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -31,6 +31,7 @@
     "jest-environment-node": "^24.9.0",
     "mktemp": "^1.0.0",
     "puppeteer": "^2.0.0",
+    "react-helmet-async": "^1.0.4",
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "url-join": "^4.0.1"


### PR DESCRIPTION
This adds a favicon to all cases, since if run in debug mode
(with open browser window) a request for the favicon
is made. Since there is no favicon in the test, the request is
replied with a 404 warning.

In the spec test set, there is a check that there are no unknown
console output in the test cases.
Unfortunately the 404 favicon request does not report a
path for the favicon but just a generic 404 error. Therefore
we are not able to whitelist this message without risking
false positives in the test.

Adding an inline favicon supresses these requests entierly
getting around the above problem.
