### PR TITLE
fix(typescript): preserve JSX when styled-components are present (v12.x)

### DIFF
--- a/packages/spec/integration/typescript-styled-components/__tests__/develop.js
+++ b/packages/spec/integration/typescript-styled-components/__tests__/develop.js
@@ -1,0 +1,19 @@
+describe('typescript-styled-components development server', () => {
+  let url;
+
+  beforeAll(async () => {
+    url = await HopsCLI.start('--fast-dev');
+  });
+
+  it('allows to use the css-props', async () => {
+    const { page } = await createPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    const color = await page.evaluate(() => {
+      return window.getComputedStyle(document.querySelector('h1')).color;
+    });
+    expect(color).toBe('rgb(255, 0, 255)');
+
+    await page.close();
+  });
+});

--- a/packages/spec/integration/typescript-styled-components/index.tsx
+++ b/packages/spec/integration/typescript-styled-components/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { render } from 'hops';
+
+export default render(
+  <h1
+    css={`
+      color: rgb(255, 0, 255);
+    `}
+  >
+    Hello World.
+  </h1>
+);

--- a/packages/spec/integration/typescript-styled-components/package.json
+++ b/packages/spec/integration/typescript-styled-components/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fixture-typescript-styled-components",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "12 || 14"
+  },
+  "jest": {
+    "testEnvironment": "../../helpers/env.js",
+    "setupFilesAfterEnv": [
+      "../../jest.setup.js"
+    ]
+  },
+  "hops": {
+    "gracePeriod": 0
+  },
+  "scripts": {
+    "start": "hops start",
+    "build": "hops build"
+  },
+  "dependencies": {
+    "hops": "*",
+    "hops-styled-components": "*",
+    "hops-typescript": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/spec/integration/typescript-styled-components/tsconfig.json
+++ b/packages/spec/integration/typescript-styled-components/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "hops-typescript/tsconfig.json"
+}

--- a/packages/typescript/mixin.core.js
+++ b/packages/typescript/mixin.core.js
@@ -83,6 +83,7 @@ class TypescriptMixin extends Mixin {
     const properties = {
       target: ts.ScriptTarget.ESNext,
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      jsx: ts.JsxEmit.Preserve,
     };
 
     for (let [property, value] of Object.entries(properties)) {

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "jsx": "react",
+    "jsx": "preserve",
     "sourceMap": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
