### PR TITLE
fix(jest-preset): fix warning in case of outdated Jest version

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -1,8 +1,8 @@
 const colors = require('colors');
 const { defaults } = require('jest-config');
-const jestVersion = require('jest/package.json').version;
+const [jestMajorVersion] = require('jest/package.json').version.split('.');
 
-if (jestVersion[0] < 26) {
+if (Number(jestMajorVersion) < 26) {
   console.error(
     colors.red(
       'Error: You are using an unsupported version of Jest! Please upgrade to Jest v26.'


### PR DESCRIPTION
The current implementation compares the string `"2"` with the number `26`. This commit should™ fix it.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
