### PR TITLE
Prepare next Hops v12.x release

### DIFF
--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -35,7 +35,10 @@ module.exports = function getConfig(config, name) {
             useBuiltIns: 'entry',
             targets: { node: config.node },
             corejs: 3,
-            include: [],
+            include: [
+              '@babel/proposal-optional-chaining',
+              '@babel/proposal-nullish-coalescing-operator',
+            ],
             exclude: [],
           },
         ],

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -24,7 +24,9 @@ module.exports = function getConfig(config, name) {
       babelrc: false,
       compact: isProduction,
       cacheDirectory: true,
-      cacheIdentifier: `${process.env.NODE_ENV || 'development'}:${name}`,
+      cacheIdentifier: `${process.env.NODE_ENV || 'development'}:${name}:${
+        process.versions.node
+      }`,
       presets: [
         [
           require.resolve('@babel/preset-env'),


### PR DESCRIPTION
Next release: Monday, November 30th

* [Fix babel transpilation target (always transpile new syntax) (#1439)](https://github.com/xing/hops/pull/1439)

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>