### PR TITLE
chore: write npm token directly into .npmrc file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,5 +69,5 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+          echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
           yarn lerna publish from-git --yes


### PR DESCRIPTION
although the npm docs recommend not doing this, because the npm cli
automatically replaces the NPM_TOKEN variable from the environment,
the library used here (libnpmpublish) doesn't seem to be able to, so we
need to actually write the token.

- https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow
- https://github.com/lerna/lerna/issues/2404


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>