### PR TITLE
refactor: correct lodash import

### DIFF
--- a/packages/bootstrap/lib/utils.js
+++ b/packages/bootstrap/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mergeWith = require('lodash.mergewith');
+const mergeWith = require('lodash/mergeWith');
 const flatten = require('flat');
 const isPlainObject = require('is-plain-obj');
 const escapeRegExp = require('escape-string-regexp');

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -22,7 +22,7 @@
     "find-up": "^5.0.0",
     "flat": "^5.0.0",
     "is-plain-obj": "^2.0.0",
-    "lodash.mergewith": "^4.6.2",
+    "lodash": "^4.6.2",
     "mixinable": "^5.0.1",
     "supports-color": "^7.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8809,7 +8809,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.6.2:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
According to lodash docs (https://lodash.com/per-method-packages) the
per method packages shouldn't be used any longer.

The bootstrap code of hops is also bundled in the client and is
therefore directly related to the described problem.
