### PR TITLE
feat: allow mixin instantiation without side-effects

### DIFF
--- a/packages/bootstrap/index.js
+++ b/packages/bootstrap/index.js
@@ -11,7 +11,32 @@ exports.initialize = function initialize(overrides = {}, ...args) {
   return exports.bootstrap(config, mixins, ...args);
 };
 
-exports.bootstrap = function bootstrap(config, mixins, ...args) {
+function hasClasses(mixins) {
+  return mixins.every((mixin) => mixin instanceof Object);
+}
+
+exports.bootstrap = function bootstrap(
+  { _mixins, _type = 'core', _workspace, ...overrides } = {},
+  ...args
+) {
+  const config = _mixins
+    ? getConfig({
+        getDefaults() {
+          return {
+            rootDir: overrides.rootDir || '',
+            name: overrides.name || '',
+            version: overrides.version || '',
+            workspace: _workspace || '',
+            settings: overrides,
+          };
+        },
+        _mixins,
+      })
+    : getConfig(overrides);
+
+  const mixins =
+    _mixins && hasClasses(_mixins[_type]) ? _mixins[_type] : getMixins(config);
+
   const strategies = {
     ...mixins.reduce(
       (result, mixin) => ({ ...result, ...mixin.strategies }),

--- a/packages/bootstrap/index.js
+++ b/packages/bootstrap/index.js
@@ -8,6 +8,10 @@ const { getConfig, getMixins } = require('./lib/config');
 exports.initialize = function initialize(overrides = {}, ...args) {
   const config = getConfig(overrides);
   const mixins = getMixins(config);
+  return exports.bootstrap(config, mixins, ...args);
+};
+
+exports.bootstrap = function bootstrap(config, mixins, ...args) {
   const strategies = {
     ...mixins.reduce(
       (result, mixin) => ({ ...result, ...mixin.strategies }),


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>