### PR TITLE
chore: run eslint in CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -35,10 +35,13 @@ jobs:
             ${{ runner.OS }}-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Run tests
+      - name: Check code quality
+        if: ${{ matrix.node-version == '15.x' }}
         run: |
           yarn fmt:check
-          yarn test --maxWorkers=2 --ci
+          yarn lint
+      - name: Run tests
+        run: yarn test --maxWorkers=2 --ci
 
   canarist:
     runs-on: ubuntu-latest

--- a/packages/jest-environment/helpers.js
+++ b/packages/jest-environment/helpers.js
@@ -115,6 +115,7 @@ const launchPuppeteer = async (disablePuppeteer) => {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   };
   debug('Starting puppeteer', config);
+  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   const { default: puppeteer } = await import('puppeteer');
   const browser = await puppeteer.launch(config);
   return {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -11,7 +11,6 @@
       "jest": true
     },
     "globals": {
-      "handleConsoleOutput": true,
       "createPage": true,
       "browser": true,
       "HopsCLI": true,


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
