### PR TITLE
fix(create-hops-app): remove @next bin workaround

### DIFF
--- a/packages/create-hops-app/package.json
+++ b/packages/create-hops-app/package.json
@@ -11,8 +11,7 @@
     "node": "^10.13 || ^12.13"
   },
   "bin": {
-    "create-hops-app": "./index.js",
-    "create-hops-app@next": "./index.js"
+    "create-hops-app": "./index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Backport for v12.x of https://github.com/xing/hops/commit/1390ab66c18dbfb4e51f91ce31390d37a877d17e