### PR TITLE
fix(webpack): ensure forked compiler exits when done

### DIFF
--- a/packages/webpack/lib/utils/compiler-fork.js
+++ b/packages/webpack/lib/utils/compiler-fork.js
@@ -8,7 +8,7 @@ const {
 } = require('../utils/errors');
 const { createCompiler } = require('./compiler');
 
-process.on('message', (message) => {
+process.once('message', (message) => {
   if (message.name !== 'start') return;
 
   const {

--- a/packages/webpack/lib/utils/compiler.js
+++ b/packages/webpack/lib/utils/compiler.js
@@ -83,7 +83,6 @@ function forkCompilation(mixin, buildConfigArgs, options = {}) {
 
       if (!watch) {
         subscriber.complete();
-        child.kill();
       }
     });
   });


### PR DESCRIPTION
Previously we've registered an event handler for the 'message' event on
the IPC channel, which kept the forked process alive even when all its
work was done and we had to manually kill it.
Now we register the callback with `.once` which should cause the child
to exit when no other handles are blocking the event loop.

Through this, the bundle analyzer plugin works correctly because its
process isn't being called once the build finishes.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>