### PR TITLE
fix(bootstrap): re-export strategies in hops-bootstrap

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -14,4 +14,4 @@ Deep imports to `hops-react/lib/runtime` are deprecated and should be changed to
 
 ### DEP0005
 
-`hops-mixin` is deprecated, please import the `Mixin` class from `hops-bootstrap` instead and the strategies from `mixinable`.
+`hops-mixin` is deprecated, please import the `Mixin` class and strategies from `hops-bootstrap` instead.

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -231,3 +231,42 @@ Note that you can call all defined mixinable methods directly on your mixin inst
 This is a semi-private function that is mainly being used internally, for example by [`hops-yargs`](../yargs/README.md). It returns the core mixin container - this allows you to call all defined mixin methods.
 
 You will only ever have to call it if you want to use `hops-bootstrap` programmatically. You can pass it an `configOverrides` object that will be merged into the main config object, and and options object mixins might use instead of CLI arguments.
+
+#### strategies
+
+Strategies allow to define mixin hooks that are usable by other mixins. There are various types of strategies. `callable` will make the method available to other mixins. Methods with strategy `pipe` pass each implementation's output to the next, using the first argument as the initial value. All other arguments are being passed to all implementations as-is.
+
+For a complete list of available strategies, have a look at the [mixinable documentation](https://github.com/untool/mixinable).
+
+##### Callable example
+
+A mixin that exposes a method to retrieve the build config.
+
+```javascript
+const {
+  Mixin,
+  strategies: { sync: callable },
+} = require('hops-bootstrap');
+
+class BuildConfigMixin extends Mixin {
+  getBuildConfig() {
+    return this.buildConfig;
+  }
+}
+
+MyMixin.strategies = {
+  getBuildConfig: callable,
+};
+```
+
+Other mixins are now able to call the method.
+
+```javascript
+const { Mixin } = require('hops-bootstrap');
+
+class ConsumerMixin extends Mixin {
+  myMethod() {
+    const config = this.getBuildConfig();
+  }
+}
+```

--- a/packages/bootstrap/index.js
+++ b/packages/bootstrap/index.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('hops:bootstrap');
 const isPlainObject = require('is-plain-obj');
-const { define } = require('mixinable');
+const { async, define, sync } = require('mixinable');
 
 const { getConfig, getMixins } = require('./lib/config');
 
@@ -13,6 +13,8 @@ exports.Mixin = class Mixin {
     this.options = isPlainObject(options) ? options : {};
   }
 };
+
+exports.strategies = { async, sync };
 
 exports.initialize = function initialize(overrides = {}, ...args) {
   const config = getConfig(overrides);


### PR DESCRIPTION
Otherwise, we would need to add mixinable to all internal Hops packages which would
be unfortunate and also makes it possible to have multiple versions of mixinable in
the app if the versions diverge.

The deprecation got introduced in #1162 and is only available in v13 AFAICT.