### PR TITLE
chore(spec): improve programmatic HopsCLI

### DIFF
--- a/packages/spec/helpers/hops-cli.js
+++ b/packages/spec/helpers/hops-cli.js
@@ -1,0 +1,293 @@
+/**
+ * @typedef {import('events').EventEmitter} EventEmitter
+ * @typedef {import('child_process').ChildProcess} ChildProcess
+ * @typedef {'build' | 'start'} Cmd
+ */
+
+/**
+ * @typedef {Object} CommandOptions
+ * @property {string} cwd
+ * @property {NodeJS.ProcessEnv} env
+ */
+
+const EventEmitter = require('events');
+const { exec, spawn } = require('child_process');
+const resolveFrom = require('resolve-from');
+const debug = require('debug')('hops-spec:cli');
+
+const debugBuild = debug.extend('build');
+const debugBuildError = debugBuild.extend('error');
+const debugBuildStdout = debugBuild.extend('stdout');
+const debugBuildStderr = debugBuild.extend('stderr');
+const debugStart = debug.extend('start');
+const debugStartError = debugStart.extend('error');
+const debugStartStdout = debugStart.extend('stdout');
+const debugStartStderr = debugStart.extend('stderr');
+
+/**
+ * @extends {EventEmitter}
+ */
+class HopsCLI extends EventEmitter {
+  /**
+   * Create a new instance for a given Hops-command.
+   *
+   * @throws {Error} When given command is invalid
+   * @param {Cmd} cmd
+   * @returns {HopsCLI}
+   */
+  static cmd(cmd) {
+    if (!['build', 'start'].includes(cmd)) {
+      throw new Error(`Invalid command "${cmd}" given.`);
+    }
+    debug('Instantiating HopsCLI in "%s"-mode', cmd);
+    return new HopsCLI(cmd);
+  }
+
+  /**
+   * @constructor
+   * @param {Cmd} cmd
+   * @returns {HopsCLI}
+   */
+  constructor(cmd) {
+    super();
+
+    if (typeof global.cwd !== 'string') {
+      throw new Error('Please make that global variable env is defined.');
+    }
+
+    /**
+     * @private
+     */
+    this._cmd = cmd;
+    /**
+     * @private
+     * @type {string | null}
+     */
+    this._cwd = global.cwd;
+    /**
+     * @private
+     * @type {NodeJS.ProcessEnv}
+     */
+    this._env = {};
+    /**
+     * @private
+     * @type {string[]}
+     */
+    this._args = [];
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this._running = false;
+    /**
+     * @private
+     * @type {ChildProcess | null}
+     */
+    this._process = null;
+    /**
+     * URL of the Hops dev-server, when running in "start"-mode
+     *
+     * @private
+     * @type {string | null}
+     */
+    this._url = null;
+  }
+
+  /**
+   * @private
+   * @param {string} command
+   * @param {CommandOptions} options
+   * @returns {undefined}
+   */
+  _build(command, options) {
+    this._running = true;
+    const output = { stdout: '', stderr: '' };
+
+    try {
+      this._process = exec(command, options, (err, stdout, stderr) => {
+        if (typeof stdout === 'string') {
+          debugBuildStdout(stdout);
+          output.stdout = stdout;
+        }
+        if (typeof stderr === 'string') {
+          debugBuildStderr(stderr);
+          output.stderr = stderr;
+        }
+        if (err) {
+          debugBuildError(err);
+          this.emit('error', err);
+        }
+
+        this.emit('end', output);
+      });
+    } catch (err) {
+      debugBuildError(err);
+      this.emit('error', err);
+    } finally {
+      this._process = null;
+      this._running = false;
+    }
+  }
+
+  /**
+   * @private
+   * @param {string} command
+   * @param {string[]} args
+   * @param {CommandOptions} options
+   * @returns {undefined}
+   */
+  _start(command, args, options) {
+    const output = { stdout: '', stderr: '' };
+    this._process = spawn(command, args, options);
+
+    this._process.stdout.on('data', (data) => {
+      const line = data.toString('utf-8');
+      debugStartStdout(line);
+      const match = line.match(/listening at (.*)/i);
+      if (match) {
+        debugStart('found match:', match[1]);
+        this._running = true;
+        const url = match[1];
+        this._url = url;
+        this.emit('running', { url });
+      }
+      output.stdout += line;
+    });
+
+    this._process.stderr.on('data', (data) => {
+      const line = data.toString('utf-8');
+      debugStartStderr(line);
+      output.stderr += line;
+    });
+
+    this._process.on('error', (err) => {
+      debugStartError(err);
+      this.emit('error', err);
+      this._process = null;
+      this._url = null;
+    });
+
+    this._process.on('close', (signal) => {
+      debugStart('Ended with signal %d', signal);
+      this.emit('close', { signal });
+      this.emit('end', output);
+      this._process = null;
+      this._url = null;
+    });
+  }
+
+  /**
+   * Set an environment variable.
+   *
+   * @param {string} name
+   * @param {string} value
+   * @returns {HopsCLI}
+   */
+  addEnvVar(name, value) {
+    debug('Adding env var %s: %s', name, value);
+    this._env[name] = String(value);
+    return this;
+  }
+
+  /**
+   * Add a command-line argument for the respective
+   * Hops-command.
+   *
+   * @param {string} arg
+   * @returns {HopsCLI}
+   */
+  addArg(arg) {
+    debug('Adding CLI arg %s', arg);
+    this._args.push(String(arg));
+    return this;
+  }
+
+  /**
+   * Invokes the given command on the Hops CLI.
+   *
+   * @throws {Error} When the instance is already running a process
+   * @throws {Error} When the current working directory has not been defined
+   * @returns {HopsCLI}
+   */
+  run() {
+    if (this._process) {
+      throw new Error(
+        `Already running a "${this._cmd}"-task (PID: ${this._process.pid}).`
+      );
+    }
+
+    const { _cwd: cwd, _cmd: cmd, _args: userArgs } = this;
+
+    const hopsBin = resolveFrom(cwd, 'hops/bin');
+    const args = [hopsBin, cmd, ...userArgs.filter(Boolean)];
+    const options = {
+      env: this._env,
+      cwd,
+    };
+
+    if (cmd === 'build') {
+      debugBuild('Invoking "hops build"...');
+      const command = [process.argv[0], ...args].join(' ');
+      process.nextTick(() => this._build(command, options));
+    }
+    if (cmd === 'start') {
+      debugStart('Invoking "hops start"...');
+      process.nextTick(() => this._start(process.argv[0], args, options));
+    }
+
+    return this;
+  }
+
+  /**
+   * Retrieve the URL of the Hops dev-server
+   * Only available, when running HopsCLI in "start"-mode.
+   *
+   * @throws {Error} When not running HopsCLI in "start"-mode
+   * @throws {Error} When HopsCLI has not be invoked yet
+   * @returns {Promise<string>}
+   */
+  async getUrl() {
+    if (this._url) {
+      return this._url;
+    }
+
+    if (this._cmd !== 'start') {
+      throw new Error('No URL available when running in "build"-mode.');
+    }
+
+    return new Promise((resolve) =>
+      process.nextTick(() => {
+        if (!this._process) {
+          throw new Error('Please call .run() first.');
+        }
+
+        this.once('running', ({ url }) => resolve(url));
+      })
+    );
+  }
+
+  /**
+   * Stops a the Hops CLI when it's in "start"-mode.
+   *
+   * @throws {Error} When called on a HopsCLI-instance in "build"-mode
+   * @returns {boolean} Could successfully end the process
+   */
+  stop() {
+    if (this._cmd !== 'start') {
+      console.warn('Cannot stop HopsCLI in "build"-mode.');
+      return;
+    }
+
+    if (!this._running || !this._process) {
+      throw new Error('Please call .run() first.');
+    }
+
+    const result = this._process.kill();
+    this.emit('end');
+    this._process = null;
+
+    return result;
+  }
+}
+
+module.exports = { HopsCLI };

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -1,71 +1,11 @@
-const { spawn } = require('child_process');
 const path = require('path');
 const { promisify } = require('util');
