### PR TITLE
feat(redux): allow function as route action creator

### DIFF
--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -89,9 +89,9 @@ export default render(<MyApp />, { redux: { middlewares: [logger, thunk] } });
 
 ##### `actionCreators`
 
-In order to dispatch actions based on the currently matching route you can specify a list of actions for [matching urls](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md).
+In order to dispatch actions based on the currently matching route you can specify a list of actions for [matching urls](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md). Those can either be plain objects or functions returning objects. Functions get the Hops config passed in as an argument when called internally. So if you need a property from the Hops config in your action, opt for the function syntax.
 
-These objects have the same properties as the [`<Route />` component](https://reacttraining.com/react-router/core/api/Route/path-string) and an additional `action` key with which the action that is to be dispatched can be specified.
+These objects — whether plain or as the return value of a function — have the same properties as the [`<Route />` component](https://reacttraining.com/react-router/core/api/Route/path-string) and an additional `action` key with which the action that is to be dispatched can be specified.
 
 When server-side rendering/data fetching is enabled, this will dispatch matching actions on the server and prefill the store for client-side.
 
@@ -113,6 +113,10 @@ export default render(<MyApp />, {
         path: '/users/:id',
         action: ({ id }) => fetchUser(id),
       },
+      (config) => ({
+        path: '/items',
+        action: () => fetchItems(config.apiBaseUrl),
+      }),
     ],
   },
 });

--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -76,7 +76,10 @@ class ReduxActionCreatorRuntimeMixin extends Mixin {
 
     return Promise.all(
       actionCreators.map((actionCreator) => {
-        const { action, path, exact = true, strict = false } = actionCreator;
+        const { action, path, exact = true, strict = false } =
+          typeof actionCreator === 'function'
+            ? actionCreator(this.config)
+            : actionCreator;
         var match = matchPath(location.pathname.replace(basePathRegEx, ''), {
           path: path,
           exact: exact,

--- a/packages/redux/index.d.ts
+++ b/packages/redux/index.d.ts
@@ -1,13 +1,20 @@
 import { Middleware, ReducersMapObject, Action as ActionCreator } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { Config } from 'hops';
 
 declare module 'hops-redux' {
-  interface HopsReduxActionCreator {
+  interface HopsReduxActionCreatorObject {
     action: ActionCreator | ThunkAction<any, any, any, any>;
     path: string;
     exact?: boolean;
     strict?: boolean;
   }
+  type HopsReduxActionCreatorFunction = (
+    config: Config
+  ) => HopsReduxActionCreatorObject;
+  type HopsReduxActionCreator =
+    | HopsReduxActionCreatorObject
+    | HopsReduxActionCreatorFunction;
 
   export interface HopsReduxOptions {
     redux: {

--- a/packages/spec/integration/redux-without-ssr/__tests__/develop.js
+++ b/packages/spec/integration/redux-without-ssr/__tests__/develop.js
@@ -1,3 +1,7 @@
+const {
+  hops: { arbitraryValue: configValue },
+} = require('../package.json');
+
 describe('redux development server', () => {
   let url;
 
@@ -12,6 +16,17 @@ describe('redux development server', () => {
     const count = await getInnerText('h1');
 
     expect(count).toBe('3');
+
+    await page.close();
+  });
+
+  it('sets the config value on page load', async () => {
+    const { page, getInnerText } = await createPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    const count = await getInnerText('dd');
+
+    expect(count).toBe(configValue);
 
     await page.close();
   });

--- a/packages/spec/integration/redux-without-ssr/index.js
+++ b/packages/spec/integration/redux-without-ssr/index.js
@@ -12,22 +12,37 @@ const reducers = {
         return state;
     }
   },
+  value(state = null, action) {
+    switch (action.type) {
+      case 'SET_VALUE':
+        return action.payload;
+      default:
+        return state;
+    }
+  },
 };
 
 const increment = () => ({ type: 'INCREMENT', payload: 3 });
 
-const Counter = ({ count }) => (
+const setValue = (value) => ({ type: 'SET_VALUE', payload: value });
+
+const Counter = ({ count, value }) => (
   <>
     <Helmet>
       <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     </Helmet>
     <h1>{count}</h1>
+    <dl>
+      <dt>Arbitrary value</dt>
+      <dd>{value}</dd>
+    </dl>
   </>
 );
 
-const ConnectedCounter = connect(({ counter }) => ({ count: counter }), {
-  increment,
-})(Counter);
+const ConnectedCounter = connect(
+  ({ counter, value }) => ({ count: counter, value }),
+  { increment }
+)(Counter);
 
 export default render(<ConnectedCounter />, {
   redux: {
@@ -37,6 +52,10 @@ export default render(<ConnectedCounter />, {
         path: '/',
         action: increment,
       },
+      (config) => ({
+        path: '/',
+        action: () => setValue(config.arbitraryValue),
+      }),
     ],
   },
 });

--- a/packages/spec/integration/redux-without-ssr/package.json
+++ b/packages/spec/integration/redux-without-ssr/package.json
@@ -17,7 +17,11 @@
   },
   "hops": {
     "gracePeriod": 0,
-    "shouldPrefetchOnServer": false
+    "shouldPrefetchOnServer": false,
+    "arbitraryValue": "foo123",
+    "browserWhitelist": {
+      "arbitraryValue": true
+    }
   },
   "dependencies": {
     "hops": "*",

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -1,4 +1,7 @@
 const urlJoin = require('url-join');
+const {
+  hops: { port },
+} = require('../package.json');
 
 describe('redux development server', () => {
   let url;
@@ -124,6 +127,19 @@ describe('redux development server', () => {
       const matchParam = await getInnerText('value');
 
       expect(matchParam).toBe('foobar');
+
+      await page.close();
+    });
+
+    it('will be provided with the Hops config if passed in as a function', async () => {
+      const { page, getInnerText } = await createPage();
+      await page.goto(urlJoin(url, '/config-test'), {
+        waitUntil: 'networkidle2',
+      });
+
+      const param = await getInnerText('value');
+
+      expect(param).toBe(port);
 
       await page.close();
     });

--- a/packages/spec/integration/redux/index.js
+++ b/packages/spec/integration/redux/index.js
@@ -50,6 +50,8 @@ const setMatchParam = (params, { match: { params: matchParams } }) => {
   };
 };
 
+const setConfigValue = (value) => ({ type: 'SET_VALUE', payload: value });
+
 const Counter = ({ count, increment, val }) => (
   <>
     <Helmet>
@@ -99,6 +101,10 @@ export default render(<ConnectedCounter />, {
         path: '/match-test/:test',
         action: setMatchParam,
       },
+      (config) => ({
+        path: '/config-test',
+        action: () => setConfigValue(config.port),
+      }),
     ],
   },
 });


### PR DESCRIPTION
Merge only in case #1291 gets merged!!

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
