### PR TITLE
fix(bootstrap): do not try to resolve ESM packages for presets

### DIFF
--- a/packages/bootstrap/lib/loader.js
+++ b/packages/bootstrap/lib/loader.js
@@ -6,7 +6,12 @@ const { cosmiconfigSync: cosmiconfig } = require('cosmiconfig');
 const { compatibleMessage } = require('check-error');
 
 const { merge: mergeFactory, getMixinSortOrder } = require('./utils');
-const { resolve, resolvePreset, isResolveError } = require('./resolver');
+const {
+  resolve,
+  resolvePreset,
+  isResolveError,
+  isESMExportsError,
+} = require('./resolver');
 
 class Loader {
   constructor(pkgData) {
@@ -30,7 +35,7 @@ class Loader {
       try {
         return this.search(dirname(resolve(context, `${preset}/package.json`)));
       } catch (error) {
-        if (!isResolveError(error)) throw error;
+        if (!(isResolveError(error) || isESMExportsError(error))) throw error;
         throw new Error(`Can't find preset '${preset}' in '${context}'`);
       }
     }

--- a/packages/bootstrap/lib/resolver.js
+++ b/packages/bootstrap/lib/resolver.js
@@ -42,3 +42,8 @@ exports.resolveMixins = (context, types, mixins) => {
 };
 
 exports.isResolveError = (error) => compatibleMessage(error, /^Can't resolve/);
+exports.isESMExportsError = (error) =>
+  compatibleMessage(
+    error,
+    /^Package path .\/package\.json is not exported from package/
+  );


### PR DESCRIPTION
Hops tries to load the package.json files of all direct dependencies to
try and figure out if the dependency is a Hops preset and should be
considered for the current config object.
This will break if the dependency that Hops tries to resolve doesn't
allow to access the package.json directly, for example by using the new
module specification "exports" field in their package.json.
This commit checks for that specific error and skips it.



<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>