### PR TITLE
chore: use hops-v11.x-branch of foosbyte/kicker-trainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       },
       {
         "repository": "https://github.com/foosbyte/kicker-trainer.git",
+        "branch": "hops-v11.x",
         "commands": [
           "yarn build -p",
           "yarn test"

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -5,7 +5,7 @@ const { execSync } = require('child_process');
 const createHopsAppBin = require.resolve('create-hops-app');
 
 describe('create-hops-app', () => {
-  const version = 'latest';
+  const version = '^11';
   const template = 'hops-template-react';
 
   beforeAll(() => {


### PR DESCRIPTION
I created a dedicated Hops-11-branch in `foosbyte/kicker-trainer`. We could then delete the `next`-branch.