### PR TITLE
fix(bootstrap): add Ajv formats

### DIFF
--- a/packages/bootstrap/lib/validator.js
+++ b/packages/bootstrap/lib/validator.js
@@ -5,9 +5,11 @@
 const { isAbsolute } = require('path');
 
 const { default: Ajv } = require('ajv');
+const { default: addFormats } = require('ajv-formats');
 const isPlainObject = require('is-plain-obj');
 
 const configureAjv = (ajv) => {
+  addFormats(ajv);
   ajv.addKeyword({
     keyword: 'absolutePath',
     errors: true,

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/xing/hops#readme",
   "dependencies": {
     "ajv": "^7.0.0",
+    "ajv-formats": "^1.5.1",
     "check-error": "^1.0.2",
     "cosmiconfig": "^7.0.0",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3199,6 +3199,13 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-1.5.1.tgz#0f301b1b3846182f224cc563fc0a032daafb7dab"
+  integrity sha512-s1RBVF4HZd2UjGkb6t6uWoXjf6o7j7dXPQIL7vprcIT/67bTD6+5ocsU0UKShS2qWxueGDWuGfKHfOxHWrlTQg==
+  dependencies:
+    ajv "^7.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"


### PR DESCRIPTION
...which aren't part of the main package anymore as of v7.

Removes the warning `unknown format "hostname" ignored in schema at path "#/properties/aws/properties/domainName"` for `hops-lambda`.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
