### PR TITLE
feat(jest-preset): print an error when Jest version is unsupported

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -1,4 +1,14 @@
+const colors = require('colors');
 const { defaults } = require('jest-config');
+const jestVersion = require('jest/package.json').version;
+
+if (jestVersion[0] < 26) {
+  console.error(
+    colors.red(
+      'Error: You are using an unsupported version of Jest! Please upgrade to Jest v26.'
+    )
+  );
+}
 
 module.exports = {
   globals: {

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
     "babel-jest": "^26.0.0",
+    "colors": "^1.4.0",
     "core-js": "^3.2.1",
     "hops": "^13.0.0-rc.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,7 +4697,7 @@ colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>