### PR TITLE
chore(spec): refactor HopsCLI

### DIFF
--- a/packages/spec/helpers/env.js
+++ b/packages/spec/helpers/env.js
@@ -112,26 +112,26 @@ class FixtureEnvironment extends NodeEnvironment {
         const { env, argv } = getCommandModifications(args);
         return build({ cwd: that.cwd, argv, env });
       },
-      async start(...args) {
+      start(...args) {
         if (that.killServer) {
           throw new Error(
             'Another long running task ("hops start") is already running. You can only start one task per file.'
           );
         }
         const { env, argv } = getCommandModifications(args);
-        const { url, teardown } = await startServer({
+        const { getUrl, stopServer: killServer } = startServer({
           cwd: that.cwd,
           command: 'start',
           env,
           argv,
         });
         // eslint-disable-next-line require-atomic-updates
-        that.killServer = teardown;
-        that.global.killServer = () => {
+        that.killServer = killServer;
+        const stopServer = () => {
           delete that.killServer;
-          return teardown();
+          return killServer();
         };
-        return url;
+        return { getUrl, stopServer };
       },
     };
   }

--- a/packages/spec/helpers/test-helpers.js
+++ b/packages/spec/helpers/test-helpers.js
@@ -2,6 +2,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const { promisify } = require('util');
 const rimraf = promisify(require('rimraf'));
+const EProm = require('eprom');
 
 const { copy } = require('fs-extra');
 const mktemp = require('mktemp').createDir;
@@ -32,52 +33,57 @@ const build = ({ cwd, env = {}, argv = [] }) =>
     process.on('exit', () => buildProcess.kill());
   });
 
