### PR TITLE
refactor(bootstrap): replace lodash.mergeWith with custom function

### DIFF
--- a/packages/bootstrap/lib/__tests__/utils.test.js
+++ b/packages/bootstrap/lib/__tests__/utils.test.js
@@ -1,0 +1,108 @@
+/* eslint-env node, jest */
+
+const { merge: mergeFactory } = require('../utils');
+
+describe('merge', () => {
+  it('should merge two objects', () => {
+    const a = { a: 1 };
+    const b = { b: 2 };
+
+    const merge = mergeFactory(false);
+
+    const result = merge(a, b);
+
+    expect(result).toEqual({
+      a: 1,
+      b: 2,
+    });
+
+    expect(a).toEqual({ a: 1 });
+    expect(b).toEqual({ b: 2 });
+  });
+
+  it('should deep-merge objects', () => {
+    const a = { a: { a: 1 } };
+    const b = { b: { b: 2 } };
+    const c = { a: { c: 3 } };
+    const d = { b: { b: 4 } };
+
+    const merge = mergeFactory(false);
+
+    const result = merge(a, b, c, d);
+
+    expect(result).toEqual({
+      a: { a: 1, c: 3 },
+      b: { b: 4 },
+    });
+
+    expect(a).toEqual({ a: { a: 1 } });
+    expect(b).toEqual({ b: { b: 2 } });
+    expect(c).toEqual({ a: { c: 3 } });
+    expect(d).toEqual({ b: { b: 4 } });
+  });
+
+  it('should concatenate mixins arrays', () => {
+    const a = { mixins: ['a'], other: [1] };
+    const b = { mixins: ['b'], other: [2] };
+
+    const merge = mergeFactory(false);
+
+    const result = merge(a, b);
+
+    expect(result).toEqual({
+      mixins: ['a', 'b'],
+      other: [2],
+    });
+
+    expect(a).toEqual({ mixins: ['a'], other: [1] });
+    expect(b).toEqual({ mixins: ['b'], other: [2] });
+  });
+
+  it('should de-duplicate mixins', () => {
+    const a = { mixins: ['a'] };
+    const b = { mixins: ['a'] };
+
+    const merge = mergeFactory(false);
+
+    const result = merge(a, b);
+
+    expect(result).toEqual({
+      mixins: ['a'],
+    });
+
+    expect(a).toEqual({ mixins: ['a'] });
+    expect(b).toEqual({ mixins: ['a'] });
+  });
+
+  it('should de-duplicate mixins (order by last occurrence)', () => {
+    const a = { mixins: ['a', 'b'] };
+    const b = { mixins: ['a', 'c'] };
+
+    const merge = mergeFactory(false);
+
+    const result = merge(a, b);
+
+    expect(result).toEqual({
+      mixins: ['b', 'a', 'c'],
+    });
+
+    expect(a).toEqual({ mixins: ['a', 'b'] });
+    expect(b).toEqual({ mixins: ['a', 'c'] });
+  });
+
+  it('should de-duplicate mixins (legacy sort order)', () => {
+    const a = { mixins: ['a', 'b'] };
+    const b = { mixins: ['a', 'c'] };
+
+    const merge = mergeFactory(true);
+
+    const result = merge(a, b);
+
+    expect(result).toEqual({
+      mixins: ['a', 'b', 'c'],
+    });
+
+    expect(a).toEqual({ mixins: ['a', 'b'] });
+    expect(b).toEqual({ mixins: ['a', 'c'] });
+  });
+});

--- a/packages/bootstrap/lib/utils.js
+++ b/packages/bootstrap/lib/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const mergeWith = require('lodash/mergeWith');
 const flatten = require('flat');
 const isPlainObject = require('is-plain-obj');
 const escapeRegExp = require('escape-string-regexp');
@@ -33,6 +32,30 @@ exports.validate = (strategy, checkArgs = () => {}, checkResult = () => {}) =>
     { value: strategy.name }
   );
 
+function merge(target, ...args) {
+  // eslint-disable-next-line no-unused-vars
+  let merger = (leftSide, rightSide, _key) => {
+    return rightSide;
+  };
+  if (typeof args[args.length - 1] === 'function') {
+    merger = args.pop();
+  }
+
+  return args.reduce((acc, obj) => {
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        if (isPlainObject(obj[key])) {
+          acc[key] = merge(acc[key] || {}, obj[key], merger);
+        } else {
+          acc[key] = merger(acc[key], obj[key], key);
+        }
+      }
+    }
+
+    return acc;
+  }, target);
+}
+
 exports.getMixinSortOrder = (...args) =>
   args.reduce((enableLegacyMixinSortOrder, config) => {
     if ('enableLegacyMixinSortOrder' in config) {
@@ -42,7 +65,7 @@ exports.getMixinSortOrder = (...args) =>
   }, false);
 
 exports.merge = (enableLegacyMixinSortOrder = false) => (...args) => {
-  return mergeWith({}, ...args, (objValue, srcValue, key) => {
+  return merge({}, ...args, (objValue, srcValue, key) => {
     if (Array.isArray(objValue)) {
       if ('mixins' === key) {
         // #542: remove this in untool v3 if no potential side-effects have been
@@ -60,6 +83,7 @@ exports.merge = (enableLegacyMixinSortOrder = false) => (...args) => {
       }
       return srcValue;
     }
+    return srcValue;
   });
 };
 

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -23,7 +23,6 @@
     "find-up": "^5.0.0",
     "flat": "^5.0.0",
     "is-plain-obj": "^3.0.0",
-    "lodash": "^4.6.2",
     "mixinable": "^5.0.1",
     "supports-color": "^8.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8987,10 +8987,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.6.2:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
To reduce our bundle size by about 10kb we replace lodash.mergeWith with
a custom implementation to merge objects and arrays.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>