### PR TITLE
chore: add publish action to push tags and publish to registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - v12.x
+      - v13.x
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Push version tag
+        id: push-version-tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          version="v$(jq -r .version lerna.json)"
+          echo "::set-output name=version::${version}"
+          git tag $version
+          git push origin --tags
+      - name: Extract changelog
+        run: |
+          git diff HEAD^..HEAD -- CHANGELOG.md > diff.patch
+          sed -i diff.patch -e 's/CHANGELOG.md/release_changelog.md/g'
+          touch release_changelog.md
+          git apply --recount -C0 diff.patch
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.push-version-tag.outputs.version }}
+          release_name: Release ${{ steps.push-version-tag.outputs.version }}
+          body_path: release_changelog.md
+          draft: false
+          prerelease: false
+      - name: Publish to registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn lerna publish from-git --yes


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>