-const exec = promisify(require('child_process').exec);
 const rimraf = promisify(require('rimraf'));
 
 const { copy } = require('fs-extra');
 const mktemp = require('mktemp').createDir;
 const mkdirp = promisify(require('mkdirp'));
 const debug = require('debug')('hops-spec:test-helpers');
-const resolveFrom = require('resolve-from');
-
-const build = async ({ cwd, env = {}, argv = [] }) => {
-  const hopsBin = resolveFrom(cwd, 'hops/bin');
-  const command = `${process.argv[0]} ${hopsBin} build ${argv.join(' ')}`;
-  debug('Starting', command);
-  try {
-    return await exec(command, { env, cwd });
-  } catch (err) {
-    return { stderr: err.message };
-  }
-};
-const startServer = ({ cwd, command, env = {}, argv = [] }) =>
-  new Promise((resolve, reject) => {
-    let onTeardown;
-    const teardownPromise = new Promise((resolve) => (onTeardown = resolve));
-
-    const hopsBin = resolveFrom(cwd, 'hops/bin');
-
-    const args = [hopsBin, command].concat(argv);
-    debug('Spawning server', [hopsBin, ...args].join(' '));
-    const started = spawn(process.argv[0], args, {
-      env,
-      cwd,
-    });
-    const teardown = () => {
-      started.kill();
-      return teardownPromise;
-    };
-
-    started.stdout.on('data', (data) => {
-      const line = data.toString('utf-8');
-      debug('stdout >', line);
-      const match = line.match(/listening at (.*)/i);
-      if (match) {
-        debug('found match:', match[1]);
-        const url = match[1];
-        resolve({ url, teardown });
-      }
-    });
-
-    let stderr = '';
-    started.stderr.on('data', (data) => {
-      const line = data.toString('utf-8');
-      debug('stderr >', line);
-      stderr += line;
-    });
-
-    started.on('close', (code) => {
-      debug('Server stopped. exitcode:', code);
-      onTeardown(stderr);
-      if (code) {
-        reject(stderr);
-      }
-    });
-
-    started.on('error', (error) => reject(error));
-  });
 
 const isPuppeteerDisabled = (pragmas) => {
   if (pragmas['jest-hops-puppeteer'] === 'off') {
@@ -110,8 +50,6 @@ const createWorkingDir = async (srcDir) => {
   };
 };
 
-module.exports.startServer = startServer;
-module.exports.build = build;
 module.exports.isPuppeteerDisabled = isPuppeteerDisabled;
 module.exports.launchPuppeteer = launchPuppeteer;
 module.exports.createWorkingDir = createWorkingDir;

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -6,10 +6,12 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');
 const urlJoin = require('url-join');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 const PORT = 8998;
 
 describe('development proxy object config', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
@@ -25,7 +27,12 @@ describe('development proxy object config', () => {
     };
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('proxies with proxy config set as object', async () => {

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -6,10 +6,12 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');
 const urlJoin = require('url-join');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 const PORT = 8999;
 
 describe('development proxy string config', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
@@ -19,7 +21,12 @@ describe('development proxy string config', () => {
     packageJson.hops.proxy = `http://localhost:${PORT}/proxy`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('proxies with proxy config set as string', async () => {

--- a/packages/spec/integration/doctor/__tests__/build.js
+++ b/packages/spec/integration/doctor/__tests__/build.js
@@ -1,6 +1,7 @@
 /**
  * @jest-hops-puppeteer off
  */
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('doctor - build', () => {
   let logs;
@@ -8,14 +9,19 @@ describe('doctor - build', () => {
   const getFromLogs = (type, message) =>
     logs.find((l) => l.endsWith(`:${type}] ${message}`));
 
+  const runHopsBuild = () =>
+    new Promise((resolve) => {
+      HopsCLI.cmd('build')
+        .addEnvVar('HOPS_IGNORE_ERRORS', 'doctor-mixin-a-two')
+        .addArg('-p')
+        .addArg('--parallel-build')
+        .run()
+        .once('end', ({ stderr }) => resolve(stderr))
+        .once('error', () => {}); // Hops Build Error needs handling
+    });
+
   beforeAll(async () => {
-    const { stderr } = await HopsCLI.build(
-      {
-        HOPS_IGNORE_ERRORS: 'doctor-mixin-a-two',
-      },
-      '-p',
-      '--parallel-build'
-    );
+    const stderr = await runHopsBuild();
     logs = stderr
       .split(/\n+/)
       .filter(Boolean)

--- a/packages/spec/integration/doctor/__tests__/develop.js
+++ b/packages/spec/integration/doctor/__tests__/develop.js
@@ -2,7 +2,7 @@
  * @jest-hops-puppeteer off
  */
 
-const delay = () => new Promise((resolve) => setTimeout(resolve, 200));
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('doctor - develop', () => {
   let logs;
@@ -10,13 +10,18 @@ describe('doctor - develop', () => {
   const getFromLogs = (type, message) =>
     logs.find((l) => l.endsWith(`:${type}] ${message}`));
 
+  const runHopsStart = () =>
+    new Promise(async (resolve, reject) => {
+      HopsCLI.cmd('start')
+        .addEnvVar('HOPS_IGNORE_ERRORS', 'doctor-mixin-a-one')
+        .addArg('--fast-dev')
+        .run()
+        .once('end', ({ stderr }) => resolve(stderr))
+        .once('error', reject);
+    });
+
   beforeAll(async () => {
-    await HopsCLI.start(
-      { HOPS_IGNORE_ERRORS: 'doctor-mixin-a-one' },
-      '--fast-dev'
-    );
-    await delay();
-    const stderr = await killServer();
+    const stderr = await runHopsStart();
     logs = stderr.split(/\n+/).filter(Boolean);
   });
 

--- a/packages/spec/integration/graphql-mock-server/__tests__/develop.js
+++ b/packages/spec/integration/graphql-mock-server/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('graphql mock server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('renders a mocked quote', async () => {

--- a/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
+++ b/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('graphql mock server without SSR', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('requests data on the client & not on the server', async () => {

--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -3,12 +3,19 @@
  */
 
 const fetch = require('cross-fetch');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('graphql development client', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   describe('/html', () => {

--- a/packages/spec/integration/hot-module-reload/__tests__/develop.js
+++ b/packages/spec/integration/hot-module-reload/__tests__/develop.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 function changeFile(id) {
   const content = `
@@ -15,10 +16,16 @@ function changeFile(id) {
 // An attempt to fix this did not lead to any satisfying result
 // More info can be found here: https://github.com/xing/hops/pull/760
 describe.skip('hot module reload', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('reflects changes automatically', async () => {

--- a/packages/spec/integration/lambda/__tests__/build.js
+++ b/packages/spec/integration/lambda/__tests__/build.js
@@ -7,6 +7,7 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const createBundle = require('hops-lambda/lib/create-lambda-bundle');
 const { createTmpDirectory } = require('hops-lambda/lib/fs-utils');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 async function zipFunctionCode(root) {
   process.chdir(root);
@@ -35,9 +36,20 @@ function invokeFunction(root, path) {
   });
 }
 
+function runHopsBuild() {
+  return new Promise((resolve, reject) => {
+    HopsCLI.cmd('build')
+      .addArg('-p')
+      .addArg('--parallel-build')
+      .run()
+      .once('end', () => resolve())
+      .once('error', reject);
+  });
+}
+
 describe('lambda production build', () => {
   beforeAll(async () => {
-    await HopsCLI.build('-p', '--parallel-build');
+    await runHopsBuild();
   });
 
   it('renders something', async () => {

--- a/packages/spec/integration/postcss/__tests__/build-static.js
+++ b/packages/spec/integration/postcss/__tests__/build-static.js
@@ -1,9 +1,17 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 // Test to ensure  https://github.com/xing/hops/issues/761 has been fixed
 describe('postcss production static build', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-ps');
+    hopsCli = HopsCLI.cmd('start').addArg('-p').addArg('-s').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('styles when served in production mode', async () => {

--- a/packages/spec/integration/postcss/__tests__/build.js
+++ b/packages/spec/integration/postcss/__tests__/build.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('postcss production build', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-p');
+    hopsCli = HopsCLI.cmd('start').addArg('-p').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('styles when served in production mode', async () => {

--- a/packages/spec/integration/postcss/__tests__/develop.js
+++ b/packages/spec/integration/postcss/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('react-postcss', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('styles when served in development mode', async () => {

--- a/packages/spec/integration/pwa/__tests__/build.js
+++ b/packages/spec/integration/pwa/__tests__/build.js
@@ -1,11 +1,18 @@
 const fs = require('fs');
 const path = require('path');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('pwa production build', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-p');
+    hopsCli = HopsCLI.cmd('start').addArg('-p').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('registers a service worker', async () => {

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -1,11 +1,18 @@
 const fetch = require('cross-fetch');
 const urlJoin = require('url-join');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('react development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('renders home', async () => {

--- a/packages/spec/integration/redux-without-ssr/__tests__/develop.js
+++ b/packages/spec/integration/redux-without-ssr/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('redux development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('increments the counter on page load', async () => {

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -1,10 +1,17 @@
 const urlJoin = require('url-join');
+const { HopsCLI } = require('../../../helpers/hops-cli');
 
 describe('redux development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('has default state', async () => {

--- a/packages/spec/integration/styled-components/__tests__/develop.js
+++ b/packages/spec/integration/styled-components/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('styled-components development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('allows to use styled components', async () => {

--- a/packages/spec/integration/typescript-styled-components/__tests__/develop.js
+++ b/packages/spec/integration/typescript-styled-components/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('typescript-styled-components development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('allows to use the css-props', async () => {

--- a/packages/spec/integration/typescript/__tests__/develop.js
+++ b/packages/spec/integration/typescript/__tests__/develop.js
@@ -1,8 +1,16 @@
+const { HopsCLI } = require('../../../helpers/hops-cli');
+
 describe('typescript development server', () => {
+  let hopsCli;
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    hopsCli = HopsCLI.cmd('start').addArg('--fast-dev').run();
+    url = await hopsCli.getUrl();
+  });
+
+  afterAll(() => {
+    hopsCli.stop();
   });
 
   it('renders a simple jsx site', async () => {


### PR DESCRIPTION
First draft of the improved `HopsCLI`. As soon as we'll have agreed upon the API, this should either be refactored out of `packages/spec` into its own released package. Or `packages/spec` needs to be released (without all the tests obviously…).

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
