### PR TITLE
chore(spec): add possibility to disable puppeteer for single tests

### DIFF
--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const path = require('path');
 const semver = require('semver');
 const { existsSync, readFileSync } = require('fs');

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const fs = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const fs = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');

--- a/packages/spec/integration/doctor/__tests__/build.js
+++ b/packages/spec/integration/doctor/__tests__/build.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 describe('doctor - build', () => {
   let logs;
 

--- a/packages/spec/integration/doctor/__tests__/develop.js
+++ b/packages/spec/integration/doctor/__tests__/develop.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const delay = () => new Promise((resolve) => setTimeout(resolve, 200));
 
 describe('doctor - develop', () => {

--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const fetch = require('cross-fetch');
 
 describe('graphql development client', () => {

--- a/packages/spec/integration/hops/__tests__/import-component-loading.js
+++ b/packages/spec/integration/hops/__tests__/import-component-loading.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import testRenderer from 'react-test-renderer';

--- a/packages/spec/integration/hops/__tests__/import-component-mocked.js
+++ b/packages/spec/integration/hops/__tests__/import-component-mocked.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import testRenderer from 'react-test-renderer';

--- a/packages/spec/integration/jest-preset/__tests__/preset.js
+++ b/packages/spec/integration/jest-preset/__tests__/preset.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 describe('jest-preset', () => {
   it('allows to use typescript', () => {
     const calculator = require('./setup/calculator').default;

--- a/packages/spec/integration/lambda/__tests__/build.js
+++ b/packages/spec/integration/lambda/__tests__/build.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const path = require('path');
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);

--- a/packages/spec/integration/typescript-unit-testing/__tests__/index.js
+++ b/packages/spec/integration/typescript-unit-testing/__tests__/index.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-hops-puppeteer off
+ */
+
 const { createElement } = require('react');
 const { render, screen } = require('@testing-library/react');
 


### PR DESCRIPTION
This change makes it possible to disable Puppeteer in Hops's integration test suite on a per-test basis, by adding the following code comment at the top of the test file:

```js
/**
 * @jest-hops-puppeteer off
 */
```

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
