### PR TITLE
docs: document available debug tags (v13)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1018,10 +1018,9 @@ Add `jest-preset-hops` as [preset](https://facebook.github.io/jest/docs/en/confi
 
 ### Debugging
 
-Hops and its underlying tools provide debugging output via the [`debug`](https://www.npmjs.com/package/debug) module.\
-In order to enable debug output you need to set an environment variable called `DEBUG`.
+Hops provides debugging output via the [`debug`](https://www.npmjs.com/package/debug) module. The available tags are listed in the READMEs of each Hops preset.
 
-For example the following command would log all debug statements of Hops:
+Since the tags are namespaced to `hops`, it's possible to log all debug statements of Hops by running…
 
 ```shell
 DEBUG=hops* npm start

--- a/packages/bootstrap/README.md
+++ b/packages/bootstrap/README.md
@@ -231,3 +231,10 @@ Note that you can call all defined mixinable methods directly on your mixin inst
 This is a semi-private function that is mainly being used internally, for example by [`hops-yargs`](../yargs/README.md). It returns the core mixin container - this allows you to call all defined mixin methods.
 
 You will only ever have to call it if you want to use `hops-bootstrap` programmatically. You can pass it an `configOverrides` object that will be merged into the main config object, and an options object mixins might use instead of CLI arguments.
+
+## Debugging
+
+Available tags for the [`debug`](https://www.npmjs.com/package/debug)-module are:
+
+- `hops:bootstrap`
+- `hops:config`

--- a/packages/development-proxy/README.md
+++ b/packages/development-proxy/README.md
@@ -100,3 +100,9 @@ Hook to implement [http-proxy-middleware `onProxyRes` event callback](https://gi
 #### `onProxyError(): void` ([sequence](https://github.com/untool/mixinable/blob/master/README.md#defineparallel)) **core**
 
 Hook to implement [http-proxy-middleware `onError` event callback](https://github.com/chimurai/http-proxy-middleware#http-proxy-events).
+
+## Debugging
+
+Available tags for the [`debug`](https://www.npmjs.com/package/debug)-module are:
+
+- `hops:development-proxy`

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -159,3 +159,9 @@ It accepts `develop`, `serve` or `static` as `mode`.
 In case you want to programmatically start a server, you can use this mixin hook.
 
 It accepts `develop` or `serve` as `mode`.
+
+## Debugging
+
+Available tags for the [`debug`](https://www.npmjs.com/package/debug)-module are:
+
+- `hops:express`

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -269,3 +269,11 @@ Path of your stats file, relative to [`serverDir`](../webpack/README.md#serverdi
   "assetFile": "stats.json"
 }
 ```
+
+## Debugging
+
+Available tags for the [`debug`](https://www.npmjs.com/package/debug)-module are:
+
+- `hops:webpack:config:build`
+- `hops:webpack:config:develop`
+- `hops:webpack:config:node`


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
