### PR TITLE
fix(webpack): only accept esnext main fields in js loader

### DIFF
--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -41,6 +41,19 @@ module.exports = function getConfig(config, name) {
       plugins: [],
       sourceType: 'unambiguous',
     },
+    resolve: {
+      mainFields: [
+        'esnext:browser',
+        'jsnext:browser',
+        'browser',
+        'module',
+        'esnext',
+        'jsnext',
+        'esnext:main',
+        'jsnext:main',
+        'main',
+      ],
+    },
   };
 
   const fileLoaderConfig = {
@@ -106,17 +119,7 @@ module.exports = function getConfig(config, name) {
         'core-js': dirname(require.resolve('core-js/package.json')),
       },
       extensions: ['.mjs', '.js'],
-      mainFields: [
-        'esnext:browser',
-        'jsnext:browser',
-        'browser',
-        'module',
-        'esnext',
-        'jsnext',
-        'esnext:main',
-        'jsnext:main',
-        'main',
-      ],
+      mainFields: ['browser', 'module', 'main'],
     },
     module: {
       rules: [{ oneOf: allLoaderConfigs }],

--- a/packages/webpack/lib/configs/develop.js
+++ b/packages/webpack/lib/configs/develop.js
@@ -36,6 +36,19 @@ module.exports = function getConfig(config, name) {
       plugins: [],
       sourceType: 'unambiguous',
     },
+    resolve: {
+      mainFields: [
+        'esnext:browser',
+        'jsnext:browser',
+        'browser',
+        'module',
+        'esnext',
+        'jsnext',
+        'esnext:main',
+        'jsnext:main',
+        'main',
+      ],
+    },
   };
 
   const fileLoaderConfig = {
@@ -100,17 +113,7 @@ module.exports = function getConfig(config, name) {
         'core-js': dirname(require.resolve('core-js/package.json')),
       },
       extensions: ['.mjs', '.js'],
-      mainFields: [
-        'esnext:browser',
-        'jsnext:browser',
-        'browser',
-        'module',
-        'esnext',
-        'jsnext',
-        'esnext:main',
-        'jsnext:main',
-        'main',
-      ],
+      mainFields: ['browser', 'module', 'main'],
     },
     module: {
       rules: [{ oneOf: allLoaderConfigs }],

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -41,6 +41,19 @@ module.exports = function getConfig(config, name) {
       plugins: [],
       sourceType: 'unambiguous',
     },
+    resolve: {
+      mainFields: [
+        'esnext:server',
+        'jsnext:server',
+        'server',
+        'module',
+        'esnext',
+        'jsnext',
+        'esnext:main',
+        'jsnext:main',
+        'main',
+      ],
+    },
   };
 
   const fileLoaderConfig = {
@@ -112,17 +125,7 @@ module.exports = function getConfig(config, name) {
         'core-js': dirname(require.resolve('core-js/package.json')),
       },
       extensions: ['.mjs', '.js'],
-      mainFields: [
-        'esnext:server',
-        'jsnext:server',
-        'server',
-        'module',
-        'esnext',
-        'jsnext',
-        'esnext:main',
-        'jsnext:main',
-        'main',
-      ],
+      mainFields: ['server', 'module', 'main'],
     },
     module: {
       rules: [{ oneOf: allLoaderConfigs }],


### PR DESCRIPTION
With the introduction of fast-dev and fast-build we don't transpile all files any more.
Therefor it's not a good idea to always read from `esnext` main fields.

