### PR TITLE
Improve diagnose hook

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -11,3 +11,7 @@ The config property `shouldPrefetchOnServer` is deprecated and will be removed i
 ### DEP0004
 
 Deep imports to `hops-react/lib/runtime` are deprecated and should be changed to `hops-react` instead.
+
+### DEP0005
+
+Returning warnings from `hops-doctor`'s `diagnose`-hook is deprecated. Please use the doctor's `pushWarning`- and `pushError`-functions instead.

--- a/packages/info/README.md
+++ b/packages/info/README.md
@@ -54,19 +54,29 @@ module.exports = class FooMixin extends Mixin {
 };
 ```
 
-### `diagnose(doctor)` ([parallel](https://github.com/untool/mixinable/blob/master/README.md#defineparallel))
+### `diagnose(doctor, mode)` ([parallel](https://github.com/untool/mixinable/blob/master/README.md#defineparallel))
 
-By implementing this method, your core mixin can perform pre-flight checks during application startup and return an array of warnings. If you need to do something asynchronous at this point, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+By implementing this method, your core mixin can perform pre-flight checks during application startup/build and create warnings & errors. If you need to do something asynchronous at this point, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+The second argument `mode` lets you create context-sensitive warnings/errors. Its possible values are:
+
+- `'build-serve'`
+- `'develop'`
+- `'serve'`
+- `'build'`
+- `'indeterminate'`
 
 ```javascript
 const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
