### PR TITLE
feat(webpack): introduce experimental fast-build mode

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -249,6 +249,7 @@ _The production flag (`--production` or `-p`) is a shortcut for setting the envi
 This command will execute a single build of all your assets.
 
 - `npm run build` builds all assets in development mode.
+- `npm run build -- --fast-build` (**experimental**) only transpiles a predefined set of node modules (_warning:_ you might have node modules which needs to be transpiled, use with caution).
 - `npm run build -- --production` builds all assets in production mode (which includes minification, etc).
 - `npm run build -- --static`¹ export static HTML pages for all configured [locations](#default-settings) in development mode.
 - `npm run build -- --production --static`¹ export static HTML pages in production mode (enables minification, etc).

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -40,6 +40,12 @@ This is equivalent to manually setting `$NODE_ENV` before calling the actual com
 $ NODE_ENV=production hops build
 ```
 
+##### `--fast-build` _experimental_
+
+Using the experimental `--fast-build` option will only transpile a predefined set of node modules. If you use a node module that ships ES language features that aren't supported by your browser matrix it might break your website. Therefore only use this feature if you have a comprehensive test setup which covers all your supported browsers.
+
+You can extend this predefined set though by adding glob patterns to the `experimental.babelIncludePatterns` config.
+
 ##### `-s` / `--static` (**deprecated**)
 
 In `static` mode, static HTML pages will be generated for the [`locations`](../express/README.md#locations) configured for your application. In `no-static` mode, `server.js` and `stats.json` files will be created instead.

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -87,12 +87,13 @@ module.exports = function getConfig(config, name) {
     mode: isProduction ? 'production' : 'development',
     bail: isProduction,
     context: config.rootDir,
-    entry: isProduction
-      ? require.resolve('../shims/node')
-      : [
-          require.resolve('webpack/hot/signal') + '?RELOAD',
-          require.resolve('../shims/node'),
-        ],
+    entry: [
+      ...(isProduction
+        ? []
+        : [require.resolve('webpack/hot/signal') + '?RELOAD']),
+      require.resolve('core-js/stable'),
+      require.resolve('../shims/node'),
+    ],
     output: {
       path: config.serverDir,
       publicPath: '/',

--- a/packages/webpack/lib/shims/node.js
+++ b/packages/webpack/lib/shims/node.js
@@ -2,10 +2,6 @@ if (!require('module').prototype._compile.__sourceMapSupport) {
   require('source-map-support/register');
 }
 
-if (process.env.__HOPS_FAST_DEV__ !== 'true') {
-  require('core-js');
-}
-
 if (module.hot) {
   require('webpack/hot/log').setLogLevel('none');
   module.hot.accept('hops/entrypoint');

--- a/packages/webpack/mixins/fast-dev/mixin.core.js
+++ b/packages/webpack/mixins/fast-dev/mixin.core.js
@@ -18,8 +18,6 @@ class FastDevWebpackMixin extends Mixin {
     }
 
     if (this.options.fastDev) {
-      process.env.__HOPS_FAST_DEV__ = 'true';
-
       jsLoaderConfig.exclude = [/node_modules\//];
 
       const presetEnv = jsLoaderConfig.options.presets.find((preset) => {
@@ -30,6 +28,12 @@ class FastDevWebpackMixin extends Mixin {
         presetEnv[1].useBuiltIns = false;
         delete presetEnv[1].corejs;
       }
+
+      webpackConfig.entry = []
+        .concat(webpackConfig.entry)
+        .filter(
+          (entry) => /(core-js|regenerator-runtime)/.test(entry) == false
+        );
 
       allLoaderConfigs
         .filter((loader) => {

--- a/packages/webpack/mixins/optimizations/mixin.core.js
+++ b/packages/webpack/mixins/optimizations/mixin.core.js
@@ -8,16 +8,19 @@ function findResolved(a, b) {
   }
 }
 
-class FastDevWebpackMixin extends Mixin {
+class WebpackOptimizationsMixin extends Mixin {
   configureBuild(webpackConfig, { allLoaderConfigs, jsLoaderConfig }, target) {
-    if (
-      target === 'build' ||
-      (target === 'node' && process.env.NODE_ENV === 'production')
-    ) {
+    const { fastDev } = this.options;
+
+    if (!fastDev) {
       return;
     }
 
-    if (this.options.fastDev) {
+    const { NODE_ENV } = process.env;
+    const isDevelop = target === 'develop' || NODE_ENV !== 'production';
+    const skipPolyfilling = fastDev && isDevelop;
+
+    if (skipPolyfilling) {
       jsLoaderConfig.exclude = [/node_modules\//];
 
       const presetEnv = jsLoaderConfig.options.presets.find((preset) => {
@@ -63,4 +66,4 @@ class FastDevWebpackMixin extends Mixin {
   }
 }
 
-module.exports = FastDevWebpackMixin;
+module.exports = WebpackOptimizationsMixin;

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -30,6 +30,7 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "memory-fs": "^0.5.0",
+    "minimatch": "^3.0.4",
     "mixinable": "^5.0.1",
     "pathifist": "^1.0.0",
     "pretty-bytes": "^5.3.0",

--- a/packages/webpack/preset.js
+++ b/packages/webpack/preset.js
@@ -43,6 +43,15 @@ module.exports = {
       type: 'array',
       items: { type: 'string', minLength: 1 },
     },
+    experimental: {
+      type: 'object',
+      properties: {
+        babelIncludePatterns: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+        },
+      },
+    },
     node: { type: 'string', minLength: 1 },
     locations: {
       type: 'array',

--- a/packages/webpack/preset.js
+++ b/packages/webpack/preset.js
@@ -19,7 +19,7 @@ module.exports = {
     join(__dirname, 'mixins', 'render'),
     join(__dirname, 'mixins', 'start'),
     join(__dirname, 'mixins', 'stats'),
-    join(__dirname, 'mixins', 'fast-dev'),
+    join(__dirname, 'mixins', 'optimizations'),
   ],
   mixinTypes: {
     browser: {


### PR DESCRIPTION
The new experimental `--fast-build` feature only transpiles some node_modules instead of all.
That also requires to change core-js `useBuiltIns` to `entry` as we don't know which polyfills we need in the end.

**`hops build -p`**
```
fixture-hops:info bundling 'node' finished after 8.4s (2.92 MB)
- server.js (2.89 MB)
- stats.json (33 kB)
fixture-hops:info bundling 'build' finished after 8.4s (1.69 MB)
- fixture-hops-0-1b0f62f1564b.js (255 B)
- fixture-hops-2-ef56cba710d4.js (338 kB)
- fixture-hops-ad490021bce4.js (39.5 kB)
```

**`hops build -p --fast-build`**
```
fixture-hops:info bundling 'node' finished after 3.2s (2.56 MB)
- server.js (2.53 MB)
- stats.json (33 kB)
fixture-hops:info bundling 'build' finished after 3.8s (1.68 MB)
- fixture-hops-0-1b0f62f1564b.js (255 B)
- fixture-hops-06324ff963f7.js (37.7 kB)
- fixture-hops-2-ba3747322e3f.js (331 kB)
```