### PR TITLE
chore: only execute linters and tests on latest Node for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,26 @@ matrix:
   include:
     - node_js: '10.13'
       name: 'Test on Node.js 10'
+      if: branch =~ /(master|staging|trying|v\d+\.x)/
       script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-v10
     - node_js: '12.13'
       name: 'Test on Node.js 12'
-      before_script:
-        - 'yarn lint'
+      if: branch =~ /(master|staging|trying|v\d+\.x)/
       script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-v12
     - node_js: '13'
       name: 'Test on Node.js 13 (latest)'
+      before_script:
+        - 'yarn lint'
       script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-v13
     - node_js: 'lts/*'
       name: 'Canarist test on Node.js latest lts'
+      if: branch =~ /(master|staging|trying|v\d+\.x)/
       script: 'yarn canarist'
       env:
         - CACHE_NAME=canary


### PR DESCRIPTION
Bors will take care of running the full test suite including canarist
tests on all other Node.js versions.