### PR TITLE
fix(redux): prevent route actions from being dispatched on hashchange

### DIFF
--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -14,14 +14,22 @@ const Dispatcher = withRouter(
       alwaysDispatchActionsOnClient: PropTypes.bool,
       prefetchedOnServer: PropTypes.bool.isRequired,
     };
+    previousPathname = null;
 
     dispatchAll() {
-      if (this.props.location) {
-        this.props.dispatchAll(this.props.location);
+      const { location } = this.props;
+      const pathnameChanged =
+        location && location.pathname !== this.previousPathname;
+
+      if (pathnameChanged) {
+        this.previousPathname = location.pathname;
+        this.props.dispatchAll(location);
       }
     }
 
     componentDidMount() {
+      this.previousPathname = this.props.location.pathname;
+
       // after the initial page load, the actions should not be dispatched immediately again,
       // because it was already done on the server and
       // this would often lead to flickering pages, unnecessary loading spinners and network requests

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -46,6 +46,23 @@ describe('redux development server', () => {
       await page.close();
     });
 
+    it('will not be executed if the location hash changes', async () => {
+      const { page, getInnerText } = await createPage();
+      const hashValue = '#some-hash';
+      await page.goto(urlJoin(url, '/increment'), {
+        waitUntil: 'networkidle2',
+      });
+      await page.click(`a[href="${hashValue}"]`);
+
+      const { hash } = new URL(page.url());
+      const count = await getInnerText('counter');
+
+      expect(hash).toBe(hashValue);
+      expect(count).toBe('1');
+
+      await page.close();
+    });
+
     it('will be executed if a search query or hash is present', async () => {
       const { page, getInnerText } = await createPage();
       await page.goto(urlJoin(url, '/increment?foo=bar#hash'), {

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import fetch from 'cross-fetch';
 import { Helmet } from 'react-helmet-async';
+import { Route } from 'react-router-dom';
 
 const reducers = {
   counter(state = 0, action) {
@@ -57,6 +58,15 @@ const Counter = ({ count, increment, val }) => (
     <button onClick={increment}>+</button>
     <counter>{count}</counter>
     <value>{val}</value>
+    <Route
+      path="/increment"
+      render={() => (
+        <>
+          <hr />
+          <a href="#some-hash">Set location hash&hellip;</a>
+        </>
+      )}
+    />
   </>
 );
 


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
