### PR TITLE
fix: module resolution in symlinked package of a preset

### DIFF
--- a/packages/bootstrap/lib/loader.js
+++ b/packages/bootstrap/lib/loader.js
@@ -15,7 +15,9 @@ class Loader {
   }
   load(context, module) {
     const { load } = cosmiconfig(this.namespace);
-    return load(resolvePreset(context, module));
+    const presetJsFilePath = resolvePreset(context, module);
+    const loadedPreset = load(presetJsFilePath);
+    return loadedPreset;
   }
   search(stopDir) {
     const { search } = cosmiconfig(this.namespace, { stopDir });

--- a/packages/bootstrap/lib/resolver.js
+++ b/packages/bootstrap/lib/resolver.js
@@ -7,14 +7,7 @@ const {
   create: { sync: createResolver },
 } = require('enhanced-resolve');
 
-const defaultConfig = {
-  symlinks: !(
-    process.env.NODE_PRESERVE_SYMLINKS == 1 ||
-    (typeof process.env.NODE_OPTIONS === 'string' &&
-      process.env.NODE_OPTIONS.includes('--preserve-symlinks')) ||
-    process.execArgv.includes('--preserve-symlinks')
-  ),
-};
+const defaultConfig = { symlinks: false };
 
 exports.resolve = resolve;
 

--- a/packages/bootstrap/lib/resolver.js
+++ b/packages/bootstrap/lib/resolver.js
@@ -7,9 +7,19 @@ const {
   create: { sync: createResolver },
 } = require('enhanced-resolve');
 
+const defaultConfig = {
+  symlinks: !(
+    process.env.NODE_PRESERVE_SYMLINKS == 1 ||
+    (typeof process.env.NODE_OPTIONS === 'string' &&
+      process.env.NODE_OPTIONS.includes('--preserve-symlinks')) ||
+    process.execArgv.includes('--preserve-symlinks')
+  ),
+};
+
 exports.resolve = resolve;
 
 exports.resolvePreset = createResolver({
+  ...defaultConfig,
   mainFiles: ['preset'],
   mainFields: ['preset'],
 });
@@ -18,7 +28,7 @@ exports.resolveMixins = (context, types, mixins) => {
   const result = {};
   const resolvers = {};
   Object.entries(types).forEach(([type, config]) => {
-    resolvers[type] = createResolver(config);
+    resolvers[type] = createResolver({ ...defaultConfig, ...config });
     result[type] = [];
   });
   return mixins.reduce((result, mixin) => {


### PR DESCRIPTION
This pull request closes issue https://github.com/xing/hops/issues/1257

**Detailed explanation and analysis can be found in [the related issue](https://github.com/xing/hops/issues/1257)**

## Current state

As described in [the issue](https://github.com/xing/hops/issues/1257):

Resolving peerDependencies of a **symlinked** hops mixin-and-preset package fails, even when using the [`--preserve-symlinks` node arg](https://nodejs.org/api/all.html#cli_preserve_symlinks) which as describe in the official node documentation as a way to interpret node resolution algorithm to treat symlinks as preserved (as if they are normal dirs). Further detailed article can be found [here](https://chevtek.io/you-can-finally-npm-link-packages-that-contain-peer-dependencies/).

## Changes introduced here

In [the resolver of bootstrap package](https://github.com/xing/hops/blob/e7a3b46/packages/bootstrap/lib/resolver.js), during any usage of [`createResolver`](https://github.com/webpack/enhanced-resolve#creating-a-resolver) we need to pass `symlinks` option as `false` if the env `NODE_PRESERVE_SYMLINK=1`.

It was proven (locally) that loading the hops-preset and hops-mixins work correctly and as expected by adding `symlinks: false` option to the createResolver (alongside env:`NODE_PRESERVE_SYMLINK=1`), specifically in [resolvePreset](https://github.com/xing/hops/blob/e7a3b46/packages/bootstrap/lib/resolver.js#L12) and [resolveMixins](https://github.com/xing/hops/blob/e7a3b46/packages/bootstrap/lib/resolver.js#L17).

**UPDATE**: I updated this PR, initially to handle the node args via `process.execArgv` (thanks to @ZauberNerd for pointing me out to it), but then also updated to set `symlinks` option to be always `false`, which will solve the issue. Aside to mention: after further investigation, the initial/main pinpoint of the issue was [the resolution of presetJs file](https://github.com/xing/hops/pull/1258/commits/34ef9afeab857144165a9fe30c5d35dbb56c450f#diff-7a1d45a005c82723268a0604aa23a9d6R18) (which is why I updated those few line only for clear names that helped me during debugging). If the presetJs file is resolved to the real path, the mixins in the config object are of real path, and any package loaded within those mixins will be resolved relative to the real path. Yet the `symlink:false` is needed for both the preset and mixin resolution.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] <del>Necessary unit tests are added in order to ensure correct behavior</del> (I am not sure how this could be possibly tested. If any of the reviewers has any idea, I would be curious to know!)
- [ ] <del>Documentation has been added</del> (Is it applicable for such change?!)

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
