### PR TITLE
chore: add release tag "v12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "jest --coverage",
     "lint": "eslint 'packages/**/*.js'",
     "prerelease": "test -n \"$GH_TOKEN\" || (echo 'GH_TOKEN missing'; exit 1)",
-    "release": "lerna publish",
+    "release": "lerna publish --dist-tag v12",
     "release:alpha": "yarn release --conventional-prerelease --preid alpha",
     "release:beta": "yarn release --conventional-prerelease --preid beta",
     "release:rc": "yarn release --conventional-prerelease --preid rc",

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -6,11 +6,23 @@ const { version, bin } = require(require.resolve(
   'create-hops-app/package.json'
 ));
 
-const isPreRelease = semver(version).prerelease.length > 0;
+const { major, prerelease } = semver(version);
+const isPreRelease = prerelease.length > 0;
 const createHopsAppBin = require.resolve('create-hops-app');
 
+const getDistTag = () => {
+  switch (true) {
+    case isPreRelease:
+      return 'next';
+    case major === 12:
+      return 'v12';
+    default:
+      return 'latest';
+  }
+};
+
 describe('create-hops-app', () => {
-  const version = isPreRelease ? 'next' : 'latest';
+  const distTag = getDistTag();
   const template = 'hops-template-react';
 
   beforeAll(() => {
@@ -19,7 +31,7 @@ describe('create-hops-app', () => {
 
   it('initializes a Hops app with yarn', () => {
     const name = 'my-app-yarn';
-    const args = [name, `--template ${template}@${version}`].join(' ');
+    const args = [name, `--template ${template}@${distTag}`].join(' ');
 
     execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 
@@ -31,7 +43,7 @@ describe('create-hops-app', () => {
 
   it('initializes a Hops app with npm', () => {
     const name = 'my-app-npm';
-    const args = [name, `--template ${template}@${version}`, `--npm`].join(' ');
+    const args = [name, `--template ${template}@${distTag}`, `--npm`].join(' ');
 
     execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
 


### PR DESCRIPTION
...in order to not accidentally tag a maintenance release of Hops 12 as `latest`.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
