### PR TITLE
fix: upgrade untool to v2.1.3

### DIFF
--- a/packages/apollo-mock-server/package.json
+++ b/packages/apollo-mock-server/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/webpack": "^2.1.2",
+    "@untool/webpack": "^2.1.3",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-server-express": "^2.9.5",
     "cookie-parser": "^1.4.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^2.1.2",
-    "@untool/webpack": "^2.1.2",
+    "@untool/core": "^2.1.3",
+    "@untool/webpack": "^2.1.3",
     "depd": "^2.0.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/config#readme"

--- a/packages/hops/package.json
+++ b/packages/hops/package.json
@@ -27,10 +27,10 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/express": "^2.1.2",
-    "@untool/info": "^2.1.2",
-    "@untool/webpack": "^2.1.2",
-    "@untool/yargs": "^2.1.2",
+    "@untool/express": "^2.1.3",
+    "@untool/info": "^2.1.3",
+    "@untool/webpack": "^2.1.3",
+    "@untool/yargs": "^2.1.3",
     "hops-mixin": "^0.0.0",
     "hops-react": "^0.0.0",
     "webpack-bundle-analyzer": "^3.5.2"

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^2.1.2",
-    "@untool/express": "^2.1.2",
+    "@untool/core": "^2.1.3",
+    "@untool/express": "^2.1.3",
     "archiver": "^3.1.1",
     "aws-sdk": "^2.546.0",
     "globby": "^11.0.0",

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^2.1.2",
+    "@untool/core": "^2.1.3",
     "mixinable": "^4.0.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/mixin#readme"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -20,8 +20,8 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/core": "^2.1.2",
-    "@untool/webpack": "^2.1.2",
+    "@untool/core": "^2.1.3",
+    "@untool/webpack": "^2.1.3",
     "app-manifest-loader": "^2.4.1",
     "file-loader": "^5.0.0",
     "hops-mixin": "^0.0.0",

--- a/packages/react-apollo/package.json
+++ b/packages/react-apollo/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
-    "@untool/react": "^2.1.2",
+    "@untool/react": "^2.1.3",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "apollo-link-http": "^1.5.16",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,8 +21,8 @@
     "@babel/core": "^7.7.0",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-transform-flow-strip-types": "^7.7.0",
-    "@untool/core": "^2.1.2",
-    "@untool/react": "^2.1.2",
+    "@untool/core": "^2.1.3",
+    "@untool/react": "^2.1.3",
     "hops-mixin": "^0.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,10 +2531,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@untool/core@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/core/-/core-2.1.2.tgz#2e019c5afe459ee69cfeb3e5ba27814029b12a67"
-  integrity sha512-iWJDbBzJIw/Lx7q0BOEVAHWRveyswwcTUkSWKlwIOGQEhahu7katAIgFlVfkR1ICQUMPdjN1OsNz65mTLIInXQ==
+"@untool/core@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/core/-/core-2.1.3.tgz#255f08034531e7f879b35c363e2be1e9f4db1ffb"
+  integrity sha512-KWIsuGMtP4Fs9CQGFuTVyL35SMF/rW+L16dbvO83u5xUQd7mVvLAShK2DPOWOCCe+BVgu2w0lYI/C1d0tiExPg==
   dependencies:
     ajv "^6.10.2"
     check-error "^1.0.2"
@@ -2550,12 +2550,12 @@
     mixinable "^4.0.0"
     supports-color "^7.1.0"
 
-"@untool/express@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/express/-/express-2.1.2.tgz#a61456a127577d8f11745372f6f98c19923dfb59"
-  integrity sha512-RjpPakQa3v4g61Yaze5vNlziHgwst6anN6IptZrrR69MnP+ZWDf9yBml5O1dWJT8bKy7C9mMev9u+XtLUmGq7w==
+"@untool/express@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/express/-/express-2.1.3.tgz#70f020fca6c6d906682d85e209af79f37dad6a8d"
+  integrity sha512-XGWM3/592seMdUzwnGZBgRmnDXKcHEFiNaGzTtUVoXsBV7WoQkAxekVQUHCKVmmXlqJpOeEQcacYGkTGLWjiUQ==
   dependencies:
-    "@untool/yargs" "^2.1.2"
+    "@untool/yargs" "^2.1.3"
     chalk "^3.0.0"
     compression "^1.7.4"
     cookie-parser "^1.4.4"
@@ -2577,26 +2577,26 @@
     split "^1.0.1"
     supports-color "^7.1.0"
 
-"@untool/info@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/info/-/info-2.1.2.tgz#5075c7df2923878c1207d6999dbfec6d47d57aa4"
-  integrity sha512-nWyzHfTrxLGVXjmT7uT40OQUiauj35cdRFKpfAuS5J4D07/EYpb+tKwEHfn5iVqE74v+aTIvY3HHOPg56Yzdrg==
+"@untool/info@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/info/-/info-2.1.3.tgz#c37d957f1720f673d3e02aceea4ec58023013048"
+  integrity sha512-x4XZ4jW5UgnH2N0ju5A+a32lG26eabrgujVKmuntRVMw4uWfn/a+pqwqQ2V91I25ZvW4X/TvgUaToS6Doo+OHg==
   dependencies:
