### PR TITLE
chore: add config for release-bot

### DIFF
--- a/.github/release-bot.yml
+++ b/.github/release-bot.yml
@@ -1,0 +1,10 @@
+dist-tags:
+  'v12.x': 'v12'
+  'v13.x': 'latest'
+  'master': 'next'
+
+labels:
+  ':package: v12': 'v12.x'
+  ':package: v13': 'v13.x'
+
+release-pr-branch-pattern: 'release-bot/next-%s'


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>