### PR TITLE
docs: update documentation for Hops 13 and remove last untool references

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1058,7 +1058,7 @@ Then, inside this folder, we will create a file named `mixin.core.js` which will
 **`mixin.core.js`**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 class MyMixin extends Mixin {
   configureBuild(webpackConfig) {
@@ -1112,7 +1112,7 @@ In this example we will add the [webpack `BannerPlugin`](https://webpack.js.org/
 **`mixin.core.js`**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 const { BannerPlugin } = require('webpack');
 
 class MyWebpackMixin extends Mixin {
@@ -1133,7 +1133,7 @@ In this example we will add a [babel plugin](https://babeljs.io/docs/en/plugins)
 **`mixin.core.js`**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 class MyWebpackMixin extends Mixin {
   configureBuild(webpackConfig, loaderConfigs, target) {
@@ -1172,7 +1172,7 @@ In this example we will add the [`cookie-parser` middleware](https://expressjs.c
 **`mixin.core.js`**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 const cookieParser = require('cookie-parser');
 
 class MyExpressMixin extends Mixin {
@@ -1191,27 +1191,42 @@ To pass data we will use the [`enhanceServerData` mixin hook](packages/react#enh
 **`mixin.core.js`**
 
 ```javascript
-configureServer(app, middlewares, mode) {
-  middlewares.initial.push((req, res, next) => {
-    // Note: res.locals should be used for locally scoped data
-    // https://expressjs.com/en/4x/api.html#res.locals
-    res.locals.someKey = "someValue"
-    next();
-  });
+const { Mixin } = require('hops-mixin');
+
+class MyExpressMixin extends Mixin {
+  configureServer(app, middlewares, mode) {
+    middlewares.initial.push((req, res, next) => {
+      // Note: res.locals should be used for locally scoped data
+      // https://expressjs.com/en/4x/api.html#res.locals
+      res.locals.someKey = 'someValue';
+      next();
+    });
+  }
 }
+
+module.exports = MyExpressMixin;
 ```
 
 **`mixin.server.js`**
 
 ```javascript
-enhanceServerData(data, req, res) {
-  return { ...data, someKey: res.locals.someKey };
+const { Mixin } = require('hops-mixin');
+
+class MyExpressMixin extends Mixin {
+  enhanceServerData(data, req, res) {
+    return { ...data, someKey: res.locals.someKey };
+  }
 }
+
+module.exports = MyExpressMixin;
 ```
 
 **`my-component.js`**
 
 ```javascript
+import React from 'react';
+import { withServerData } from 'hops';
+
 const MyComponent = ({ serverData }) => <div>{serverData.someKey}</div>;
 
 export default withServerData(MyComponent);
@@ -1228,7 +1243,7 @@ The following example demonstrates how you could implement a custom [mobx](https
 **`mixin.runtime.js`**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 const { Provider } = require('mobx-react');
 const React = require('react');
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 ## Docs
 
+- [Hops v13 documentation](https://github.com/xing/hops/blob/v13.x/DOCUMENTATION.md).
 - [Hops v12 documentation](https://github.com/xing/hops/blob/v12.x/DOCUMENTATION.md).
-- [Hops v11 documentation](https://github.com/xing/hops/blob/v11.x/DOCUMENTATION.md).
 
 ## Contributing
 

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -1,6 +1,6 @@
 # `hops-bootstrap`
 
-`hops-bootstrap` is the functional foundation every other `hops` component is built upon. It contains a comprehensive configuration engine and a mixin base class.
+`hops-bootstrap` is the functional foundation every other `hops` component is built upon. It contains a comprehensive configuration engine and takes care of loading mixins and presets.
 
 ### Installation
 
@@ -32,7 +32,7 @@ It allows you to set up mixins and pull in presets. Mixins provide extra functio
 Now if you start your app in an environment in which the corresponding variable is defined, it will be picked up _at runtime_. To streamline development workflows, `hops-bootstrap` comes with built-in support for [`dotenv`](https://github.com/motdotla/dotenv).
 
 ```bash
-$ PORT=12345 un start
+$ PORT=12345 hops start
 ```
 
 Furthermore those placeholders accept fallback values. So — regarding our example — if there's no `PORT`-variable given _at runtime_, `hops-bootstrap` is able to fall back to a value provided via the configuration.
@@ -230,4 +230,4 @@ Note that you can call all defined mixinable methods directly on your mixin inst
 
 This is a semi-private function that is mainly being used internally, for example by [`hops-yargs`](../yargs/README.md). It returns the core mixin container - this allows you to call all defined mixin methods.
 
-You will only ever have to call it if you want to use `hops-bootstrap` programmatically. You can pass it an `configOverrides` object that will be merged into the main config object, and and options object mixins might use instead of CLI arguments.
+You will only ever have to call it if you want to use `hops-bootstrap` programmatically. You can pass it an `configOverrides` object that will be merged into the main config object, and an options object mixins might use instead of CLI arguments.

--- a/packages/development-proxy/README.md
+++ b/packages/development-proxy/README.md
@@ -26,9 +26,9 @@ npm install --save hops-development-proxy
 
 #### Preset Options
 
-| Name | Type | Default | Required | Description |
-| --- | --- | --- | --- | --- |
-| `proxy` | `String | Object` | `undefined` | _no_ | Proxy target configuration |
+| Name    | Type    | Default | Required    | Description |
+| ------- | ------- | ------- | ----------- | ----------- |
+| `proxy` | `String | Object` | `undefined` | _no_        | Proxy target configuration |
 
 ##### proxy
 
@@ -82,7 +82,7 @@ Sometimes additional request headers are needed, for example to add a fake user 
 `mixin.core.js`
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 class MyMixin extends Mixin {
   onProxyReq(proxyReq) {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -170,7 +170,7 @@ This preset has no runtime configuration options.
 This method is being called whenever you call the main `render` method. In a server-side, i.e. Node.js, environment it receives the usual arguments any Express [middleware](https://expressjs.com/en/guide/writing-middleware.html) receives: `req`, `res`, and `next`. In a client-side, i.e. browser, environment it receives no arguments whatsoever.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   render(req, res, next) {
@@ -190,7 +190,7 @@ You will not usually have to override this method as it exposes the following mi
 Within this method, you are expected to set up your application. Your implementation will receive both Express' [`req`](https://expressjs.com/en/4x/api.html#req) and [`res`](https://expressjs.com/en/4x/api.html#res) objects for you to do whatever you like with. If you need to do something asynchronous in this method, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   bootstrap(req, res) {
@@ -210,7 +210,7 @@ Remember you can register custom middlewares using [`hops-express`](../express/R
 With this method, you can wrap the React root element with additional components, like Redux' [Provider](https://redux.js.org/basics/usage-with-react). If you need to do something asynchronous in this method, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving to the wrapped element.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   enhanceElement(element) {
@@ -224,7 +224,7 @@ module.exports = class FooMixin extends Mixin {
 Most applications need some sort of data. Implement this method in your mixin, to fetch said data before rendering and return an object with that additional data. If you need to do something asynchronous in this method, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving to the data.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   fetchData(data, element) {
@@ -238,7 +238,7 @@ module.exports = class FooMixin extends Mixin {
 In case you need to gather additional template data after React rendering, e.g. if you are using [styled components](https://www.styled-components.com), you can add the required data by implementing this hook in your custom mixin. To do so asynchronously, have this method return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving to the extended data.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   getTemplateData(data) {

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -122,7 +122,7 @@ If you implement this mixin hook in your `hops-bootstrap` [`core` mixin](../boos
 In addition to the actual `webpackConfig`, which, by the way, your implementation is expected to return, you will receive an object containing all `loaderConfigs` and a `target` argument. This last argument can be `build`, `develop`, or `node`.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class MyMixin extends Mixin {
   configureBuild(webpackConfig, loaderConfigs, target) {

--- a/packages/yargs/README.md
+++ b/packages/yargs/README.md
@@ -12,12 +12,12 @@ $ yarn add hops-yargs # OR npm install hops-yargs
 
 `hops-yargs` does not define any commands of its own, but only takes care of basically setting up [`yargs`](http://yargs.js.org).
 
-`hops-yargs` provides a basic command line interface you can use to control your application. It is called `un` - and it is best used inside your `package.json` scripts section.
+`hops-yargs` provides a basic command line interface you can use to control your application. It is called `hops` - and it is best used inside your `package.json` scripts section.
 
 ```json
 {
   "scripts": {
-    "start": "un start"
+    "start": "hops start"
   }
 }
 ```
@@ -25,7 +25,7 @@ $ yarn add hops-yargs # OR npm install hops-yargs
 Alternatively, you can call it directly inside your project using `npx` or `yarn exec`. Call it without any command to see the available commands and options.
 
 ```bash
-$ yarn exec un start # OR npx un start
+$ yarn exec hops start # OR npx hops start
 ```
 
 ## API
@@ -37,7 +37,7 @@ $ yarn exec un start # OR npx un start
 Within this method, you are expected to set up your application. If you need to do something asynchronous at this point, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   bootstrap(yargs) {
@@ -51,7 +51,7 @@ module.exports = class FooMixin extends Mixin {
 This is the most relevant hook provided by `hops-yargs`: it enables other mixins to register their respective commands. Implementations of this mixin method will receive a single argument: a [`yargs`](http://yargs.js.org) instance.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   registerCommands(yargs) {
@@ -71,7 +71,7 @@ module.exports = class FooMixin extends Mixin {
 By implementing this method, your mixin can intercept and alter command configuration. Its main purpose is to enable you to add arguments to commands defined by other mixins.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooBarMixin extends Mixin {
   configureCommand(definition) {
@@ -94,7 +94,7 @@ module.exports = class FooBarMixin extends Mixin {
 Your mixin's implementation of this method will receive the parsed CLI arguments passed to `hops-yargs`. You may want to implement it if you need to alter mixin behaviour according to these args.
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 
 module.exports = class FooMixin extends Mixin {
   handleArguments(argv) {
@@ -108,7 +108,7 @@ module.exports = class FooMixin extends Mixin {
 By implementing this method, you can handle exceptions occuring in your application - even uncaught errors and unhandled promise rejections. **If `receoverable' is 'false`, `hops-yargs` will automatically terminate the [running process](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly).**
 
 ```javascript
-const { Mixin } = require('hops');
+const { Mixin } = require('hops-mixin');
 const { logError } = require('./logger');
 
 module.exports = class FooMixin extends Mixin {


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>