### PR TITLE
chore: remove pr_status from bors config

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,11 +3,6 @@ status = [
   "canarist/0",
 ]
 
-pr_status = [
-  "Node.js CI / tests %",
-  "canarist/0",
-]
-
 block_labels = [
   ":hand: blocked",
   ":construction: wip",


### PR DESCRIPTION
For some reason bors always seems to forget the pr_status and wait on a
status even when all statuses are green.
It might be an issue with bors or it might be heroku which might suspend
the instance if there are no requests for a given timeframe, but anyway
I'll remove the checks again, because it brings us more frustration than
joy.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>