### PR TITLE
fix(lambda): pass Hops config into server app

### DIFF
--- a/packages/lambda/lambda.js
+++ b/packages/lambda/lambda.js
@@ -6,7 +6,9 @@ const serverlessHttp = require('serverless-http');
 const config = require('hops-config');
 const { trimSlashes } = require('pathifist');
 
-const app = require('@untool/express').createServer('serve');
+const app = require('@untool/express')
+  .configure(config)
+  .createServer('serve');
 
 const awsConfig = require('./lib/aws-config')(config);
 

--- a/packages/spec/integration/lambda/__tests__/build.js
+++ b/packages/spec/integration/lambda/__tests__/build.js
@@ -44,6 +44,6 @@ describe('lambda production build', () => {
     const response = await invokeFunction(unzipDir, '/prod');
 
     expect(response.statusCode).toBe(200);
-    expect(response.body).toContain('<h1>hello lambda</h1>');
+    expect(response.body).toContain('<h1>hello <!-- -->lambda</h1>');
   });
 });

--- a/packages/spec/integration/lambda/index.js
+++ b/packages/spec/integration/lambda/index.js
@@ -1,12 +1,14 @@
-import { render } from 'hops';
+import { render, withConfig } from 'hops';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
-export default render(
+const App = withConfig(({ config }) => (
   <>
     <Helmet>
       <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     </Helmet>
-    <h1>hello lambda</h1>
+    <h1>hello {config.subject}</h1>
   </>
-);
+));
+
+export default render(<App />);

--- a/packages/spec/integration/lambda/package.json
+++ b/packages/spec/integration/lambda/package.json
@@ -15,7 +15,11 @@
     "gracePeriod": 0,
     "basePath": "prod",
     "assetPath": "prod",
-    "node": "10.13"
+    "node": "10.13",
+    "subject": "lambda",
+    "browserWhitelist": {
+      "subject": true
+    }
   },
   "scripts": {
     "start": "hops start",


### PR DESCRIPTION
This issue became obvious to me, when the lambda test failed with `Node version 13.8 is not supported.`, although in the Hops config the Node version was set to `10.13`.