-const startServer = ({ cwd, command, env = {}, argv = [] }) =>
-  new Promise((resolve, reject) => {
-    let onTeardown;
-    const teardownPromise = new Promise((resolve) => (onTeardown = resolve));
+const startServer = ({ cwd, command, env = {}, argv = [] }) => {
+  const teardownPromise = new EProm();
+  const urlPromise = new EProm();
+  let stdout = '';
+  let stderr = '';
 
-    const hopsBin = resolveFrom(cwd, 'hops/bin');
-
-    const args = [hopsBin, command].concat(argv);
-    debug('Spawning server', [hopsBin, ...args].join(' '));
-    const started = spawn(process.argv[0], args, {
-      env,
-      cwd,
-    });
-    const teardown = () => {
-      started.kill();
-      return teardownPromise;
-    };
-
-    started.stdout.on('data', (data) => {
-      const line = data.toString('utf-8');
-      debug('stdout >', line);
-      const match = line.match(/listening at (.*)/i);
-      if (match) {
-        debug('found match:', match[1]);
-        const url = match[1];
-        resolve({ url, teardown });
-      }
-    });
-
-    let stderr = '';
-    started.stderr.on('data', (data) => {
-      const line = data.toString('utf-8');
-      debug('stderr >', line);
-      stderr += line;
-    });
-
-    started.on('close', (code) => {
-      debug('Server stopped. exitcode:', code);
-      onTeardown(stderr);
-      if (code) {
-        reject(stderr);
-      }
-    });
-
-    started.on('error', (error) => reject(error));
+  const hopsBin = resolveFrom(cwd, 'hops/bin');
+  const args = [hopsBin, command].concat(argv);
+  debug('Spawning server', args.join(' '), { env });
+  const started = spawn(process.argv[0], args, {
+    env,
+    cwd,
   });
+  let stopServer = () => {
+    started.kill();
+    teardownPromise.resolve({ stderr, stdout });
+    return teardownPromise;
+  };
+
+  started.stdout.on('data', (data) => {
+    const line = data.toString('utf-8');
+    debug('stdout >', line);
+    stdout += line;
+
+    const [, url] = line.match(/listening at (.*)/i) || [];
+    if (url) {
+      debug('found match:', url);
+      urlPromise.resolve(url);
+    }
+  });
+
+  started.stderr.on('data', (data) => {
+    const line = data.toString('utf-8');
+    debug('stderr >', line);
+    stderr += line;
+  });
+
+  started.on('close', (code) => {
+    debug('Server stopped. exitcode:', code);
+    urlPromise.reject('server closed');
+    stopServer = () => {};
+  });
+
+  started.on('error', (error) => teardownPromise.reject(error));
+
+  process.on('exit', () => {
+    stopServer();
+  });
+
+  return { getUrl: () => urlPromise, stopServer };
+};
 
 const isPuppeteerDisabled = (pragmas) => {
   if (pragmas['jest-hops-puppeteer'] === 'off') {

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -25,7 +25,8 @@ describe('development proxy object config', () => {
     };
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('proxies with proxy config set as object', async () => {

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -19,7 +19,8 @@ describe('development proxy string config', () => {
     packageJson.hops.proxy = `http://localhost:${PORT}/proxy`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('proxies with proxy config set as string', async () => {

--- a/packages/spec/integration/doctor/__tests__/develop.js
+++ b/packages/spec/integration/doctor/__tests__/develop.js
@@ -11,12 +11,13 @@ describe('doctor - develop', () => {
     logs.find((l) => l.endsWith(`:${type}] ${message}`));
 
   beforeAll(async () => {
-    await HopsCLI.start(
+    const { getUrl: serverStarted, stopServer } = HopsCLI.start(
       { HOPS_IGNORE_ERRORS: 'doctor-mixin-a-one' },
       '--fast-dev'
     );
+    await serverStarted();
     await delay();
-    const stderr = await killServer();
+    const { stderr } = await stopServer();
     logs = stderr.split(/\n+/).filter(Boolean);
   });
 

--- a/packages/spec/integration/graphql-mock-server/__tests__/develop.js
+++ b/packages/spec/integration/graphql-mock-server/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('graphql mock server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('renders a mocked quote', async () => {

--- a/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
+++ b/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('graphql mock server without SSR', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('requests data on the client & not on the server', async () => {

--- a/packages/spec/integration/graphql/__tests__/develop.js
+++ b/packages/spec/integration/graphql/__tests__/develop.js
@@ -8,7 +8,8 @@ describe('graphql development client', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   describe('/html', () => {

--- a/packages/spec/integration/hot-module-reload/__tests__/develop.js
+++ b/packages/spec/integration/hot-module-reload/__tests__/develop.js
@@ -18,7 +18,8 @@ describe.skip('hot module reload', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('reflects changes automatically', async () => {

--- a/packages/spec/integration/postcss/__tests__/build-static.js
+++ b/packages/spec/integration/postcss/__tests__/build-static.js
@@ -3,7 +3,8 @@ describe('postcss production static build', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-ps');
+    const { getUrl } = HopsCLI.start('-ps');
+    url = await getUrl();
   });
 
   it('styles when served in production mode', async () => {

--- a/packages/spec/integration/postcss/__tests__/build.js
+++ b/packages/spec/integration/postcss/__tests__/build.js
@@ -2,7 +2,8 @@ describe('postcss production build', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-p');
+    const { getUrl } = HopsCLI.start('-p');
+    url = await getUrl();
   });
 
   it('styles when served in production mode', async () => {

--- a/packages/spec/integration/postcss/__tests__/develop.js
+++ b/packages/spec/integration/postcss/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('react-postcss', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('styles when served in development mode', async () => {

--- a/packages/spec/integration/pwa/__tests__/build.js
+++ b/packages/spec/integration/pwa/__tests__/build.js
@@ -5,7 +5,8 @@ describe('pwa production build', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('-p');
+    const { getUrl } = HopsCLI.start('-p');
+    url = await getUrl();
   });
 
   it('registers a service worker', async () => {

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -5,7 +5,8 @@ describe('react development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('renders home', async () => {

--- a/packages/spec/integration/redux-without-ssr/__tests__/develop.js
+++ b/packages/spec/integration/redux-without-ssr/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('redux development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('increments the counter on page load', async () => {

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -4,7 +4,8 @@ describe('redux development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('has default state', async () => {

--- a/packages/spec/integration/styled-components/__tests__/develop.js
+++ b/packages/spec/integration/styled-components/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('styled-components development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('allows to use styled components', async () => {

--- a/packages/spec/integration/typescript-styled-components/__tests__/develop.js
+++ b/packages/spec/integration/typescript-styled-components/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('typescript-styled-components development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('allows to use the css-props', async () => {

--- a/packages/spec/integration/typescript/__tests__/develop.js
+++ b/packages/spec/integration/typescript/__tests__/develop.js
@@ -2,7 +2,8 @@ describe('typescript development server', () => {
   let url;
 
   beforeAll(async () => {
-    url = await HopsCLI.start('--fast-dev');
+    const { getUrl } = HopsCLI.start('--fast-dev');
+    url = await getUrl();
   });
 
   it('renders a simple jsx site', async () => {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -33,6 +33,7 @@
     "@types/styled-components": "5.1.7",
     "create-hops-app": "^14.0.0-nightly.4",
     "cross-fetch": "^3.0.4",
+    "eprom": "^1.0.0",
     "fs-extra": "^9.0.0",
     "jest-environment-node": "^26.0.0",
     "mktemp": "^1.0.0",


### PR DESCRIPTION
supersedes #1470 

Not that much changes here, but running the `start`-command got decoupled from retrieving the URL. And retrieving the URL got decoupled from retrieving the function for stopping the server.

Also the values, the `build`-command resolves to, now reflects what `exec` is yielding.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
