### PR TITLE
chore: use GH_TOKEN to push tags and releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 10
+          token: ${{ secrets.GH_TOKEN }}
       - name: Check out release commit
         # The CHANGELOG has been touched by lerna during the creation of the
         # latest release; so the respective commit SHA is the one we need
@@ -42,8 +43,8 @@ jobs:
       - name: Push version tag
         id: push-version-tag
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name hops-untool
+          git config user.email 45232789+hops-untool@users.noreply.github.com
           version="v$(jq -r .version lerna.json)"
           echo "::set-output name=version::${version}"
           git tag $version
@@ -57,7 +58,7 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ steps.push-version-tag.outputs.version }}
           release_name: Release ${{ steps.push-version-tag.outputs.version }}


### PR DESCRIPTION
because the built-in GITHUB_TOKEN does not allow to push to workflow
files.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>