### PR TITLE
perf: reduce memory footprint by not serializing all stats

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -58,7 +58,7 @@ exports.StatsPlugin = class StatsPlugin {
 
           try {
             enhancedPromise.resolve({
-              ...compilation.getStats().toJson({ source: false }),
+              ...compilation.getStats().toJson({ all: false, assets: true }),
               ...extractFiles(analyzeCompilation(compilation), publicPath),
             });
           } catch (error) {


### PR DESCRIPTION
We only serialized all stats to disk, so that users may be able to
inspect them with the webpack bundle analyzer.
But since we've introduced `hops build --analyze-client-bundle` the
full stats file is no longer necessary.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>