### PR TITLE
fix(jest-preset): correctly handle coverage instrumented importComponent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .vscode
 .idea
 .tmp
+coverage/

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preinstall": "node -e \"process.exit(process.env.npm_execpath.includes('yarn') ? 0 : 1)\"",
     "start": "cd packages/template-react; yarn start",
     "start:graphql": "cd packages/template-graphql; yarn start",
-    "test": "jest",
+    "test": "jest --coverage",
     "lint": "eslint 'packages/**/*.js'",
     "prerelease": "test -n \"$GH_TOKEN\" || (echo 'GH_TOKEN missing'; exit 1)",
     "release": "lerna publish",

--- a/packages/spec/integration/hops/__tests__/__snapshots__/import-component-loading.js.snap
+++ b/packages/spec/integration/hops/__tests__/__snapshots__/import-component-loading.js.snap
@@ -1,7 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ImportComponent loading should display the loading state 1`] = `
-<p>
-  Fetching content…
-</p>
+Array [
+  <p>
+    Fetching content…
+  </p>,
+  <p>
+    Fetching content…
+  </p>,
+  <p>
+    Fetching content…
+  </p>,
+  <p>
+    Fetching content…
+  </p>,
+]
 `;

--- a/packages/spec/integration/hops/__tests__/__snapshots__/import-component-mocked.js.snap
+++ b/packages/spec/integration/hops/__tests__/__snapshots__/import-component-mocked.js.snap
@@ -1,9 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ImportComponent mocked should display the loaded component 1`] = `
-<p>
-  Hello lazy 
-  world
-  !
-</p>
+Array [
+  <p>
+    Hello lazy 
+    world
+    !
+  </p>,
+  <p>
+    Hello lazy 
+    world1
+    !
+  </p>,
+  <p>
+    Hello lazy 
+    world2
+    !
+  </p>,
+  <p>
+    Hello lazy 
+    world3
+    !
+  </p>,
+]
 `;

--- a/packages/spec/integration/hops/index.js
+++ b/packages/spec/integration/hops/index.js
@@ -3,6 +3,12 @@ import { importComponent, render } from 'hops';
 import { Helmet } from 'react-helmet-async';
 
 const Text = importComponent('./text');
+const Text1 = importComponent('./text', 'default');
+const Text2 = importComponent(() => import('./text'));
+const Text3 = importComponent(
+  () => import('./text'),
+  exports => exports.default
+);
 
 const loader = load =>
   Promise.race([new Promise((_, reject) => setTimeout(reject, 10000)), load()]);
@@ -12,7 +18,14 @@ const renderText = ({ Component, loading, ...props }) => {
 };
 
 export function App() {
-  return <Text loader={loader} render={renderText} subject="world" />;
+  return (
+    <>
+      <Text loader={loader} render={renderText} subject="world" />
+      <Text1 loader={loader} render={renderText} subject="world1" />
+      <Text2 loader={loader} render={renderText} subject="world2" />
+      <Text3 loader={loader} render={renderText} subject="world3" />
+    </>
+  );
 }
 
 export default render(


### PR DESCRIPTION
When executing jest with `jest --coverage` it adds coverage instrumentation
code to the source code which breaks our babel plugin for the
`importComponent` function. With this change we can correctly handle
instrumented code.

Closes: #1080