### PR TITLE
chore: deprecate "hops-mixin" in favor of "hops-bootstrap"

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -15,3 +15,7 @@ The config property `shouldPrefetchOnServer` is deprecated and will be removed i
 ### DEP0004
 
 Deep imports to `hops-react/lib/runtime` are deprecated and should be changed to `hops-react` instead.
+
+### DEP0005
+
+`hops-mixin` is deprecated, please import the `Mixin` class from `hops-bootstrap` instead and the strategies from `mixinable`.

--- a/packages/mixin/index.js
+++ b/packages/mixin/index.js
@@ -1,5 +1,10 @@
 const { Mixin } = require('hops-bootstrap');
 const { sync, async } = require('mixinable');
+const deprecate = require('depd')('hops-config');
+
+deprecate(
+  '[DEP0005] hops-mixin is deprecated. Please import "Mixin" from "hops-bootstrap" and strategies from "mixinable" https://github.com/xing/hops/blob/master/DEPRECATIONS.md#dep0005.'
+);
 
 module.exports = {
   Mixin,

--- a/packages/mixin/package.json
+++ b/packages/mixin/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/xing/hops.git"
   },
   "dependencies": {
+    "depd": "^2.0.0",
     "hops-bootstrap": "^0.0.0",
     "mixinable": "^4.0.0"
   },


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>