### PR TITLE
Force npm legacy peer dependency handling in create-hops-app (v13)

### DIFF
--- a/packages/create-hops-app/lib/package-manager.js
+++ b/packages/create-hops-app/lib/package-manager.js
@@ -40,7 +40,9 @@ function installPackages(packages, type, options) {
   } else {
     command =
       packages.length === 0
-        ? ['npm', 'install']
+        ? // TODO: remove the `--legacy-peer-deps` flag again when
+          // react-helmet-async supports react@17 (https://github.com/staylor/react-helmet-async/issues/109)
+          ['npm', 'install', '--legacy-peer-deps']
         : ['npm', 'install', type === 'dev' ? '--save-dev' : '--save'];
   }
   if (options.verbose) {

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -17,8 +17,7 @@ describe('create-hops-app', () => {
     process.chdir(cwd);
   });
 
-  // TODO: enable again when there's been a Hops release, that supports Node v15
-  xit('initializes a Hops app with yarn', () => {
+  it('initializes a Hops app with yarn', () => {
     const name = 'my-app-yarn';
     const args = [name, `--template ${template}@${version}`].join(' ');
 


### PR DESCRIPTION
picks #1432 

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
