### PR TITLE
fix(webpack): compile browser bundle for latest chrome only

### DIFF
--- a/packages/webpack/mixins/optimizations/mixin.core.js
+++ b/packages/webpack/mixins/optimizations/mixin.core.js
@@ -53,6 +53,7 @@ class WebpackOptimizationsMixin extends Mixin {
 
       if (presetEnvOptions) {
         if (skipPolyfilling) {
+          presetEnvOptions.targets.browsers = ['last 1 chrome versions'];
           presetEnvOptions.useBuiltIns = false;
           delete presetEnvOptions.corejs;
         } else if (skipNodeModules) {


### PR DESCRIPTION
We should only compile for the latest chrome version in fast dev mode.
Leaving the old browsers list in there causes code to be down-transpiled
into an older version and transpiles async functions to regeneratorRuntime

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
