### PR TITLE
feat(webpack): improve error output for core-js issues

### DIFF
--- a/packages/webpack/lib/utils/errors.js
+++ b/packages/webpack/lib/utils/errors.js
@@ -34,3 +34,36 @@ class CompilerError extends Error {
 }
 
 exports.CompilerError = CompilerError;
+
+class CoreJsResolutionError extends Error {
+  constructor(pkg) {
+    super();
+    this.name = this.constructor.name;
+    this.pkg = pkg;
+    this.stack = '';
+    this.message = `There is an incompatible version of core-js
+
+The dependency "${this.pkg}" relies on an (outdated) version of core-js,
+which breaks the build of Hops. There are four ways to fix this situation:
+
+1.) Tell the author of the package to not consume core-js in their package,
+    but leave the act of polyfilling to the application, that consumes their
+    package. In this case Hops.
+
+2.) If possible, open a PR at the package's repository and remove the
+    problematic usages of core-js yourself. Beware though, that not every
+    open-source project is well maintained & sometimes PRs never get merged.
+
+3.) If it's not possible — for whatever reason — to contribute back to the
+    package's project, use patch-package (https://npm.im/patch-package) to
+    apply your fix to this package locally via a "postinstall"-hook.
+
+4.) If the author of the package won't remove the usages of core-js and
+    removing them yourself is not an option for you, you'll have to find
+    an alternative package, that provides a similar functionality, while
+    playing by the rules of polyfilling.
+`;
+  }
+}
+
+exports.CoreJsResolutionError = CoreJsResolutionError;


### PR DESCRIPTION
picks #1238 

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
