### PR TITLE
refactor(react): reduce render promise chain by one promise

### DIFF
--- a/packages/react/render/mixin.server.js
+++ b/packages/react/render/mixin.server.js
@@ -41,8 +41,7 @@ class ReactMixin extends Mixin {
   }
 
   render(req, res, next) {
-    Promise.resolve()
-      .then(() => this.bootstrap(req, res))
+    return this.bootstrap(req, res)
       .then(() => this.enhanceElement(this.element))
       .then((element) =>
         this.fetchData({}, element).then(() => this.renderToFragments(element))


### PR DESCRIPTION
Since mixinable always wraps async hooks in a promise [1] there is no
need for us to add another promise on top.

[1]: https://github.com/untool/mixinable/blob/master/src/index.js#L109


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>