### PR TITLE
fix(bootstrap): ignore exports fields when resolving presets

### DIFF
--- a/packages/bootstrap/lib/resolver.js
+++ b/packages/bootstrap/lib/resolver.js
@@ -15,6 +15,7 @@ exports.resolvePreset = createResolver({
   ...defaultConfig,
   mainFiles: ['preset'],
   mainFields: ['preset'],
+  exportsFields: [],
 });
 
 exports.resolveMixins = (context, types, mixins) => {


### PR DESCRIPTION
They're not relevant for Hops presets and lead to packages being
resolved, that aren't qualified Hops presets, like e.g. `tslib`.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
