### PR TITLE
chore: fix retrieving the latest change on the CHANGELOG

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,8 @@ jobs:
           git push origin --tags
       - name: Extract changelog
         run: |
-          git diff HEAD^..HEAD -- CHANGELOG.md > diff.patch
+          SHA=$(git log -n 1 --pretty=format:%H -- CHANGELOG.md | tr -d '\n')
+          git diff $SHA^ -- CHANGELOG.md > diff.patch
           sed -i diff.patch -e 's/CHANGELOG.md/release_changelog.md/g'
           touch release_changelog.md
           git apply --recount -C0 diff.patch


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
