### PR TITLE
perf: use transpileOnly flag of ts-loader for node dev build

### DIFF
--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -29,9 +29,11 @@ const getCompilerOptions = (ts, rootPath) => {
 class TypescriptMixin extends Mixin {
   configureBuild(webpackConfig, { jsLoaderConfig, allLoaderConfigs }, target) {
     const { loader, options, exclude } = jsLoaderConfig;
-    const targetDevelop = target === 'develop';
-    const compilerOptions = targetDevelop
-      ? { compilerOptions: { isolatedModules: true } }
+    const isDevelop =
+      target === 'develop' ||
+      (target === 'node' && process.env.NODE_ENV !== 'production');
+    const loaderOptions = isDevelop
+      ? { compilerOptions: { isolatedModules: true }, transpileOnly: true }
       : undefined;
 
     allLoaderConfigs.unshift({
@@ -44,10 +46,7 @@ class TypescriptMixin extends Mixin {
         },
         {
           loader: require.resolve('ts-loader'),
-          options: {
-            ...compilerOptions,
-            transpileOnly: targetDevelop,
-          },
+          options: loaderOptions,
         },
       ],
     });


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>