### PR TITLE
fix(webpack): replace serialize-error with a custom implementation

### DIFF
--- a/packages/webpack/lib/utils/compiler-fork.js
+++ b/packages/webpack/lib/utils/compiler-fork.js
@@ -1,8 +1,11 @@
 const { join } = require('path');
-const { serializeError } = require('serialize-error');
 
 const { configure } = require('../../');
-const { BuildError, CompilerError } = require('../utils/errors');
+const {
+  BuildError,
+  CompilerError,
+  serializeError,
+} = require('../utils/errors');
 const { createCompiler } = require('./compiler');
 
 process.on('message', (message) => {

--- a/packages/webpack/lib/utils/compiler.js
+++ b/packages/webpack/lib/utils/compiler.js
@@ -3,7 +3,11 @@ const { fork } = require('child_process');
 const Observable = require('zen-observable');
 const sourceMapSupport = require('source-map-support');
 
-const { BuildError, CompilerError } = require('../utils/errors');
+const {
+  BuildError,
+  CompilerError,
+  deserializeError,
+} = require('../utils/errors');
 
 function createCompiler(webpackConfig) {
   const webpack = require('webpack');
@@ -71,7 +75,7 @@ function forkCompilation(mixin, buildConfigArgs, options = {}) {
         subscriber.error(
           typeof reason === 'string'
             ? new BuildError(reason)
-            : new CompilerError(reason)
+            : deserializeError(reason)
         );
       } else if (type === 'resolve') {
         subscriber.next(data);

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -37,7 +37,6 @@
     "pretty-ms": "^7.0.0",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^3.0.0",
-    "serialize-error": "^7.0.0",
     "source-map-support": "^0.5.13",
     "speed-measure-webpack-plugin": "^1.3.3",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
For some reason, serialize-error is unable to successfully detect and resolve a circular error object. The result is an out-of-memory error when the compilation fails. I haven't tested if this is the case for all errors or only some specific ones though.

Another flaw of the previous implementation is that we lose the information whether the error is a compile or build error as the error deserialization always created a plain `Error` instance.
And as an error object only consists of the [three fields `name`,  `message` and  `stack`](https://github.com/microsoft/TypeScript/blob/7c6462aa10329884618c51ff9af76c66b503f47c/lib/lib.es5.d.ts#L972-L976
) the serialization of any other fields seems unnecessary to me.