### PR TITLE
chore: remove foosbyte/kicker-trainer from canarist tests

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -42,17 +42,3 @@ jobs:
           yarn lint
       - name: Run tests
         run: yarn test --maxWorkers=2 --ci
-
-  canarist:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: 15.x
-      - name: Install canarist
-        run: npm i -g canarist
-      - name: Run canarist
-        run: canarist -p kicker-trainer

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,6 @@ status = [
   "tests (12.x)",
   "tests (14.x)",
   "tests (15.x)",
-  "canarist",
   "canarist/internal-hops",
   "canarist/internal-workshop",
 ]

--- a/package.json
+++ b/package.json
@@ -45,24 +45,6 @@
   "canarist": {
     "projects": [
       {
-        "name": "kicker-trainer",
-        "repositories": [
-          {
-            "url": ".",
-            "commands": [
-              ""
-            ]
-          },
-          {
-            "url": "https://github.com/foosbyte/kicker-trainer.git",
-            "commands": [
-              "yarn build -p",
-              "yarn test"
-            ]
-          }
-        ]
-      },
-      {
         "name": "internal-hops",
         "repositories": [
           {


### PR DESCRIPTION
...because it is not actively maintained and blocks us by causing failing tests in CI.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
