### PR TITLE
chore: check out release commit before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 10
+      - name: Check out release commit
+        # The CHANGELOG has been touched by lerna during the creation of the
+        # latest release; so the respective commit SHA is the one we need
+        # to publish from.
+        run: |
+          SHA=$(git log -n 1 --pretty=format:%H -- CHANGELOG.md | tr -d '\n')
+          git checkout ${SHA}
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
@@ -43,8 +50,7 @@ jobs:
           git push origin --tags
       - name: Extract changelog
         run: |
-          SHA=$(git log -n 1 --pretty=format:%H -- CHANGELOG.md | tr -d '\n')
-          git diff $SHA^ -- CHANGELOG.md > diff.patch
+          git diff HEAD^ -- CHANGELOG.md > diff.patch
           sed -i diff.patch -e 's/CHANGELOG.md/release_changelog.md/g'
           touch release_changelog.md
           git apply --recount -C0 diff.patch


### PR DESCRIPTION
`lerna publish from-git` is what we want to do. Unfortunately though there's a merge commit done by the bors-bot between `lerna version` and `lerna publish`.

So when lerna does `git diff-tree --name-only --no-commit-id --root -r -c HEAD` to detect the packages it needs to publish, it doesn't find any on the merge commit.

The solution is to detect the release commit done during `lerna version` and check out that one. Then the git tag created in the publish-Action references the correct commit. And `lerna publish from-git` actually finds packages to publish.

Still feels a little dirty, though… :grimacing:

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
