### PR TITLE
WIP: implement circuit breaker

### DIFF
--- a/packages/express/lib/circuit-breaker.js
+++ b/packages/express/lib/circuit-breaker.js
@@ -1,0 +1,47 @@
+const { performance } = require('perf_hooks');
+
+// TODO: figure out good values
+const upperThreshold = 0.9;
+const lowerThreshold = 0.7;
+const intervalMs = 1000;
+
+function createCircuitBreaker(app) {
+  let elu = performance.eventLoopUtilization();
+  let lastMeasurementMs = performance.now();
+
+  return (req, res, next) => {
+    // we don't want a new elu measurement for each incoming request, so we
+    // throttle it based on how much time passed since the last measurement
+    const nowMs = performance.now();
+    if (nowMs - lastMeasurementMs > intervalMs) {
+      elu = performance.eventLoopUtilization(elu);
+      lastMeasurementMs = nowMs;
+    }
+
+    // we're using `app.locals` instead of `res.locals` here, because then
+    // other parts of the application (for example a load balancer health check)
+    // can also use `app.locals` in order to respond with an unhealthy state
+    if (elu.utilization > upperThreshold) {
+      app.locals.breaker = 'open';
+    } else {
+      app.locals.breaker = 'closed';
+    }
+
+    if (app.locals.breaker === 'open') {
+      return res.status(503).end();
+    }
+
+    // I suppose we should also write this state to `app.locals`, so that the
+    // load balancer health check can already see that the app is experiencing
+    // high load
+    if (elu.utilization > lowerThreshold) {
+      res.locals.noSSR = true;
+    } else {
+      res.locals.noSSR = false;
+    }
+
+    return next();
+  };
+}
+
+module.exports = { createCircuitBreaker };

--- a/packages/express/mixins/mixin.core.js
+++ b/packages/express/mixins/mixin.core.js
@@ -6,6 +6,7 @@ const EnhancedPromise = require('eprom');
 const { async, sync } = require('mixinable');
 const { trimLeadingSlash } = require('pathifist');
 const { Mixin } = require('hops-mixin');
+const { createCircuitBreaker } = require('../lib/circuit-breaker');
 
 const { callable: callableAsync } = async;
 const { sequence, callable: callableSync } = sync;
@@ -68,6 +69,7 @@ class ExpressMixin extends Mixin {
     }
 
     if (mode === 'serve' && process.env.NODE_ENV === 'production') {
+      middlewares.preinitial.unshift(createCircuitBreaker(app));
       middlewares.prefiles.push(require('compression')());
     }
   }


### PR DESCRIPTION
This commit introduces a two-staged circuit breaker which will:
* disable react's `renderToString` if the process has high utilization
* quickly respond with a 503 if the process has even higher utilization



<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>