### PR TITLE
fix(webpack): use webpack HMR for node build to fix memory leak

### DIFF
--- a/packages/webpack/lib/middlewares/render.js
+++ b/packages/webpack/lib/middlewares/render.js
@@ -17,10 +17,18 @@ function createRenderMiddleware(buildConfigArgs, watch, mixin) {
   }
 
   const enhancedPromise = new EnhancedPromise();
+  let middleware;
 
   compilation.subscribe(({ output }) => {
     enhancedPromise.reset();
-    enhancedPromise.resolve(loadRenderMiddleware(output));
+
+    if (middleware) {
+      process.emit('RELOAD');
+    } else {
+      middleware = loadRenderMiddleware(output);
+    }
+
+    enhancedPromise.resolve(middleware);
   });
 
   return function renderMiddleware(req, res, next) {


### PR DESCRIPTION
This was implemented previously already but got lost during the
implementation of another feature which was intended to reduce memory
consumption.

We are using webpack hot module reload for the server bundle, to be able
to update a running server with incremental changes.
In order to use the HMR on the server side, we need to send a signal to
the process which tells webpack to reloaad the module.
This is the part that got lost and instead we re-required the server
bundle every time a watch event happened on the webpack compiler.

In the current implementation we require the server bundle just once and
let webpack HMR handle all other updates.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>