### PR TITLE
fix(react): render react-helmet-async values on the server

### DIFF
--- a/packages/react/helmet/mixin.runtime.js
+++ b/packages/react/helmet/mixin.runtime.js
@@ -5,17 +5,17 @@ const { HelmetProvider } = require('react-helmet-async');
 class ReactHelmetMixin extends Mixin {
   constructor(config, _element, options) {
     super(config, options);
-    this.helmet = {};
+    this.context = {};
   }
 
   bootstrap(_req, res) {
     if (res) {
-      res.locals.helmet = this.helmet;
+      res.locals.helmetContext = this.context;
     }
   }
 
   enhanceElement(element) {
-    return createElement(HelmetProvider, { context: this.helmet }, element);
+    return createElement(HelmetProvider, { context: this.context }, element);
   }
 }
 

--- a/packages/react/render/mixin.server.js
+++ b/packages/react/render/mixin.server.js
@@ -44,10 +44,10 @@ class ReactMixin extends Mixin {
         this.fetchData({}, element).then(() => this.renderToFragments(element))
       )
       .then((fragments) => {
-        // note: res.locals.helmet is set by the ReactHelmetMixin
+        // note: res.locals.helmetContext is set by the ReactHelmetMixin
         Object.assign(
           fragments,
-          Object.entries(res.locals.helmet).reduce(
+          Object.entries(res.locals.helmetContext.helmet).reduce(
             (result, [key, value]) => ({ ...result, [key]: value.toString() }),
             { headPrefix: '', headSuffix: '' }
           )

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -116,4 +116,10 @@ describe('react development server', () => {
 
     await page.close();
   });
+
+  it('renders helmet <link> server-side', async () => {
+    const response = await fetch(url);
+    const content = await response.text();
+    expect(content).toMatch('data:;base64,iVBORw0KGgo=');
+  });
 });


### PR DESCRIPTION
As specified in the documentation of react-helmet-async[1] it will create
a property helmet in the passed context. Back when the react package from
untool[2] was used, this was saved in a context variable and later taken out.
Now the context is saved in a helmet variable, but the nested helmet key is
never taken out. So instead of adding keys like title, base, meta, etc. to
the fragments, only a key called helmet was added, so everything set by helmet
got lost on the server. Luckily the client immediately fixes that, so the problem
went unnoticed for some time.

This adds back the context concept and then properly takes out the helmet
key form it, so that the individual entries are copied to the fragments again.

Also it adds an integration test to see that it actually works and to avoid
regressions in the future.

  1: https://github.com/staylor/react-helmet-async#usage
  2: https://github.com/untool/untool/blob/ef7abccc693ee5fb24c1c17bc7a33098aafed0b1/packages/react/mixins/mixin.server.js#L47

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>