### PR TITLE
feat(info): make logger available in server runtime (v13)

### DIFF
--- a/packages/info/logger/mixin.core.js
+++ b/packages/info/logger/mixin.core.js
@@ -14,6 +14,19 @@ class LogMixin extends Mixin {
     this.handleArguments(this.options);
   }
 
+  configureServer(app, middlewares, mode) {
+    if (mode === 'static') {
+      return;
+    }
+
+    middlewares.preinitial.unshift((_, res, next) => {
+      Object.assign(res.locals, {
+        logger: this.logger,
+      });
+      next();
+    });
+  }
+
   getLogger() {
     return this.logger;
   }

--- a/packages/info/logger/mixin.core.js
+++ b/packages/info/logger/mixin.core.js
@@ -21,7 +21,7 @@ class LogMixin extends Mixin {
 
     middlewares.preinitial.unshift((_, res, next) => {
       Object.assign(res.locals, {
-        logger: this.logger,
+        logger: res.locals.logger || this.logger,
       });
       next();
     });

--- a/packages/info/logger/mixin.server.js
+++ b/packages/info/logger/mixin.server.js
@@ -1,0 +1,25 @@
+const { sync } = require('mixinable');
+const { Mixin } = require('hops-mixin');
+const { internal: bootstrap } = require('hops-bootstrap');
+
+const { callable } = sync;
+const { validate, invariant } = bootstrap;
+
+class ServerLogMixin extends Mixin {
+  bootstrap(_, res) {
+    const { logger } = res.locals;
+    this.logger = logger;
+  }
+
+  getLogger() {
+    return this.logger;
+  }
+}
+
+ServerLogMixin.strategies = {
+  getLogger: validate(callable, ({ length }) => {
+    invariant(length === 0, 'getLogger(): Received unexpected argument(s)');
+  }),
+};
+
+module.exports = ServerLogMixin;


### PR DESCRIPTION
picks #1404 

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
