### PR TITLE
chore: correct error name for deserialization

### DIFF
--- a/packages/webpack/lib/utils/errors.js
+++ b/packages/webpack/lib/utils/errors.js
@@ -22,7 +22,7 @@ function deserializeError(data) {
   switch (_type) {
     case 'BuildError':
       return new BuildError(error);
-    case 'CompileError':
+    case 'CompilerError':
       return new CompilerError(error);
     default:
       return Object.assign(new Error(error.message), error);


### PR DESCRIPTION
A small typo slipped through 😬

The other side is correct though:
https://github.com/xing/hops/blob/143089a668a541de2542a4c50924ed9df03fc716/packages/webpack/lib/utils/errors.js#L62