### PR TITLE
test: remove redundant failing graphql test

### DIFF
--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -7,13 +7,6 @@ describe('graphql development client', () => {
     url = await HopsCLI.start('--fast-dev');
   });
 
-  it('renders a list of commits', async () => {
-    const { page } = await createPage();
-    await page.goto(url, { waitUntil: 'networkidle2' });
-    await page.waitForSelector('#commits', { timeout: 10000 });
-    await page.close();
-  });
-
   describe('/html', () => {
     it('should render a 500 error page for an invalid status 200 response', async () => {
       const response = await fetch(`${url}html`);

--- a/packages/spec/integration/graphql/index.js
+++ b/packages/spec/integration/graphql/index.js
@@ -1,32 +1,9 @@
-import gql from 'graphql-tag';
 import { render } from 'hops';
 import { Helmet } from 'react-helmet-async';
 import { Switch, Route } from 'react-router-dom';
 import React from 'react';
-import { Query } from 'react-apollo';
 
 import TestQuery from './query';
-
-const commits = gql`
-  query commits {
-    showCommits @client
-    github {
-      repo(ownerUsername: "xing", name: "hops") {
-        commits(limit: 10) {
-          ... on GithubCommit {
-            sha
-            message
-            author {
-              ... on GithubUser {
-                login
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
 
 const App = () => (
   <>
@@ -34,31 +11,6 @@ const App = () => (
       <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     </Helmet>
     <Switch>
-      <Route
-        path="/"
-        exact={true}
-        render={() => (
-          <Query query={commits}>
-            {({ loading, error, data }) => {
-              if (loading) return <b id="loading">loading commits...</b>;
-              if (error) return <b id="error">Error: {error.message}</b>;
-
-              if (!data.showCommits) {
-                return null;
-              }
-              return (
-                <ul id="commits">
-                  {data.github.repo.commits.map((commit) => (
-                    <li key={commit.sha}>
-                      {commit.message} by <b>{commit.author.login}</b>
-                    </li>
-                  ))}
-                </ul>
-              );
-            }}
-          </Query>
-        )}
-      />
       <Route
         path="/html"
         exact={true}
@@ -83,14 +35,4 @@ const App = () => (
   </>
 );
 
-export default render(<App />, {
-  graphql: {
-    resolvers: {
-      Query: {
-        showCommits() {
-          return true;
-        },
-      },
-    },
-  },
-});
+export default render(<App />);

--- a/packages/spec/integration/graphql/package.json
+++ b/packages/spec/integration/graphql/package.json
@@ -10,7 +10,7 @@
     "mixins": [
       "./"
     ],
-    "graphqlUri": "https://www.graphqlhub.com/graphql"
+    "graphqlUri": "https://some.graphql/api"
   },
   "jest": {
     "testEnvironment": "../../helpers/env.js",


### PR DESCRIPTION
This test verifies that a GraphQL response has been rendered onto the
page.
We have another test (./packages/spec/integration/graphql-mock-server/__tests__/develop.js)
which also verifies that a GraphQL response has been rendered.
The mock-server test uses our own GraphQL mock server instead of a
third party.
The problem here is that the GraphQL test uses a third party server
which is not available anymore and therefore our tests are failing.
By switching to our own mock server we are not relying on external
services anymore.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>