### PR TITLE
feat(apollo-mock-server): add hook for enhancing the response object

### DIFF
--- a/packages/apollo-mock-server/README.md
+++ b/packages/apollo-mock-server/README.md
@@ -124,3 +124,7 @@ addMockFunctionsToSchema({
 
 export default mockSchema;
 ```
+
+#### `enhanceApolloMockServerResponse(res): res` ([pipe](https://www.npmjs.com/package/mixinable#definepipe)) **core**
+
+With this mixin hook it is possible to enhance the Apollo Mock-Server's response object, for e.g. setting a custom header on it.

--- a/packages/apollo-mock-server/package.json
+++ b/packages/apollo-mock-server/package.json
@@ -26,9 +26,11 @@
     "express": "^4.17.1",
     "graphql": "^15.0.0",
     "graphql-tools": "^5.0.0",
+    "hops-bootstrap": "^0.0.0",
     "hops-config": "^0.0.0",
     "hops-mixin": "^0.0.0",
-    "hops-webpack": "^0.0.0"
+    "hops-webpack": "^0.0.0",
+    "mixinable": "^5.0.1"
   },
   "peerDependencies": {
     "graphql-tag": "^2.10.0"

--- a/packages/spec/integration/graphql-mock-server/__tests__/develop.js
+++ b/packages/spec/integration/graphql-mock-server/__tests__/develop.js
@@ -5,11 +5,11 @@ describe('graphql mock server', () => {
     url = await HopsCLI.start('--fast-dev');
   });
 
-  it('renders a mocked quote', async () => {
+  it('renders the altered quote', async () => {
     const { page, getInnerText } = await createPage();
     await page.goto(url, { waitUntil: 'networkidle2' });
 
-    expect(await getInnerText('p')).toBe('Hello World');
+    expect(await getInnerText('p')).toBe('Hello altered text.');
 
     await page.close();
   });

--- a/packages/spec/integration/graphql-mock-server/mixin.core.js
+++ b/packages/spec/integration/graphql-mock-server/mixin.core.js
@@ -1,0 +1,14 @@
+const { Mixin } = require('hops-bootstrap');
+
+class GraphQLMockServerMixin extends Mixin {
+  enhanceApolloMockServerResponse(res) {
+    res.actualSend = res.send;
+    res.send = (json) => {
+      const { data } = JSON.parse(json);
+      data.chirpById.text = 'Hello altered text.';
+      res.actualSend(JSON.stringify({ data }));
+    };
+  }
+}
+
+module.exports = GraphQLMockServerMixin;

--- a/packages/spec/integration/graphql-mock-server/package.json
+++ b/packages/spec/integration/graphql-mock-server/package.json
@@ -10,7 +10,8 @@
     "allowServerSideDataFetching": true,
     "port": "8029",
     "graphqlUri": "http://localhost:8029/graphql",
-    "graphqlMockSchemaFile": "<rootDir>/mock-schema.js"
+    "graphqlMockSchemaFile": "<rootDir>/mock-schema.js",
+    "mixins": ["."]
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
