### PR TITLE
feat(webpack): introduce parallel build

### DIFF
--- a/packages/apollo-mock-server/mixin.core.js
+++ b/packages/apollo-mock-server/mixin.core.js
@@ -1,6 +1,6 @@
 const { Mixin } = require('hops-mixin');
 const {
-  internal: { createWebpackMiddleware, StatsFilePlugin },
+  internal: { createWebpackMiddleware },
 } = require('hops-webpack');
 
 function exists(path) {
@@ -75,10 +75,6 @@ class GraphQLMixin extends Mixin {
       );
       webpackConfig.resolve.alias['hops/entrypoint'] = require.resolve(
         './lib/mock-server-middleware'
-      );
-
-      webpackConfig.plugins = webpackConfig.plugins.filter(
-        (p) => !(p instanceof StatsFilePlugin)
       );
     }
   }

--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -113,7 +113,9 @@ class FixtureEnvironment extends NodeEnvironment {
 
   async teardown() {
     await super.teardown();
-    await this.closeBrowser();
+    if (this.closeBrowser) {
+      await this.closeBrowser();
+    }
     if (this.killServer) {
       await this.killServer();
     }

--- a/packages/spec/integration/lambda/__tests__/build.js
+++ b/packages/spec/integration/lambda/__tests__/build.js
@@ -33,7 +33,7 @@ function invokeFunction(root, path) {
 
 describe('lambda production build', () => {
   beforeAll(async () => {
-    await HopsCLI.build('-p');
+    await HopsCLI.build('-p', '--parallel-build');
   });
 
   it('renders something', async () => {

--- a/packages/spec/integration/postcss/__tests__/build.js
+++ b/packages/spec/integration/postcss/__tests__/build.js
@@ -37,7 +37,7 @@ describe('postcss production build', () => {
     await page.close();
   });
 
-  it('supports gobal un-hashed CSS classnames', async () => {
+  it('supports global un-hashed CSS classnames', async () => {
     const { page } = await createPage();
 
     await page.setJavaScriptEnabled(false);

--- a/packages/spec/integration/react/index.js
+++ b/packages/spec/integration/react/index.js
@@ -58,6 +58,7 @@ export default render(
     </Helmet>
     <div>
       <Link to="/two">Link to two</Link>
+      <Link to="/import">Link to import</Link>
       <Switch>
         <Route path="/" exact render={() => <h1>home</h1>} />
         <Route path="/two" exact render={() => <h1>two</h1>} />

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -84,6 +84,12 @@ $ NODE_ENV=production hops start
 
 In `static` mode, static HTML pages will be generated for the [`locations`](../express/README.md#locations) configured for your application.
 
+##### `--parallel-build` / `--no-parallel-build`
+
+A Hops build will fork its process in order to let the Webpack builds run in parallel child processes. While it usually does not reduce the build time it actually helps to significantly reduce the peak memory consumption of the build.
+
+This feature is enabled by default and can be disabled via the `--no-parallel-build` (or `--parallel-build=false`) argument.
+
 ##### `--fast-dev` _experimental_
 
 Using the experimental `--fast-dev` option will disable automatic polyfilling and transpiling of all `node_modules` files through babel to enable faster development times. This will lead to a different bundle being created than in production mode and will not work on all browsers (modern browsers only). Use with caution and report any bugs you may encounter.

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -2,8 +2,8 @@
 
 const { initialize } = require('hops-bootstrap');
 
-const createWebpackMiddleware = require('./lib/middlewares/render');
-const createStatsMiddleware = require('./lib/middlewares/stats');
+const { createRenderMiddleware } = require('./lib/middlewares/render');
+const { createStatsMiddleware } = require('./lib/middlewares/stats');
 
 const { RenderPlugin } = require('./lib/plugins/render');
 const { StatsPlugin, StatsFilePlugin } = require('./lib/plugins/stats');
@@ -22,7 +22,7 @@ const configure = (config, options) => ({
     return initialize(config, options).getBuildConfig(...args);
   },
   internal: {
-    createWebpackMiddleware,
+    createWebpackMiddleware: createRenderMiddleware,
     createStatsMiddleware,
     RenderPlugin,
     StatsPlugin,

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -6,7 +6,7 @@ const { createRenderMiddleware } = require('./lib/middlewares/render');
 const { createStatsMiddleware } = require('./lib/middlewares/stats');
 
 const { RenderPlugin } = require('./lib/plugins/render');
-const { StatsPlugin, StatsFilePlugin } = require('./lib/plugins/stats');
+const { StatsWritePlugin } = require('./lib/plugins/stats');
 
 const { BuildError } = require('./lib/utils/errors');
 const configLoader = require('./lib/utils/loader');
@@ -25,8 +25,7 @@ const configure = (config, options) => ({
     createWebpackMiddleware: createRenderMiddleware,
     createStatsMiddleware,
     RenderPlugin,
-    StatsPlugin,
-    StatsFilePlugin,
+    StatsWritePlugin,
     BuildError,
     configLoader,
   },

--- a/packages/webpack/lib/middlewares/stats.js
+++ b/packages/webpack/lib/middlewares/stats.js
@@ -1,4 +1,4 @@
-module.exports = function createStatsMiddleware(enhancedPromise) {
+function createStatsMiddleware(enhancedPromise) {
   return function statsMiddleware(req, res, next) {
     enhancedPromise
       .then((stats) => {
@@ -7,4 +7,6 @@ module.exports = function createStatsMiddleware(enhancedPromise) {
       })
       .catch(next);
   };
-};
+}
+
+module.exports = { createStatsMiddleware };

--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -1,4 +1,5 @@
-const { RawSource } = require('webpack-sources');
+const { mkdirSync, writeFileSync } = require('fs');
+const { dirname } = require('path');
 const { trimTrailingSlash } = require('pathifist');
 
 const analyzeCompilation = ({ chunks, chunkGroups }) => {
@@ -45,48 +46,30 @@ const extractFiles = (chunkData, rawPublicPath) => {
   };
 };
 
-exports.StatsPlugin = class StatsPlugin {
-  constructor(enhancedPromise) {
+exports.StatsWritePlugin = class StatsWritePlugin {
+  constructor(enhancedPromise, statsFile) {
     this.apply = (compiler) => {
-      compiler.hooks.compilation.tap('StatsPlugin', (compilation) => {
-        compilation.hooks.additionalAssets.tap('StatsPlugin', () => {
+      compiler.hooks.compilation.tap('StatsWritePlugin', (compilation) => {
+        compilation.hooks.additionalAssets.tap('StatsWritePlugin', () => {
           const { publicPath } = compilation.outputOptions;
 
           if (compilation.compiler.isChild()) {
             return;
           }
 
-          try {
-            enhancedPromise.resolve({
-              ...compilation
-                .getStats()
-                .toJson({ all: false, assets: true, entrypoints: true }),
-              ...extractFiles(analyzeCompilation(compilation), publicPath),
-            });
-          } catch (error) {
-            enhancedPromise.reject(error);
-          }
+          const stats = {
+            ...compilation
+              .getStats()
+              .toJson({ all: false, assets: true, entrypoints: true }),
+            ...extractFiles(analyzeCompilation(compilation), publicPath),
+          };
+
+          mkdirSync(dirname(statsFile), { recursive: true });
+          writeFileSync(statsFile, JSON.stringify(stats), 'utf8');
+
+          enhancedPromise.resolve(stats);
         });
       });
-
-      compiler.hooks.watchRun.tap('StatsPlugin', () => enhancedPromise.reset());
-    };
-  }
-};
-
-exports.StatsFilePlugin = class StatsFilePlugin {
-  constructor(enhancedPromise, { statsFile }) {
-    this.apply = (compiler) => {
-      compiler.hooks.compilation.tap('StatsFilePlugin', (compilation) =>
-        compilation.hooks.additionalAssets.tapPromise('StatsFilePlugin', () =>
-          enhancedPromise.then(
-            (stats) =>
-              (compilation.assets[statsFile] = new RawSource(
-                JSON.stringify(stats)
-              ))
-          )
-        )
-      );
     };
   }
 };

--- a/packages/webpack/lib/utils/compiler-fork.js
+++ b/packages/webpack/lib/utils/compiler-fork.js
@@ -1,0 +1,66 @@
+const { join } = require('path');
+const { serializeError } = require('serialize-error');
+
+const { configure } = require('../../');
+const { BuildError, CompilerError } = require('../utils/errors');
+const { createCompiler } = require('./compiler');
+
+process.on('message', (message) => {
+  if (message.name !== 'start') return;
+
+  const {
+    buildConfigArgs,
+    configureArgs,
+    options: { watch },
+  } = message;
+  const webpackConfig = configure(...configureArgs).getBuildConfig(
+    ...buildConfigArgs
+  );
+  const {
+    output: { path, filename },
+    watchOptions,
+  } = webpackConfig;
+  const output = join(path, filename);
+
+  try {
+    const compiler = createCompiler(webpackConfig);
+    const callback = (compileError, stats) => {
+      if (compileError) {
+        process.send({
+          type: 'reject',
+          reason: new CompilerError(compileError),
+        });
+      } else if (stats.hasErrors()) {
+        stats.toJson({ all: false, errors: true }).errors.forEach((error) => {
+          process.send({
+            type: 'reject',
+            reason: new BuildError(error),
+          });
+        });
+      } else {
+        process.send({
+          type: 'resolve',
+          data: {
+            output,
+            stats: stats.toJson({
+              chunks: false,
+              modules: false,
+              entrypoints: false,
+            }),
+          },
+        });
+      }
+    };
+
+    if (watch) {
+      compiler.watch(watchOptions, callback);
+    } else {
+      compiler.run(callback);
+    }
+  } catch (error) {
+    process.send({
+      type: 'reject',
+      reason: serializeError(error),
+    });
+  }
+});

--- a/packages/webpack/mixins/build/mixin.core.js
+++ b/packages/webpack/mixins/build/mixin.core.js
@@ -121,6 +121,11 @@ class WebpackBuildMixin extends Mixin {
               'Experimental: increase build speed (modern browsers only)',
             type: 'boolean',
           },
+          parallelBuild: {
+            default: true,
+            describe: 'Run webpack builds in parallel',
+            type: 'boolean',
+          },
         },
         handler: (argv) =>
           Promise.resolve(argv.clean && this.clean())

--- a/packages/webpack/mixins/build/mixin.core.js
+++ b/packages/webpack/mixins/build/mixin.core.js
@@ -6,6 +6,14 @@ const { sequence } = sync;
 const { callable } = async;
 const { validate, invariant } = bootstrap;
 
+const toPromise = (observable) =>
+  new Promise((resolve, reject) => {
+    observable.subscribe({
+      next: resolve,
+      error: reject,
+    });
+  });
+
 class WebpackBuildMixin extends Mixin {
   clean() {
     const rimraf = require('rimraf');
@@ -23,6 +31,29 @@ class WebpackBuildMixin extends Mixin {
 
   build() {
     const webpack = require('webpack');
+    const { parallelBuild } = this.options;
+
+    if (parallelBuild) {
+      const { forkCompilation } = require('../../lib/utils/compiler');
+      const buildRequests = [];
+      this.collectBuildRequests(buildRequests);
+
+      const compilations = buildRequests.map(({ buildName }) => {
+        const compilation = forkCompilation(this, [buildName]);
+        return toPromise(compilation);
+      });
+
+      return Promise.all(compilations).then((allStats) => {
+        allStats.forEach((stats) => {
+          if (stats instanceof webpack.Stats) {
+            this.inspectBuild(stats);
+          } else {
+            debug(stats);
+          }
+        });
+      });
+    }
+
     const webpackConfigs = [];
     this.collectBuildConfigs(webpackConfigs);
 
@@ -43,6 +74,15 @@ class WebpackBuildMixin extends Mixin {
       this.inspectBuild(stats, webpackConfigs);
       return stats;
     });
+  }
+
+  collectBuildRequests(requests) {
+    requests.push({ buildName: 'node' });
+    requests.push({ buildName: 'build' });
+  }
+
+  handleArguments(argv) {
+    this.options = { ...this.options, ...argv };
   }
 
   inspectBuild(stats) {
@@ -118,6 +158,12 @@ WebpackBuildMixin.strategies = {
     invariant(
       stats && typeof stats.toString === 'function',
       'inspectBuild(): Received invalid Webpack Stats object'
+    );
+  }),
+  collectBuildRequests: validate(sequence, ([requests]) => {
+    invariant(
+      Array.isArray(requests),
+      'collectBuildRequests(): Received invalid requests array'
     );
   }),
 };

--- a/packages/webpack/mixins/develop/mixin.core.js
+++ b/packages/webpack/mixins/develop/mixin.core.js
@@ -1,13 +1,13 @@
 const { Mixin } = require('hops-bootstrap');
+const { createCompiler } = require('../../lib/utils/compiler');
 
 class WebpackDevelopMixin extends Mixin {
   configureServer(app, middlewares, mode) {
     if (mode === 'develop') {
-      const webpack = require('webpack');
       const createWebpackDevMiddleware = require('webpack-dev-middleware');
       const createWebpackHotMiddleware = require('webpack-hot-middleware');
       const webpackDevelopConfig = this.getBuildConfig('develop');
-      const compiler = webpack(webpackDevelopConfig);
+      const compiler = createCompiler(webpackDevelopConfig);
 
       middlewares.initial.push(
         createWebpackDevMiddleware(compiler, {

--- a/packages/webpack/mixins/render/mixin.core.js
+++ b/packages/webpack/mixins/render/mixin.core.js
@@ -4,6 +4,8 @@ const { async } = require('mixinable');
 const { join: joinUrl, ensureLeadingSlash } = require('pathifist');
 const { Mixin, internal: bootstrap } = require('hops-bootstrap');
 
+const { createRenderMiddleware } = require('../../lib/middlewares/render');
+
 const { override } = async;
 const { validate, invariant } = bootstrap;
 
@@ -34,8 +36,6 @@ class WebpackRenderMixin extends Mixin {
 
   configureServer(app, middlewares, mode) {
     if (mode === 'static' || mode === 'develop') {
-      const createRenderMiddleware = require('../../lib/middlewares/render');
-
       middlewares.routes.push(
         createRenderMiddleware(['node'], mode === 'develop', this)
       );

--- a/packages/webpack/mixins/render/mixin.core.js
+++ b/packages/webpack/mixins/render/mixin.core.js
@@ -1,10 +1,11 @@
-const { existsSync: exists } = require('fs');
 const { join } = require('path');
 const { async } = require('mixinable');
 const { join: joinUrl, ensureLeadingSlash } = require('pathifist');
 const { Mixin, internal: bootstrap } = require('hops-bootstrap');
-
-const { createRenderMiddleware } = require('../../lib/middlewares/render');
+const {
+  createRenderMiddleware,
+  tryLoadRenderMiddleware,
+} = require('../../lib/middlewares/render');
 
 const { override } = async;
 const { validate, invariant } = bootstrap;
@@ -39,14 +40,12 @@ class WebpackRenderMixin extends Mixin {
       middlewares.routes.push(
         createRenderMiddleware(['node'], mode === 'develop', this)
       );
-    }
-
-    if (mode === 'serve') {
+    } else if (mode === 'serve') {
       const { serverDir, serverFile } = this.config;
-      const serverFilePath = join(serverDir, serverFile);
+      const middleware = tryLoadRenderMiddleware(join(serverDir, serverFile));
 
-      if (exists(serverFilePath)) {
-        middlewares.routes.push(require(serverFilePath));
+      if (middleware) {
+        middlewares.routes.push(middleware);
       }
     }
   }

--- a/packages/webpack/mixins/stats/mixin.core.js
+++ b/packages/webpack/mixins/stats/mixin.core.js
@@ -46,7 +46,7 @@ class WebpackStatsMixin extends Mixin {
       );
     }
 
-    const createStatsMiddleware = require('../../lib/middlewares/stats');
+    const { createStatsMiddleware } = require('../../lib/middlewares/stats');
 
     middlewares.preroutes.push(createStatsMiddleware(this.statsPromise));
   }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -29,14 +29,12 @@
     "loader-utils": "^2.0.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "memory-fs": "^0.5.0",
     "minimatch": "^3.0.4",
     "mixinable": "^5.0.1",
     "pathifist": "^1.0.0",
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^7.0.0",
     "regenerator-runtime": "^0.13.3",
-    "require-from-string": "^2.0.2",
     "rimraf": "^3.0.0",
     "serialize-error": "^7.0.0",
     "source-map-support": "^0.5.13",
@@ -48,7 +46,8 @@
     "webpack": "^4.41.0",
     "webpack-dev-middleware": "^3.7.2",
     "webpack-hot-middleware": "^2.25.0",
-    "webpack-sources": "^1.4.3"
+    "webpack-sources": "^1.4.3",
+    "zen-observable": "^0.8.15"
   },
   "engines": {
     "node": "10 || 12 || 13 || 14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11629,11 +11629,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -13914,7 +13909,7 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable@^0.8.0, zen-observable@^0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Successor of #1256

When the new `--parallel-build` CLI argument is set to true (which is the default)
we will fork the process for each Webpack compilation into a new child process.
This helps to reduce the peak memory consumption because we don't need to rely on the GC to clean everything up as the
child process stops right after the compilation has finished.
The build might also be faster as we can use more CPU cores but that improvement isn't as significant as I was hoping for though.
