### PR TITLE
fix(webpack): fix memory leak in StatsWriterPlugin

### DIFF
--- a/packages/webpack/lib/plugins/stats.js
+++ b/packages/webpack/lib/plugins/stats.js
@@ -68,10 +68,10 @@ exports.StatsWritePlugin = class StatsWritePlugin {
           writeFileSync(statsFile, JSON.stringify(stats), 'utf8');
           enhancedPromise.resolve(stats);
         });
+      });
 
-        compiler.hooks.watchRun.tap('StatsWritePlugin', () => {
-          enhancedPromise.reset();
-        });
+      compiler.hooks.watchRun.tap('StatsWritePlugin', () => {
+        enhancedPromise.reset();
       });
     };
   }


### PR DESCRIPTION
Previously the closure that resets the enhancedPromise shared the same
context (variable bindings) as the closure to the additionalAssets hook
and since the closure for the additionalAssets hook needs access to the
compilation object, it was retained through the closure to the watchRun
hook, even though it wasn't referenced there.
By moving the watchRun hook up one level its closure no longer shares
the context object with the additionalAssets closure.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>