### PR TITLE
Fix lambda diagnosis hook

### DIFF
--- a/packages/lambda/mixin.core.js
+++ b/packages/lambda/mixin.core.js
@@ -109,8 +109,9 @@ class LambdaMixin extends Mixin {
 
     if (
       !this.awsConfig.domainName &&
-      this.awsConfig.basePath.indexOf(this.awsConfig.stageName) !== 0 &&
-      trimSlashes(this.config.assetPath).indexOf(this.awsConfig.stageName) !== 0
+      (this.awsConfig.basePath.indexOf(this.awsConfig.stageName) !== 0 ||
+        trimSlashes(this.config.assetPath).indexOf(this.awsConfig.stageName) !==
+          0)
     ) {
       warnings.push(
         `When no custom domain is configured, the stageName (${this.awsConfig.stageName}) should be the first path segment in basePath (${this.awsConfig.basePath}) and assetPath (${this.config.assetPath}).`

--- a/packages/lambda/mixin.core.js
+++ b/packages/lambda/mixin.core.js
@@ -123,6 +123,8 @@ class LambdaMixin extends Mixin {
         'Setting a custom domain name also requires to specify the ACM certificate ARN.'
       );
     }
+
+    return warnings;
   }
 }
 


### PR DESCRIPTION
- fix condition concerning `basePath` and `assetPath`
- ensure warnings are printed

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
