### PR TITLE
fix(postcss): disable external PostCSS configs

### DIFF
--- a/packages/postcss/mixin.core.js
+++ b/packages/postcss/mixin.core.js
@@ -27,6 +27,7 @@ const getPostCssLoader = (...additionalPlugins) => ({
   options: {
     postcssOptions: {
       ident: 'postcss',
+      config: false,
       plugins: [postcssImportPlugin(), ...additionalPlugins],
     },
   },


### PR DESCRIPTION
`postcss-loader@4` introduced [the feature of collecting & merging all
the `postcss.config.js`-files](https://www.npmjs.com/package/postcss-loader/v/4.0.0#config) of a project (even of external ones in the
`node_modules`-folder) and take them into account, when processing CSS.

This has not been in the scope of `hops-postcss` and thus needs to be
deactivated.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
