### PR TITLE
chore: use Node.js latest current release (v14) on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,29 @@ install:
 
 matrix:
   include:
-    - node_js: "10"
-      name: "Test on Node.js 10"
+    - node_js: '10'
+      name: 'Test on Node.js 10'
       if: branch =~ /(master|staging|trying|v\d+\.x)/ AND NOT branch =~ /\.tmp$/
-      script: "yarn test --maxWorkers=2 --ci"
+      script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-v10
-    - node_js: "12"
-      name: "Test on Node.js 12"
+    - node_js: '12'
+      name: 'Test on Node.js 12'
       if: branch =~ /(master|staging|trying|v\d+\.x)/ AND NOT branch =~ /\.tmp$/
-      script: "yarn test --maxWorkers=2 --ci"
+      script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-v12
-    - node_js: "13"
-      name: "Test on Node.js 13"
+    - node_js: 'node'
+      name: 'Test on Node.js latest "current"'
       if: NOT branch =~ /\.tmp$/
       before_script:
-        - "yarn lint"
-      script: "yarn test --maxWorkers=2 --ci"
+        - 'yarn lint'
+      script: 'yarn test --maxWorkers=2 --ci'
       env:
         - CACHE_NAME=node-latest
-    - node_js: "lts/*"
-      name: "Canarist test on Node.js latest lts"
+    - node_js: 'lts/*'
+      name: 'Canarist test on Node.js latest lts'
       if: branch =~ /(master|staging|trying|v\d+\.x)/ AND NOT branch =~ /\.tmp$/
-      script: "yarn canarist"
+      script: 'yarn canarist'
       env:
         - CACHE_NAME=canary


### PR DESCRIPTION
Also: Not sure what happened to the formatting, but prettier thinks that
this is correct now.

**Attention:** We can only merge this PR after we have released a new Hops version with updated `engines` field that allows Node.js v14.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>