### PR TITLE
chore: pin version of react-apollo in canarist runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,12 @@
             "directory": "internal-hops",
             "branch": "v13.x"
           }
-        ]
+        ],
+        "rootManifest": {
+          "resolutions": {
+            "react-apollo": "3.1.5"
+          }
+        }
       },
       {
         "name": "internal-workshop",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   "requiredStatusChecks": null,
   "semanticCommitType": "chore",
   "semanticCommitScope": null,
-  "baseBranches": ["master", "v12.x", "v11.x"],
   "packageRules": [
     {
       "depTypeList": ["dependencies", "peerDependencies"],
@@ -26,11 +25,6 @@
       "depTypeList": ["devDependencies"],
       "updateTypes": ["major", "minor"],
       "rangeStrategy": "bump"
-    },
-    {
-      "baseBranchList": ["v11.x"],
-      "major": { "enabled": false },
-      "minor": { "enabled": false }
     }
   ]
 }


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
