### PR TITLE
chore: disable yarn cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 cache:
-  yarn: true
+  yarn: false
   directories:
     - node_modules
 


### PR DESCRIPTION
The travis yarn cache is currently broken for us. It might be related to the fact that Travis is using a different yarn version for the cache and the installation but we are not sure yet.
Let's disable this feature for now, we can come back to it later.