-    "@untool/core" "^2.1.2"
+    "@untool/core" "^2.1.3"
     chalk "^3.0.0"
     duplitect "^2.0.1"
     enhanced-resolve "^4.1.1"
     escape-string-regexp "^2.0.0"
     mixinable "^4.0.0"
 
-"@untool/react@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/react/-/react-2.1.2.tgz#fabf4562bfc0296fc0583b0e359098e51664da54"
-  integrity sha512-KIYt+nJKs6PgkI14//R/HZDyzHfnYLSzBaNseVTX7A7+zQfS6nheatHlA1MxtfKIurqlK9Pq3iCuyOqa4tUd9w==
+"@untool/react@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/react/-/react-2.1.3.tgz#8f8c6740bc60220a468f412ec289ee8193fa611f"
+  integrity sha512-vz5zLyQGDYe2kaRKIhQcaNavDaejVFjwI+sZuz/q/wHiFBOEa0tsZLA+B0ike6j4iXy7NcRGBPH9MqOWkrsbfA==
   dependencies:
     "@babel/core" "^7.7.0"
     "@babel/preset-react" "^7.7.0"
-    "@untool/core" "^2.1.2"
+    "@untool/core" "^2.1.3"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
     clone "^2.1.2"
     depd "^2.0.0"
@@ -2605,19 +2605,19 @@
     mixinable "^4.0.0"
     pathifist "^1.0.0"
     prop-types "^15.7.2"
-    serialize-javascript "^2.1.1"
+    serialize-javascript "^3.0.0"
 
-"@untool/webpack@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/webpack/-/webpack-2.1.2.tgz#5c40894536c194f828ac711337f8afc843528ca0"
-  integrity sha512-Kby+QMD+S0jJjy4A4DR1VWN1jSz23F5zetkjIxFGEuRedKOM03XUO3n4KrfI/Hv3NCE5KXM6hiqM0IvPruNLsA==
+"@untool/webpack@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/webpack/-/webpack-2.1.3.tgz#89bffccf48344eca8e426b1e98763cd9c570f285"
+  integrity sha512-Hb2NrgqkhSJ724i+cqq32p8R10f0HlOoPqFsNnYEOdWORSnCGFvIJfmU/e9wfsm4h9nOjXqpAm1wYwWL4ako1A==
   dependencies:
     "@babel/core" "^7.7.0"
     "@babel/plugin-syntax-dynamic-import" "^7.7.0"
     "@babel/preset-env" "^7.7.0"
-    "@untool/core" "^2.1.2"
-    "@untool/express" "^2.1.2"
-    "@untool/yargs" "^2.1.2"
+    "@untool/core" "^2.1.3"
+    "@untool/express" "^2.1.3"
+    "@untool/yargs" "^2.1.3"
     babel-loader "^8.0.6"
     babel-plugin-dynamic-import-node "^2.3.0"
     caniuse-lite "^1.0.30000898"
@@ -2657,12 +2657,12 @@
     webpack-hot-middleware "^2.25.0"
     webpack-sources "^1.4.3"
 
-"@untool/yargs@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@untool/yargs/-/yargs-2.1.2.tgz#57b4935d32bb9d67c8c6e7c72fac464efa2b1438"
-  integrity sha512-rIXPLOfABv9KdVIDetvZzXDEFVjYHR5wGbGjhSUSlerT3oa8mVgdgt5ErfDvx6QVYNUzDDZ7Ura4PTDS55VCrg==
+"@untool/yargs@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@untool/yargs/-/yargs-2.1.3.tgz#9996e0a3e05ddea449fa1605b8a19200a8bc1098"
+  integrity sha512-dx9DLRxCZWjPzYKYhDX6daKes5KR+1lbjZpFyFBGnLiVqncGbofgADkq43OTIpIXKMKaTv1WLDfvk4lKfDTmqw==
   dependencies:
-    "@untool/core" "^2.1.2"
+    "@untool/core" "^2.1.3"
     is-plain-obj "^2.0.0"
     mixinable "^4.0.0"
     yargs "^13.0.0"
@@ -11893,10 +11893,15 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^2.1.1, serialize-javascript@^2.1.2:
+serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.0.0.tgz#492e489a2d77b7b804ad391a5f5d97870952548e"
+  integrity sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==
 
 serve-static@1.14.1:
   version "1.14.1"


### PR DESCRIPTION
Changes:
* update dependency serialize-javascript to v3 ([1e0aadb](https://github.com/untool/untool/commit/1e0aadb51e90c95435ed3370af2e48d68fa3f121))
* **core:** allow to ignore certain presets through "ignoredPresets" ([1dc9422](https://github.com/untool/untool/commit/1dc942266cd47d2d496afafcec405b3130624719)), closes [#580](https://github.com/untool/untool/issues/580)
* **react:** set data-mounted attribute after hydration ([566a3a5](https://github.com/untool/untool/commit/566a3a55d631f89113acc7c5390123688310cda6))

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>