### PR TITLE
feat(webpack): print total bundle size

### DIFF
--- a/packages/webpack/lib/plugins/log.js
+++ b/packages/webpack/lib/plugins/log.js
@@ -38,7 +38,13 @@ const formatWarning = (name, duration, assets, isRebuild) => {
 };
 
 const formatSuccess = (name, duration, assets, isRebuild) => {
-  const message = `bundling '${name}' finished after ${duration}`;
+  const totalSize = Object.values(assets).reduce(
+    (sum, asset) => sum + asset.size,
+    0
+  );
+  const message = `bundling '${name}' finished after ${duration} (${prettyBytes(
+    totalSize
+  )})`;
   return isRebuild ? `re-${message}` : `${message}\n${formatAssets(assets)}`;
 };
 


### PR DESCRIPTION
example output:
```
hops-demo:info bundling 'node' finished after 30.7s (12.4 MB)
hops-demo:info bundling 'build' finished after 51.2s (7.34 MB)
```