### PR TITLE
fix: remove unnecessary babel plugin dynamic import node

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,8 +166,5 @@
     "lerna": "^3.17.0",
     "lint-staged": "^10.0.0",
     "prettier": "^2.0.0"
-  },
-  "resolutions": {
-    "babel-plugin-dynamic-import-node": "2.3.0"
   }
 }

--- a/packages/jest-preset/helpers/__tests__/babel-plugin-import-component.js
+++ b/packages/jest-preset/helpers/__tests__/babel-plugin-import-component.js
@@ -15,10 +15,7 @@ const tests = [
 ].map(([code, expected], i) => [String(++i), fixture(code), fixture(expected)]);
 
 const babelOptions = {
-  plugins: [
-    require.resolve('../babel-plugin-import-component'),
-    require.resolve('babel-plugin-dynamic-import-node'),
-  ],
+  plugins: [require.resolve('../babel-plugin-import-component')],
   babelrc: false,
 };
 

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -27,7 +27,6 @@
     "@babel/preset-env": "^7.7.0",
     "@babel/preset-react": "^7.7.0",
     "babel-jest": "^24.9.0",
-    "babel-plugin-dynamic-import-node": "^2.3.0",
     "core-js": "^3.2.1",
     "hops": "^0.0.0",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/jest-preset/transforms/babel.js
+++ b/packages/jest-preset/transforms/babel.js
@@ -17,7 +17,6 @@ const babelConfig = {
     require.resolve('../helpers/babel-plugin-rename-corejs'),
     require.resolve('../helpers/babel-plugin-import-component'),
     require.resolve('@babel/plugin-transform-flow-strip-types'),
-    require.resolve('babel-plugin-dynamic-import-node'),
     require.resolve('@babel/plugin-proposal-class-properties'),
   ],
   babelrc: false,

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -38,7 +38,7 @@ module.exports = function getConfig(config, name) {
           },
         ],
       ],
-      plugins: [require.resolve('babel-plugin-dynamic-import-node')],
+      plugins: [],
       sourceType: 'unambiguous',
     },
   };

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -9,7 +9,6 @@
     "@babel/plugin-syntax-dynamic-import": "^7.7.0",
     "@babel/preset-env": "^7.7.0",
     "babel-loader": "^8.0.6",
-    "babel-plugin-dynamic-import-node": "^2.3.0",
     "caniuse-lite": "^1.0.30000898",
     "chalk": "^4.0.0",
     "core-js": "^3.2.1",


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>