### PR TITLE
feat: change CSS Modules export syntax

### DIFF
--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -79,7 +79,37 @@ For more information on that topic, please have a look at [the documentation of 
 
 #### Preset Options
 
-This preset has no preset configuration options.
+| Name | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `postcss.namedExport` | `Boolean` | `false` | _no_ | Whether CSS Modules do a named exports of class names rather than a default export of the class name object. |
+
+##### `postcss.namedExport`
+
+This option enables you to opt into CSS Modules exporting named exports, instead of doing a default export of the object, that holds all the class names.
+
+To enable it, set the following option in your Hops config.
+
+```json
+"hops": {
+  "postcss": {
+    "namedExport": true
+  }
+}
+```
+
+Then you can do named imports from your your CSS Modules.
+
+```js
+import { btn, btnLabel } from './module.css';
+
+const Btn = ({ children }) => (
+  <button className={btn}>
+    <span className={btnLabel}>{children}</span>
+  </button>
+);
+```
+
+Beware, that this feature requires all class names to be converted to camel-case. This can lead to issues, when e.g. a CSS library leverages the BEM-syntax and two actually different class names yield the same value after being camel-cased. If this happens, the Hops build fails.
 
 #### Render Options
 

--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -13,13 +13,11 @@ const cssLoaderLocalOptions = {
     localIdentName: '[folder]-[name]-[local]-[hash:8]',
     exportLocalsConvention: 'camelCase',
   },
-  esModule: false,
   sourceMap: process.env.NODE_ENV !== 'production',
 };
 
 const cssLoaderGlobalOptions = {
   modules: false,
-  esModule: false,
   sourceMap: process.env.NODE_ENV !== 'production',
 };
 
@@ -98,9 +96,8 @@ class PostCSSMixin extends Mixin {
       getCSSLoaderConfig(this.config.browsers, {
         loader: ExtractCSSPlugin.loader,
         options: {
-          esModule: false,
           modules: {
-            namedExport: true,
+            namedExport: false,
           },
         },
       })
@@ -140,9 +137,8 @@ class PostCSSMixin extends Mixin {
       getCSSLoaderConfig(this.config.browsers, {
         loader: require.resolve('style-loader'),
         options: {
-          esModule: false,
           modules: {
-            namedExport: true,
+            namedExport: false,
           },
         },
       })

--- a/packages/postcss/preset.js
+++ b/packages/postcss/preset.js
@@ -1,3 +1,17 @@
 module.exports = {
   mixins: [__dirname],
+  postcss: {
+    namedExport: false,
+  },
+  configSchema: {
+    postcss: {
+      type: 'object',
+      properties: {
+        namedExport: {
+          type: 'boolean',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
 };

--- a/packages/spec/integration/postcss/__tests__/build-static.js
+++ b/packages/spec/integration/postcss/__tests__/build-static.js
@@ -14,24 +14,21 @@ describe('postcss production static build', () => {
       position,
       fontFamily,
       textAlign,
-      paddingTop,
-      paddingLeft,
+      padding,
       borderRadius,
     } = await page.evaluate(() => {
       const {
         position,
         fontFamily,
         textAlign,
-        paddingTop,
-        paddingLeft,
+        padding,
         borderRadius,
       } = window.getComputedStyle(document.querySelector('h1'));
       return {
         position,
         fontFamily,
         textAlign,
-        paddingTop,
-        paddingLeft,
+        padding,
         borderRadius,
       };
     });
@@ -39,9 +36,8 @@ describe('postcss production static build', () => {
     expect(position).toBe('sticky');
     expect(fontFamily).toContain('-apple-system');
     expect(textAlign).toBe('center');
-    expect(paddingTop).toBe('50px');
-    expect(paddingLeft).toBe('38px');
-    expect(borderRadius).toBe('100px');
+    expect(padding).toBe('32px');
+    expect(borderRadius).toBe('50px');
 
     // there should be 2 stylesheets
     // the global animate.css and the css-modules import

--- a/packages/spec/integration/postcss/index.js
+++ b/packages/spec/integration/postcss/index.js
@@ -1,7 +1,7 @@
 import { render } from 'hops';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
-import styles from './styles.css';
+import * as styles from './styles.css';
 /* eslint-disable import/no-unresolved */
 import './global.css?global';
 import 'animate.css/animate.min.css?global';

--- a/packages/spec/integration/postcss/package.json
+++ b/packages/spec/integration/postcss/package.json
@@ -23,6 +23,9 @@
     "gracePeriod": 0,
     "locations": [
       "/"
-    ]
+    ],
+    "postcss": {
+      "namedExport": true
+    }
   }
 }

--- a/packages/spec/integration/postcss/styles.css
+++ b/packages/spec/integration/postcss/styles.css
@@ -1,10 +1,10 @@
 @import url(imported-from-css.css);
-@import '@zendeskgarden/css-buttons';
+@import '@vishnucss/chips';
 
 .headline {
   composes: compose from './for-composing.css';
-  composes: c-btn--pill from '@zendeskgarden/css-buttons';
-  padding-left: var(--zd-btn-line-height);
+  composes: chips from '@vishnucss/chips';
+  padding: var(--spacing-xl);
   color: aqua;
   position: sticky;
   font-family: system-ui;

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -43,7 +43,7 @@
     "url-join": "^4.0.1"
   },
   "dependencies": {
-    "@zendeskgarden/css-buttons": "^8.0.0",
+    "@vishnucss/chips": "^1.1.2",
     "animate.css": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,6 +2905,11 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.1.tgz#5668c0bce55a91f2b9566b1d8a4c0a8dbbc79764"
   integrity sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
 
+"@vishnucss/chips@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@vishnucss/chips/-/chips-1.1.2.tgz#3de6c0f689461a3e026b82baddc04759ca88de70"
+  integrity sha512-DrsKnnVBEsvYjeb3kv5ob3g14mIMH4hTU014c9EybYOXX4aXx4TbTQKSbrGCbayQ4cYv6SfeEbH98WEsuhOiVA==
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3074,18 +3079,6 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
-
-"@zendeskgarden/css-buttons@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/css-buttons/-/css-buttons-8.0.0.tgz#36d7ba003fea4db3653a0f2056a1fde875bd115b"
-  integrity sha512-evmybZFoONmxp29ELv+Zw/ajsNCEsAQpx3whrIVqfjSbBtffHMdQKbxS/AMXAfgaevaIpDRI/I3iFjFoHwLq5g==
-  dependencies:
-    "@zendeskgarden/css-variables" "^6.4.5"
-
-"@zendeskgarden/css-variables@^6.4.5":
-  version "6.4.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/css-variables/-/css-variables-6.4.5.tgz#b51a50046f42a11b8d1bfec46e100b02fd6fc1d9"
-  integrity sha512-vX7vDJVQoyYFUshYXXX5QE2fL9M6K2bnxTeB2IVyEIaGRYEi20xjoY6cuO1uAQ7RaIRGCSyZFKgWW+/IrlQMKg==
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
1.) Changes the export syntax of CSS Modules from CommonJS to ESM, which is a **Breaking Change**.
2.) Adds option, to export named exports from CSS Modules

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
