### PR TITLE
Release v12.1.4

### DIFF
--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -14,21 +14,25 @@ const Dispatcher = withRouter(
       alwaysDispatchActionsOnClient: PropTypes.bool,
       prefetchedOnServer: PropTypes.bool.isRequired,
     };
-    previousPathname = null;
+    previousLocation = {};
 
     dispatchAll() {
-      const { location } = this.props;
+      const { location = {} } = this.props;
       const pathnameChanged =
-        location && location.pathname !== this.previousPathname;
+        location.pathname !== this.previousLocation.pathname;
+      const hashChanged = location.hash !== this.previousLocation.hash;
+      const onlyHashChanged = hashChanged && !pathnameChanged;
+      this.previousLocation = location;
 
-      if (pathnameChanged) {
-        this.previousPathname = location.pathname;
-        this.props.dispatchAll(location);
+      if (onlyHashChanged) {
+        return;
       }
+
+      this.props.dispatchAll(location);
     }
 
     componentDidMount() {
-      this.previousPathname = this.props.location.pathname;
+      this.previousLocation = this.props.location;
 
       // after the initial page load, the actions should not be dispatched immediately again,
       // because it was already done on the server and

--- a/packages/spec/integration/redux-without-ssr/__tests__/develop.js
+++ b/packages/spec/integration/redux-without-ssr/__tests__/develop.js
@@ -1,0 +1,18 @@
+describe('redux development server', () => {
+  let url;
+
+  beforeAll(async () => {
+    url = await HopsCLI.start();
+  });
+
+  it('increments the counter on page load', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    const count = await getInnerText('h1');
+
+    expect(count).toBe('3');
+
+    await page.close();
+  });
+});

--- a/packages/spec/integration/redux-without-ssr/index.js
+++ b/packages/spec/integration/redux-without-ssr/index.js
@@ -1,0 +1,42 @@
+import { render } from 'hops';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Helmet } from 'react-helmet-async';
+
+const reducers = {
+  counter(state = 0, action) {
+    switch (action.type) {
+      case 'INCREMENT':
+        return state + action.payload;
+      default:
+        return state;
+    }
+  },
+};
+
+const increment = () => ({ type: 'INCREMENT', payload: 3 });
+
+const Counter = ({ count }) => (
+  <>
+    <Helmet>
+      <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    </Helmet>
+    <h1>{count}</h1>
+  </>
+);
+
+const ConnectedCounter = connect(({ counter }) => ({ count: counter }), {
+  increment,
+})(Counter);
+
+export default render(<ConnectedCounter />, {
+  redux: {
+    reducers,
+    actionCreators: [
+      {
+        path: '/',
+        action: increment,
+      },
+    ],
+  },
+});

--- a/packages/spec/integration/redux-without-ssr/package.json
+++ b/packages/spec/integration/redux-without-ssr/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "fixture-redux-without-ssr",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "^10.13 || ^12.13 || ^13.0"
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js",
+    "setupFilesAfterEnv": [
+      "../../jest.setup.js"
+    ]
+  },
+  "scripts": {
+    "start": "hops start",
+    "build": "hops build"
+  },
+  "hops": {
+    "gracePeriod": 0,
+    "shouldPrefetchOnServer": false
+  },
+  "dependencies": {
+    "hops": "*",
+    "hops-redux": "*"
+  }
+}


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
