### PR TITLE
fix(webpack): reset stats file / promise on watch run events

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -66,8 +66,11 @@ exports.StatsWritePlugin = class StatsWritePlugin {
 
           mkdirSync(dirname(statsFile), { recursive: true });
           writeFileSync(statsFile, JSON.stringify(stats), 'utf8');
-
           enhancedPromise.resolve(stats);
+        });
+
+        compiler.hooks.watchRun.tap('StatsWritePlugin', () => {
+          enhancedPromise.reset();
         });
       });
     };


### PR DESCRIPTION
Seems like this has gotten lost during the parallel build feature: https://github.com/xing/hops/commit/30ad91c2eccfbd103ca40290cdc0f8a655651da6#diff-5fe2ecdd50bbcabc5564903e94169121L72

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>