### PR TITLE
chore: add ./build-folders from prettifying

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 node_modules/
-packages/*/**/build
 packages/*/**/dist
 package-lock.json
 fragmentTypes.json

--- a/packages/webpack/mixins/build/mixin.core.js
+++ b/packages/webpack/mixins/build/mixin.core.js
@@ -4,9 +4,7 @@ const { Mixin, internal: bootstrap } = require('hops-bootstrap');
 
 const { sequence } = sync;
 const { callable } = async;
-const {
-  validate, invariant
-} = bootstrap;
+const { validate, invariant } = bootstrap;
 
 class WebpackBuildMixin extends Mixin {
   clean() {


### PR DESCRIPTION
the `./build`-folders came in with the merge of untool into hops. that's why they're still pretty nicely formatted. but things will slowly go south, if we don't have them formatted automatically.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