-  diagnose(doctor) {
+  diagnose(doctor, mode) {
     doctor.diagnoseDuplicatePackages('bar');
-    if (1 + 1 !== 2) {
-      return ['Math is broken.'];
-    }
+    const mathIsBroken = 1 + 1 !== 2;
+    const message = 'Math is broken.';
+
+    if (mode === 'develop') doctor.pushWarning(message);
+    if (mode === 'serve') doctor.pushError('heavy-math', message);
   }
 };
 ```

--- a/packages/info/doctor/index.js
+++ b/packages/info/doctor/index.js
@@ -1,4 +1,4 @@
-const { define, sync } = require('mixinable');
+const { define, sync, async: asyncHooks } = require('mixinable');
 
 const { callable, sequence } = sync;
 
@@ -6,7 +6,11 @@ const strategies = {
   validateConfig: callable,
   detectDuplicatePackages: callable,
   collectResults: callable,
+  pushWarning: callable,
+  pushError: callable,
   logResults: sequence,
+  setMode: callable,
+  getMode: asyncHooks.callable,
 };
 
 const mixins = [

--- a/packages/info/doctor/mixin.core.js
+++ b/packages/info/doctor/mixin.core.js
@@ -1,5 +1,6 @@
 const { async } = require('mixinable');
 const { Mixin } = require('hops-mixin');
+const deprecate = require('depd')('hops-doctor');
 const { internal: bootstrap } = require('hops-bootstrap');
 const { createDoctor } = require('.');
 
@@ -44,9 +45,13 @@ class DoctorMixin extends Mixin {
     return Promise.resolve().then(() => {
       doctor.getMode().then((mode) =>
         this.diagnose(doctor, mode).then((results) => {
-          doctor.collectResults(
-            ...[].concat(...results.filter((result) => result !== undefined))
-          );
+          const messages = results.filter(Boolean);
+          if (messages.length) {
+            deprecate(
+              'Returning messages from the diagnose-hook is deprecated. Please use "pushWarning" and "pushError" instead.'
+            );
+          }
+          doctor.collectResults(...[].concat(...messages));
           doctor.logResults(this.getLogger());
         })
       );

--- a/packages/info/doctor/validators/generic.js
+++ b/packages/info/doctor/validators/generic.js
@@ -1,10 +1,31 @@
+const EnhancedPromise = require('eprom');
+
 const defaultHandler = (messages, logger) => {
   messages.forEach((message) => logger.warn(message));
 };
 
+const { HOPS_IGNORE_ERRORS = '' } = process.env;
+const errorsIgnoreList = HOPS_IGNORE_ERRORS.split(/\s*,\s*/).filter(Boolean);
+
+const errorIsIgnored = (tag) => errorsIgnoreList.includes(tag);
+
 module.exports = class GenericValidationMixin {
-  constructor() {
+  constructor(_, handleError) {
     this.messagesMap = new Map();
+    this.modePromise = new EnhancedPromise();
+    this.handleError = (errors) =>
+      errors.forEach((err, i, { length }) => {
+        const recoverable = i < length - 1;
+        handleError(err, recoverable);
+      });
+  }
+
+  setMode(mode) {
+    this.modePromise.resolve(mode);
+  }
+
+  getMode() {
+    return this.modePromise;
   }
 
   collectResults(handler, ...messages) {
@@ -24,8 +45,35 @@ module.exports = class GenericValidationMixin {
     }
   }
 
+  pushWarning(warning) {
+    this.collectResults(warning);
+  }
+
+  pushError(tag, error) {
+    if (!error) {
+      throw new Error('Please provide a tag for the error message.');
+    }
+
+    if (errorIsIgnored(tag)) {
+      this.collectResults(error);
+    } else {
+      this.collectResults(this.handleError, error);
+    }
+  }
+
   logResults(logger) {
     const { messagesMap } = this;
-    messagesMap.forEach((messages, handler) => handler(messages, logger));
+    const entries = [];
+
+    for (const [handler, messages] of messagesMap.entries()) {
+      const fn = () => handler(messages, logger);
+      if (handler === this.handleError) {
+        entries.push(fn);
+      } else {
+        entries.unshift(fn);
+      }
+    }
+
+    entries.forEach((fn) => fn());
   }
 };

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/xing/hops#readme",
   "dependencies": {
     "chalk": "^4.0.0",
+    "depd": "^2.0.0",
     "duplitect": "^3.0.0",
     "enhanced-resolve": "^5.0.0",
     "eprom": "^1.0.0",

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -15,6 +15,7 @@
     "chalk": "^4.0.0",
     "duplitect": "^3.0.0",
     "enhanced-resolve": "^5.0.0",
+    "eprom": "^1.0.0",
     "escape-string-regexp": "^4.0.0",
     "hops-bootstrap": "^14.0.0-nightly.0",
     "hops-mixin": "^14.0.0-nightly.0",

--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -119,6 +119,10 @@ class FixtureEnvironment extends NodeEnvironment {
         });
         // eslint-disable-next-line require-atomic-updates
         that.killServer = teardown;
+        that.global.killServer = () => {
+          delete that.killServer;
+          return teardown();
+        };
         return url;
       },
     };

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -13,7 +13,7 @@ const resolveFrom = require('resolve-from');
 
 const build = async ({ cwd, env = {}, argv = [] }) => {
   const hopsBin = resolveFrom(cwd, 'hops/bin');
-  const command = `${hopsBin} build ${argv.join(' ')}`;
+  const command = `${process.argv[0]} ${hopsBin} build ${argv.join(' ')}`;
   debug('Starting', command);
   try {
     return await exec(command, { env, cwd });

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -15,9 +15,11 @@ const build = async ({ cwd, env = {}, argv = [] }) => {
   const hopsBin = resolveFrom(cwd, 'hops/bin');
   const command = `${hopsBin} build ${argv.join(' ')}`;
   debug('Starting', command);
-  await exec(command, { env, cwd });
-
-  return cwd;
+  try {
+    return await exec(command, { env, cwd });
+  } catch (err) {
+    return { stderr: err.message };
+  }
 };
 const startServer = ({ cwd, command, env = {}, argv = [] }) =>
   new Promise((resolve, reject) => {

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -57,7 +57,7 @@ const startServer = ({ cwd, command, env = {}, argv = [] }) =>
 
     started.on('close', (code) => {
       debug('Server stopped. exitcode:', code);
-      onTeardown();
+      onTeardown(stderr);
       if (code) {
         reject(stderr);
       }

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -11,15 +11,15 @@ const mkdirp = promisify(require('mkdirp'));
 const debug = require('debug')('hops-spec:test-helpers');
 const resolveFrom = require('resolve-from');
 
-const build = async ({ cwd, argv = [] }) => {
+const build = async ({ cwd, env = {}, argv = [] }) => {
   const hopsBin = resolveFrom(cwd, 'hops/bin');
   const command = `${hopsBin} build ${argv.join(' ')}`;
   debug('Starting', command);
-  await exec(command, { cwd });
+  await exec(command, { env, cwd });
 
   return cwd;
 };
-const startServer = ({ cwd, command, argv = [] }) =>
+const startServer = ({ cwd, command, env = {}, argv = [] }) =>
   new Promise((resolve, reject) => {
     let onTeardown;
     const teardownPromise = new Promise((resolve) => (onTeardown = resolve));
@@ -29,6 +29,7 @@ const startServer = ({ cwd, command, argv = [] }) =>
     const args = [hopsBin, command].concat(argv);
     debug('Spawning server', [hopsBin, ...args].join(' '));
     const started = spawn(process.argv[0], args, {
+      env,
       cwd,
     });
     const teardown = () => {

--- a/packages/spec/integration/doctor/__tests__/build.js
+++ b/packages/spec/integration/doctor/__tests__/build.js
@@ -1,0 +1,40 @@
+describe('doctor - build', () => {
+  let logs;
+
+  const getFromLogs = (type, message) =>
+    logs.find((l) => l.endsWith(`:${type}] ${message}`));
+
+  beforeAll(async () => {
+    const { stderr } = await HopsCLI.build(
+      {
+        HOPS_IGNORE_ERRORS: 'doctor-mixin-a-two',
+      },
+      '-p',
+      '--parallel-build'
+    );
+    logs = stderr
+      .split(/\n+/)
+      .filter(Boolean)
+      .filter((l) => l.startsWith('['));
+  });
+
+  it('produces a warning for "build"-mode', () => {
+    const warning = getFromLogs('warning', 'Warn::Mixin-B Second');
+    const nonExistingWarning = getFromLogs('warning', 'Warn::Mixin-B First');
+
+    expect(warning).toBeTruthy();
+    expect(nonExistingWarning).toBeUndefined();
+  });
+
+  it('produces an error for "build"-mode', () => {
+    const error = getFromLogs('error', 'Err::Mixin-B Second');
+
+    expect(error).toBeTruthy();
+  });
+
+  it('outputs the ignord error as warning', () => {
+    const ignoredError = getFromLogs('warning', 'Err::Mixin-A Second');
+
+    expect(ignoredError).toBeTruthy();
+  });
+});

--- a/packages/spec/integration/doctor/__tests__/develop.js
+++ b/packages/spec/integration/doctor/__tests__/develop.js
@@ -1,0 +1,42 @@
+const delay = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+describe('doctor - develop', () => {
+  let logs;
+
+  const getFromLogs = (type, message) =>
+    logs.find((l) => l.endsWith(`:${type}] ${message}`));
+
+  beforeAll(async () => {
+    await HopsCLI.start(
+      { HOPS_IGNORE_ERRORS: 'doctor-mixin-a-one' },
+      '--fast-dev'
+    );
+    await delay();
+    const stderr = await killServer();
+    logs = stderr.split(/\n+/).filter(Boolean);
+  });
+
+  it('produces warnings for "develop"-mode', () => {
+    const firstWarning = getFromLogs('warning', 'Warn::Mixin-A First');
+    const secondWarning = getFromLogs('warning', 'Warn::Mixin-B First');
+    const nonExistingWarning = getFromLogs('warning', 'Warn::Mixin-B Second');
+    const deferredWarning = getFromLogs('warning', 'Warn::Mixin-A Second');
+
+    expect(firstWarning).toBeTruthy();
+    expect(secondWarning).toBeTruthy();
+    expect(nonExistingWarning).toBeUndefined();
+    expect(deferredWarning).toBeTruthy();
+  });
+
+  it('produces errors for "develop"-mode', () => {
+    const error = getFromLogs('error', 'Err::Mixin-B First');
+
+    expect(error).toBeTruthy();
+  });
+
+  it('outputs the ignord error as warning', () => {
+    const ignoredError = getFromLogs('warning', 'Err::Mixin-A First');
+
+    expect(ignoredError).toBeTruthy();
+  });
+});

--- a/packages/spec/integration/doctor/index.js
+++ b/packages/spec/integration/doctor/index.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import { render } from 'hops';
+
+export default render(<h1>I'm not here.</h1>);

--- a/packages/spec/integration/doctor/mixin-a/mixin.core.js
+++ b/packages/spec/integration/doctor/mixin-a/mixin.core.js
@@ -1,0 +1,16 @@
+const { Mixin } = require('hops-mixin');
+
+const defer = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+module.exports = class DoctorCoreMixin extends Mixin {
+  diagnose({ pushError, pushWarning }, mode) {
+    if (mode === 'develop') {
+      pushError('doctor-mixin-a-one', 'Err::Mixin-A First');
+      pushWarning('Warn::Mixin-A First');
+    }
+    if (mode === 'build') {
+      pushError('doctor-mixin-a-two', 'Err::Mixin-A Second');
+    }
+    return defer().then(() => pushWarning('Warn::Mixin-A Second'));
+  }
+};

--- a/packages/spec/integration/doctor/mixin-b/mixin.core.js
+++ b/packages/spec/integration/doctor/mixin-b/mixin.core.js
@@ -1,0 +1,14 @@
+const { Mixin } = require('hops-mixin');
+
+module.exports = class DoctorCoreMixin extends Mixin {
+  diagnose({ pushError, pushWarning }, mode) {
+    if (mode === 'develop') {
+      pushError('doctor-mixin-b-one', 'Err::Mixin-B First');
+      pushWarning('Warn::Mixin-B First');
+    }
+    if (mode === 'build') {
+      pushError('doctor-mixin-b-one', 'Err::Mixin-B Second');
+      pushWarning('Warn::Mixin-B Second');
+    }
+  }
+};

--- a/packages/spec/integration/doctor/package.json
+++ b/packages/spec/integration/doctor/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "fixture-doctor",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "12 || 14"
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js",
+    "setupFilesAfterEnv": [
+      "../../jest.setup.js"
+    ]
+  },
+  "scripts": {
+    "start": "hops start",
+    "build": "hops build"
+  },
+  "hops": {
+    "mixins": [
+      "./mixin-a/mixin.core.js",
+      "./mixin-b/mixin.core.js"
+    ]
+  },
+  "dependencies": {
+    "hops": "*",
+    "hops-preset-jest": "*"
+  }
+}


### PR DESCRIPTION
**ToC**

- the `doctor` got two new methods: `pushWarning(message: string)` and `pushError(tag: string, message: string)`; errors are completely listed, the last one ends the process with exit code `1`
- the `diagnose`-hook got a second argument: `mode: string`, which is either `build`, `develop`, `serve`, `build-serve` or `indeterminate`.
- errors can be converted into non-fatal warnings, by passing their tag via `HOPS_IGNORE_ERRORS` into the Hops command
- the test-helper's `HopsCLI`-object's `start`- & `build`-methods now take environment variables
- the test-helper's `HopsCLI`-object's `start`- & `build`-methods make their `stderr`-output available to the test environment

The changes to the `HopsCLI`-object are needed in order to be able to test the `doctor`. Let me know, if you'd rather see those changes in a separate PR. Personally, I'd cherry-pick them if we can't agree on the approach and thus need a few more iterations on the implementation.

Also note, that the `doctor`'s README isn't updated yet. I'd wait for this until we agreed on the API changes.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
