### PR TITLE
feat: rewrite runtime code to ESM to facilitate tree shaking

### DIFF
--- a/packages/apollo-mock-server/context-extender.js
+++ b/packages/apollo-mock-server/context-extender.js
@@ -1,1 +1,1 @@
-module.exports = (context) => context;
+export default (context) => context;

--- a/packages/config/browser.js
+++ b/packages/config/browser.js
@@ -1,7 +1,9 @@
-const deprecate = require('depd')('hops-config');
+import deprecateFactory from 'depd';
+import { internal } from 'hops-bootstrap';
+const deprecate = deprecateFactory('hops-config');
 
 deprecate(
   '[DEP0001] hops-config is deprecated. Please use ConfigContext or the withConfig() HOC from hops instead.'
 );
 
-module.exports = require('hops-bootstrap').internal.getConfig();
+export default internal.getConfig();

--- a/packages/hops/lib/runtime.js
+++ b/packages/hops/lib/runtime.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {
+export {
   render,
   Header,
   importComponent,
@@ -12,22 +12,6 @@ const {
   ConfigContext,
   withConfig,
   useConfig,
-} = require('hops-react');
+} from 'hops-react';
 
-const { Mixin, strategies } = require('hops-mixin');
-
-module.exports = {
-  Header,
-  importComponent,
-  Miss,
-  Status,
-  render,
-  ServerDataContext,
-  withServerData,
-  useServerData,
-  ConfigContext,
-  withConfig,
-  useConfig,
-  Mixin,
-  strategies,
-};
+export { Mixin, strategies } from 'hops-mixin';

--- a/packages/info/logger/mixin.server.js
+++ b/packages/info/logger/mixin.server.js
@@ -1,6 +1,6 @@
-const { sync } = require('mixinable');
-const { Mixin } = require('hops-mixin');
-const { internal: bootstrap } = require('hops-bootstrap');
+import { sync } from 'mixinable';
+import { Mixin } from 'hops-mixin';
+import { internal as bootstrap } from 'hops-bootstrap';
 
 const { callable } = sync;
 const { validate, invariant } = bootstrap;
@@ -22,4 +22,4 @@ ServerLogMixin.strategies = {
   }),
 };
 
-module.exports = ServerLogMixin;
+export default ServerLogMixin;

--- a/packages/jest-preset/mocks/hops.js
+++ b/packages/jest-preset/mocks/hops.js
@@ -2,4 +2,7 @@
 const hops = require('hops/lib/runtime');
 const importComponent = require('../helpers/import-component');
 
-module.exports = Object.assign(hops, { importComponent });
+module.exports = {
+  ...hops,
+  importComponent,
+};

--- a/packages/pwa/dom.js
+++ b/packages/pwa/dom.js
@@ -1,8 +1,7 @@
 /* eslint-env browser */
 
-const {
-  internal: { getConfig },
-} = require('hops-bootstrap');
+import { internal } from 'hops-bootstrap';
+const { getConfig } = internal;
 
 const isLocalHost = (host) => {
   return (
@@ -14,7 +13,7 @@ const isLocalHost = (host) => {
   );
 };
 
-module.exports = function installServiceWorker() {
+export default function installServiceWorker() {
   return new Promise((resolve, reject) => {
     if (!('serviceWorker' in navigator)) {
       return reject(
@@ -31,4 +30,4 @@ module.exports = function installServiceWorker() {
       });
     }
   });
-};
+}

--- a/packages/pwa/node.js
+++ b/packages/pwa/node.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = function installServiceWorke() {
+export default function installServiceWorker() {
   return new Promise(function () {
     /* intentionally left empty */
   });
-};
+}

--- a/packages/pwa/worker.js
+++ b/packages/pwa/worker.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = (config, assets) => {
+export default (config, assets) => {
   console.log('hello from worker', assets, config);
 };

--- a/packages/react-apollo/mixin.browser.js
+++ b/packages/react-apollo/mixin.browser.js
@@ -1,20 +1,18 @@
-const React = require('react');
-const {
-  Mixin,
-  strategies: {
-    sync: { override, callable },
-  },
-} = require('hops-mixin');
-
-const { ApolloProvider } = require('react-apollo');
-const { default: ApolloClient } = require('apollo-client');
-const { HttpLink } = require('apollo-link-http');
-const {
+import { createElement } from 'react';
+import { Mixin, strategies } from 'hops-mixin';
+import { ApolloProvider } from 'react-apollo';
+import { ApolloClient } from 'apollo-client';
+import { HttpLink } from 'apollo-link-http';
+import {
   InMemoryCache,
   IntrospectionFragmentMatcher,
   HeuristicFragmentMatcher,
-} = require('apollo-cache-inmemory');
-require('cross-fetch/polyfill');
+} from 'apollo-cache-inmemory';
+import 'cross-fetch/polyfill';
+
+const {
+  sync: { override, callable },
+} = strategies;
 
 class GraphQLMixin extends Mixin {
   constructor(config, element, { graphql: options = {} } = {}) {
@@ -71,7 +69,7 @@ class GraphQLMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       ApolloProvider,
       { client: this.getApolloClient() },
       reactElement
@@ -85,4 +83,4 @@ GraphQLMixin.strategies = {
   createFragmentMatcher: callable,
 };
 
-module.exports = GraphQLMixin;
+export default GraphQLMixin;

--- a/packages/react-apollo/mixin.server.js
+++ b/packages/react-apollo/mixin.server.js
@@ -1,23 +1,21 @@
-const React = require('react');
-const renderToFragments = require('hops-react/lib/fragments');
-const { existsSync, readFileSync } = require('fs');
-const {
-  Mixin,
-  strategies: {
-    sync: { override, callable, sequence },
-  },
-} = require('hops-mixin');
-
-const { ApolloProvider, getMarkupFromTree } = require('react-apollo');
-const { default: ApolloClient } = require('apollo-client');
-const { ApolloLink } = require('apollo-link');
-const { HttpLink } = require('apollo-link-http');
-const {
+import { createElement } from 'react';
+import renderToFragments from 'hops-react/lib/fragments';
+import { existsSync, readFileSync } from 'fs';
+import { Mixin, strategies } from 'hops-mixin';
+import { ApolloProvider, getMarkupFromTree } from 'react-apollo';
+import { ApolloClient } from 'apollo-client';
+import { ApolloLink } from 'apollo-link';
+import { HttpLink } from 'apollo-link-http';
+import {
   InMemoryCache,
   IntrospectionFragmentMatcher,
   HeuristicFragmentMatcher,
-} = require('apollo-cache-inmemory');
-const fetch = require('cross-fetch');
+} from 'apollo-cache-inmemory';
+import fetch from 'cross-fetch';
+
+const {
+  sync: { override, callable, sequence },
+} = strategies;
 
 let introspectionResult = undefined;
 
@@ -138,7 +136,7 @@ class GraphQLMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       ApolloProvider,
       { client: this.getApolloClient() },
       reactElement
@@ -153,4 +151,4 @@ GraphQLMixin.strategies = {
   canPrefetchOnServer: sequence,
 };
 
-module.exports = GraphQLMixin;
+export default GraphQLMixin;

--- a/packages/react/config/context.js
+++ b/packages/react/config/context.js
@@ -1,3 +1,7 @@
-const React = require('react');
+import { createContext } from 'react';
 
-module.exports = React.createContext({});
+const context = createContext({});
+
+export default context;
+export const Consumer = context.Consumer;
+export const Provider = context.Provider;

--- a/packages/react/config/mixin.runtime.js
+++ b/packages/react/config/mixin.runtime.js
@@ -1,9 +1,9 @@
 /* eslint-env browser, node */
 
-const React = require('react');
-const { Mixin } = require('hops-mixin');
+import { createElement } from 'react';
 
-const { Provider } = require('./context');
+import { Mixin } from 'hops-mixin';
+import { Provider } from './context';
 
 const warnOnIncompleteBrowserWhitelist = (config) => {
   if (process.env.NODE_ENV === 'development' && typeof Proxy === 'function') {
@@ -31,7 +31,7 @@ const warnOnIncompleteBrowserWhitelist = (config) => {
 
 class HopsReactConfigMixin extends Mixin {
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       Provider,
       { value: warnOnIncompleteBrowserWhitelist(this.config) },
       reactElement
@@ -39,4 +39,4 @@ class HopsReactConfigMixin extends Mixin {
   }
 }
 
-module.exports = HopsReactConfigMixin;
+export default HopsReactConfigMixin;

--- a/packages/react/config/use-config.js
+++ b/packages/react/config/use-config.js
@@ -1,8 +1,6 @@
-const React = require('react');
-const ConfigContext = require('./context');
+import { useContext } from 'react';
+import ConfigContext from './context';
 
-function useConfig() {
-  return React.useContext(ConfigContext);
+export default function useConfig() {
+  return useContext(ConfigContext);
 }
-
-module.exports = useConfig;

--- a/packages/react/config/with-config.js
+++ b/packages/react/config/with-config.js
@@ -1,14 +1,14 @@
-const React = require('react');
-const { Consumer } = require('./context');
+import { Component as ReactComponent, createElement } from 'react';
+import { Consumer } from './context';
 
 function withConfig(Component) {
-  return class WithConfig extends React.Component {
+  return class WithConfig extends ReactComponent {
     render() {
-      return React.createElement(Consumer, {}, (config) =>
-        React.createElement(Component, { ...this.props, config })
+      return createElement(Consumer, {}, (config) =>
+        createElement(Component, { ...this.props, config })
       );
     }
   };
 }
 
-module.exports = withConfig;
+export default withConfig;

--- a/packages/react/helmet/mixin.runtime.js
+++ b/packages/react/helmet/mixin.runtime.js
@@ -1,6 +1,6 @@
-const { Mixin } = require('hops-mixin');
-const { createElement } = require('react');
-const { HelmetProvider } = require('react-helmet-async');
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
 
 class ReactHelmetMixin extends Mixin {
   constructor(config, _element, options) {
@@ -19,4 +19,4 @@ class ReactHelmetMixin extends Mixin {
   }
 }
 
-module.exports = ReactHelmetMixin;
+export default ReactHelmetMixin;

--- a/packages/react/import-component/context.js
+++ b/packages/react/import-component/context.js
@@ -1,3 +1,7 @@
-const React = require('react');
+import { createContext } from 'react';
 
-module.exports = React.createContext({});
+const context = createContext({});
+
+export default context;
+export const Consumer = context.Consumer;
+export const Provider = context.Provider;

--- a/packages/react/import-component/index.js
+++ b/packages/react/import-component/index.js
@@ -1,9 +1,10 @@
 /* global __webpack_modules__, __webpack_require__ */
-const { createElement, Component, useContext } = require('react');
-const PropTypes = require('prop-types');
-const ImportComponentContext = require('./context');
+import { createElement, Component, useContext } from 'react';
 
-exports.importComponent = (
+import PropTypes from 'prop-types';
+import ImportComponentContext from './context';
+
+export const importComponent = (
   { load, moduleId },
   resolve = (module) => module.default
 ) => {

--- a/packages/react/import-component/mixin.runtime.js
+++ b/packages/react/import-component/mixin.runtime.js
@@ -1,6 +1,6 @@
-const { Mixin } = require('hops-mixin');
-const { createElement } = require('react');
-const ImportComponentContext = require('./context');
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import { Provider } from './context';
 
 class ImportComponentMixin extends Mixin {
   bootstrap(_req, res) {
@@ -10,12 +10,8 @@ class ImportComponentMixin extends Mixin {
   }
 
   enhanceElement(element) {
-    return createElement(
-      ImportComponentContext.Provider,
-      { value: this.modules },
-      element
-    );
+    return createElement(Provider, { value: this.modules }, element);
   }
 }
 
-module.exports = ImportComponentMixin;
+export default ImportComponentMixin;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,24 +1,9 @@
-const { render } = require('./render');
-const { Header, Miss, Status } = require('./router');
-const { importComponent } = require('./import-component');
-const ServerDataContext = require('./server-data/context');
-const withServerData = require('./server-data/with-server-data');
-const useServerData = require('./server-data/use-server-data');
-
-const ConfigContext = require('./config/context');
-const withConfig = require('./config/with-config');
-const useConfig = require('./config/use-config');
-
-module.exports = {
-  Header,
-  importComponent,
-  Miss,
-  Status,
-  render,
-  ServerDataContext,
-  withServerData,
-  useServerData,
-  ConfigContext,
-  withConfig,
-  useConfig,
-};
+export { render } from './render';
+export { Header, Miss, Status } from './router';
+export { importComponent } from './import-component';
+export { default as ServerDataContext } from './server-data/context';
+export { default as withServerData } from './server-data/with-server-data';
+export { default as useServerData } from './server-data/use-server-data';
+export { default as ConfigContext } from './config/context';
+export { default as withConfig } from './config/with-config';
+export { default as useConfig } from './config/use-config';

--- a/packages/react/lib/assets.js
+++ b/packages/react/lib/assets.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { extname } = require('path');
+import { extname } from 'path';
 
-module.exports = (stats, modules) => {
+export default (stats, modules) => {
   const { entryFiles, vendorFiles, moduleFileMap } = stats;
   const moduleFiles = modules.reduce(
     (result, module) => [...result, ...moduleFileMap[module]],

--- a/packages/react/lib/fragments.js
+++ b/packages/react/lib/fragments.js
@@ -1,6 +1,6 @@
-const { renderToString } = require('react-dom/server');
+import { renderToString } from 'react-dom/server';
 
-module.exports = (element) => {
+export default (element) => {
   const reactMarkup = renderToString(element);
   return { reactMarkup };
 };

--- a/packages/react/lib/resource-hints.js
+++ b/packages/react/lib/resource-hints.js
@@ -1,4 +1,4 @@
-const { extname } = require('path');
+import { extname } from 'path';
 
 const extnameToType = (extension) => {
   switch (extension) {
@@ -37,7 +37,7 @@ const augment = (rel) => (acc, resource) => {
   return acc;
 };
 
-module.exports = (stats) => {
+export default (stats) => {
   const { preload = [], prefetch = [] } = stats.entrypoints.main.childAssets;
 
   return [

--- a/packages/react/lib/runtime.js
+++ b/packages/react/lib/runtime.js
@@ -1,16 +1,12 @@
-const deprecate = require('depd')('hops-react');
+import deprecateFactory from 'depd';
+const deprecate = deprecateFactory('hops-react');
 
 deprecate(
   '[DEP004] Do not use deep imports to "hops-react" (https://github.com/xing/hops/blob/master/DEPRECATIONS.md#dep004).'
 );
-// TODO: clean-up after implementing this in internal Hops
-const { Status, Miss, Header } = require('../router');
-const { importComponent } = require('../import-component');
-const { render } = require('../render');
 
 // TODO: clean-up after implementing this in internal Hops
-exports.render = render;
-exports.Status = Status;
-exports.Miss = Miss;
-exports.Header = Header;
-exports.importComponent = importComponent;
+export { Status, Miss, Header } from '../router';
+
+export { importComponent } from '../import-component';
+export { render } from '../render';

--- a/packages/react/lib/template.js
+++ b/packages/react/lib/template.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const esc = require('serialize-javascript');
+import esc from 'serialize-javascript';
 
 const printResourceHint = ({ rel, href, htmlAs }) =>
   `<link rel="${rel}" href="${href}" ${htmlAs ? `as="${htmlAs}" ` : ''}/>`;
 
-module.exports = ({
+export default ({
   fragments = {},
   globals = {},
   assets: { css = [], js = [] } = {},

--- a/packages/react/render/index.js
+++ b/packages/react/render/index.js
@@ -1,11 +1,9 @@
-const { isValidElement } = require('react');
-const isPlainObject = require('is-plain-obj');
-const {
-  initialize,
-  internal: { invariant },
-} = require('hops-bootstrap');
+import { isValidElement } from 'react';
+import isPlainObject from 'is-plain-obj';
+import { initialize, internal } from 'hops-bootstrap';
+const { invariant } = internal;
 
-exports.render = (element, options) => (...args) => {
+export const render = (element, options) => (...args) => {
   invariant(
     isValidElement(element),
     'render(): Received invalid React element'

--- a/packages/react/render/mixin.browser.js
+++ b/packages/react/render/mixin.browser.js
@@ -2,12 +2,13 @@
 
 /* eslint-env browser */
 
-const { isValidElement } = require('react');
-const { unmountComponentAtNode, hydrate, render } = require('react-dom');
-const isPlainObject = require('is-plain-obj');
-const { override, async } = require('mixinable');
-const { Mixin } = require('hops-mixin');
-const { internal: bootstrap } = require('hops-bootstrap');
+import { isValidElement } from 'react';
+
+import { unmountComponentAtNode, hydrate, render } from 'react-dom';
+import isPlainObject from 'is-plain-obj';
+import { override, async } from 'mixinable';
+import { Mixin } from 'hops-mixin';
+import { internal as bootstrap } from 'hops-bootstrap';
 
 const { compose, parallel, pipe } = async;
 const { validate, invariant } = bootstrap;
@@ -82,4 +83,4 @@ ReactMixin.strategies = {
   }),
 };
 
-module.exports = ReactMixin;
+export default ReactMixin;

--- a/packages/react/render/mixin.server.js
+++ b/packages/react/render/mixin.server.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const { isValidElement } = require('react');
-const isPlainObject = require('is-plain-obj');
-const { override: overrideSync, async } = require('mixinable');
-const { Mixin } = require('hops-mixin');
-const { internal: bootstrap } = require('hops-bootstrap');
-const renderToFragments = require('../lib/fragments');
-const getAssets = require('../lib/assets');
-const getResourceHints = require('../lib/resource-hints');
-const template = require('../lib/template');
+import { isValidElement } from 'react';
+import isPlainObject from 'is-plain-obj';
+import { override as overrideSync, async } from 'mixinable';
+import { Mixin } from 'hops-mixin';
+import { internal as bootstrap } from 'hops-bootstrap';
+import renderToFragments from '../lib/fragments';
+import getAssets from '../lib/assets';
+import getResourceHints from '../lib/resource-hints';
+import template from '../lib/template';
 
 const { compose, parallel, pipe, override: overrideAsync } = async;
 const { validate, invariant } = bootstrap;
@@ -191,4 +191,4 @@ ReactMixin.strategies = {
   }),
 };
 
-module.exports = ReactMixin;
+export default ReactMixin;

--- a/packages/react/router/index.js
+++ b/packages/react/router/index.js
@@ -1,47 +1,25 @@
-const { withRouter } = require('react-router-dom');
-const PropTypes = require('prop-types');
+import { withRouter } from 'react-router-dom';
 
-const Miss = ({ staticContext }) => {
+export const Miss = withRouter(({ staticContext }) => {
   if (staticContext) {
     staticContext.miss = true;
   }
 
   return null;
-};
+});
 
-Miss.propTypes = {
-  staticContext: PropTypes.object,
-};
-
-exports.Miss = withRouter(Miss);
-
-const Status = ({ staticContext, code }) => {
+export const Status = withRouter(({ staticContext, code }) => {
   if (staticContext) {
     staticContext.status = code;
   }
 
   return null;
-};
+});
 
-Status.propTypes = {
-  staticContext: PropTypes.object,
-  code: PropTypes.number.isRequired,
-};
-
-exports.Status = withRouter(Status);
-
-const Header = ({ staticContext, name = '', value = '' }) => {
+export const Header = withRouter(({ staticContext, name = '', value = '' }) => {
   if (staticContext) {
     staticContext.headers = { ...staticContext.headers, [name]: value };
   }
 
   return null;
-};
-
-Header.propTypes = {
-  staticContext: PropTypes.object,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-};
-
-exports.Header = withRouter(Header);
+});

--- a/packages/react/router/mixin.browser.js
+++ b/packages/react/router/mixin.browser.js
@@ -1,7 +1,7 @@
-const { Mixin } = require('hops-mixin');
-const { createElement } = require('react');
-const { BrowserRouter } = require('react-router-dom');
-const { ensureLeadingSlash, trimTrailingSlash } = require('pathifist');
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { ensureLeadingSlash, trimTrailingSlash } from 'pathifist';
 
 class ReactRouterMixin extends Mixin {
   enhanceElement(element) {
@@ -14,4 +14,4 @@ class ReactRouterMixin extends Mixin {
   }
 }
 
-module.exports = ReactRouterMixin;
+export default ReactRouterMixin;

--- a/packages/react/router/mixin.server.js
+++ b/packages/react/router/mixin.server.js
@@ -1,9 +1,10 @@
 // eslint-disable-next-line node/no-deprecated-api
-const { parse } = require('url');
-const { Mixin } = require('hops-mixin');
-const { createElement } = require('react');
-const { StaticRouter } = require('react-router-dom');
-const { ensureLeadingSlash, trimTrailingSlash } = require('pathifist');
+import { parse } from 'url';
+
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import { StaticRouter } from 'react-router-dom';
+import { ensureLeadingSlash, trimTrailingSlash } from 'pathifist';
 
 class ReactRouterMixin extends Mixin {
   constructor(config, _element, options) {
@@ -29,4 +30,4 @@ class ReactRouterMixin extends Mixin {
   }
 }
 
-module.exports = ReactRouterMixin;
+export default ReactRouterMixin;

--- a/packages/react/server-data/context.js
+++ b/packages/react/server-data/context.js
@@ -1,3 +1,7 @@
-const React = require('react');
+import { createContext } from 'react';
 
-module.exports = React.createContext({});
+const context = createContext({});
+
+export default context;
+export const Consumer = context.Consumer;
+export const Provider = context.Provider;

--- a/packages/react/server-data/mixin.browser.js
+++ b/packages/react/server-data/mixin.browser.js
@@ -1,14 +1,13 @@
 /* eslint-env browser, node */
 
-const React = require('react');
-const {
-  Mixin,
-  strategies: {
-    sync: { callable },
-  },
-} = require('hops-mixin');
+import { createElement } from 'react';
 
-const { Provider } = require('./context');
+import { Mixin, strategies } from 'hops-mixin';
+import { Provider } from './context';
+
+const {
+  sync: { callable },
+} = strategies;
 
 class HopsReactServerDataBrowserMixin extends Mixin {
   getServerData() {
@@ -16,7 +15,7 @@ class HopsReactServerDataBrowserMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       Provider,
       { value: this.getServerData() },
       reactElement
@@ -28,4 +27,4 @@ HopsReactServerDataBrowserMixin.strategies = {
   getServerData: callable,
 };
 
-module.exports = HopsReactServerDataBrowserMixin;
+export default HopsReactServerDataBrowserMixin;

--- a/packages/react/server-data/mixin.server.js
+++ b/packages/react/server-data/mixin.server.js
@@ -1,13 +1,13 @@
 /* eslint-env browser, node */
 
-const React = require('react');
+import { createElement } from 'react';
+
+import { Mixin, strategies } from 'hops-mixin';
+import { Provider } from './context';
+
 const {
-  Mixin,
-  strategies: {
-    sync: { pipe, callable },
-  },
-} = require('hops-mixin');
-const { Provider } = require('./context');
+  sync: { pipe, callable },
+} = strategies;
 
 class HopsReactServerDataServerMixin extends Mixin {
   bootstrap(req, res) {
@@ -32,7 +32,7 @@ class HopsReactServerDataServerMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       Provider,
       { value: this.getServerData() },
       reactElement
@@ -45,4 +45,4 @@ HopsReactServerDataServerMixin.strategies = {
   getServerData: callable,
 };
 
-module.exports = HopsReactServerDataServerMixin;
+export default HopsReactServerDataServerMixin;

--- a/packages/react/server-data/use-server-data.js
+++ b/packages/react/server-data/use-server-data.js
@@ -1,8 +1,8 @@
-const React = require('react');
-const ServerDataContext = require('./context');
+import { useContext } from 'react';
+import ServerDataContext from './context';
 
 function useServerData() {
-  return React.useContext(ServerDataContext);
+  return useContext(ServerDataContext);
 }
 
-module.exports = useServerData;
+export default useServerData;

--- a/packages/react/server-data/with-server-data.js
+++ b/packages/react/server-data/with-server-data.js
@@ -1,14 +1,14 @@
-const React = require('react');
-const { Consumer } = require('./context');
+import { Component as ReactComponent, createElement } from 'react';
+import { Consumer } from './context';
 
 function withServerData(Component) {
-  return class WithServerData extends React.Component {
+  return class WithServerData extends ReactComponent {
     render() {
-      return React.createElement(Consumer, {}, (data) =>
-        React.createElement(Component, { ...this.props, serverData: data })
+      return createElement(Consumer, {}, (data) =>
+        createElement(Component, { ...this.props, serverData: data })
       );
     }
   };
 }
 
-module.exports = withServerData;
+export default withServerData;

--- a/packages/redux/action-creator-dispatcher/mixin.browser.js
+++ b/packages/redux/action-creator-dispatcher/mixin.browser.js
@@ -1,4 +1,4 @@
-const ReduxActionCreatorCommonMixin = require('./mixin.runtime-common');
+import ReduxActionCreatorCommonMixin from './mixin.runtime-common';
 
 class ReduxActionCreatorBrowserMixin extends ReduxActionCreatorCommonMixin {
   constructor(...args) {
@@ -7,4 +7,4 @@ class ReduxActionCreatorBrowserMixin extends ReduxActionCreatorCommonMixin {
   }
 }
 
-module.exports = ReduxActionCreatorBrowserMixin;
+export default ReduxActionCreatorBrowserMixin;

--- a/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
+++ b/packages/redux/action-creator-dispatcher/mixin.runtime-common.js
@@ -1,10 +1,9 @@
-const React = require('react');
-const PropTypes = require('prop-types');
-const { matchPath, withRouter } = require('react-router-dom');
+import { Component, Children, createElement } from 'react';
+import PropTypes from 'prop-types';
+import { matchPath, withRouter } from 'react-router-dom';
+import { Mixin } from 'hops-mixin';
 
-const { Mixin } = require('hops-mixin');
-
-class Dispatcher extends React.Component {
+class Dispatcher extends Component {
   constructor(props) {
     super(props);
 
@@ -47,9 +46,7 @@ class Dispatcher extends React.Component {
   }
 
   render() {
-    return this.props.children
-      ? React.Children.only(this.props.children)
-      : null;
+    return this.props.children ? Children.only(this.props.children) : null;
   }
 }
 
@@ -92,7 +89,7 @@ class ReduxActionCreatorRuntimeMixin extends Mixin {
 
   enhanceElement(reactElement) {
     const { alwaysDispatchActionsOnClient } = this.options;
-    return React.createElement(
+    return createElement(
       RoutedDispatcher,
       {
         dispatchAll: this.dispatchAll.bind(this),
@@ -104,4 +101,4 @@ class ReduxActionCreatorRuntimeMixin extends Mixin {
   }
 }
 
-module.exports = ReduxActionCreatorRuntimeMixin;
+export default ReduxActionCreatorRuntimeMixin;

--- a/packages/redux/action-creator-dispatcher/mixin.server.js
+++ b/packages/redux/action-creator-dispatcher/mixin.server.js
@@ -1,11 +1,10 @@
-const { createLocation } = require('history');
-const {
-  strategies: {
-    sync: { sequence },
-  },
-} = require('hops-mixin');
+import { createLocation } from 'history';
+import { strategies } from 'hops-mixin';
+import ReduxActionCreatorCommonMixin from './mixin.runtime-common';
 
-const ReduxActionCreatorCommonMixin = require('./mixin.runtime-common');
+const {
+  sync: { sequence },
+} = strategies;
 
 class ReduxActionCreatorServerMixin extends ReduxActionCreatorCommonMixin {
   constructor(...args) {
@@ -44,4 +43,4 @@ ReduxActionCreatorServerMixin.strategies = {
   canPrefetchOnServer: sequence,
 };
 
-module.exports = ReduxActionCreatorServerMixin;
+export default ReduxActionCreatorServerMixin;

--- a/packages/redux/index.js
+++ b/packages/redux/index.js
@@ -1,1 +1,1 @@
-module.exports = null;
+export default null;

--- a/packages/redux/mixin.browser.js
+++ b/packages/redux/mixin.browser.js
@@ -1,5 +1,5 @@
-const { compose, combineReducers, createStore } = require('redux');
-const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
+import { compose, combineReducers, createStore } from 'redux';
+import ReduxRuntimeCommonMixin from './mixin.runtime-common';
 
 const ReduxCompose = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
@@ -32,4 +32,4 @@ class ReduxMixin extends ReduxRuntimeCommonMixin {
   }
 }
 
-module.exports = ReduxMixin;
+export default ReduxMixin;

--- a/packages/redux/mixin.runtime-common.js
+++ b/packages/redux/mixin.runtime-common.js
@@ -1,13 +1,12 @@
-const React = require('react');
-const { Provider } = require('react-redux');
-const { applyMiddleware } = require('redux');
-const ReduxThunkMiddleware = require('redux-thunk').default;
+import { createElement } from 'react';
+import { Provider } from 'react-redux';
+import { applyMiddleware } from 'redux';
+import ReduxThunkMiddleware from 'redux-thunk';
+import { Mixin, strategies } from 'hops-mixin';
+
 const {
-  Mixin,
-  strategies: {
-    sync: { override },
-  },
-} = require('hops-mixin');
+  sync: { override },
+} = strategies;
 
 class ReduxRuntimeCommonMixin extends Mixin {
   constructor(config, element, { redux: options = {} } = {}) {
@@ -32,7 +31,7 @@ class ReduxRuntimeCommonMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       Provider,
       { store: this.getReduxStore() },
       reactElement
@@ -45,4 +44,4 @@ ReduxRuntimeCommonMixin.strategies = {
   getReduxStore: override,
 };
 
-module.exports = ReduxRuntimeCommonMixin;
+export default ReduxRuntimeCommonMixin;

--- a/packages/redux/mixin.server.js
+++ b/packages/redux/mixin.server.js
@@ -1,5 +1,5 @@
-const { createStore, combineReducers, compose } = require('redux');
-const ReduxRuntimeCommonMixin = require('./mixin.runtime-common');
+import { createStore, combineReducers, compose } from 'redux';
+import ReduxRuntimeCommonMixin from './mixin.runtime-common';
 
 class ReduxMixin extends ReduxRuntimeCommonMixin {
   createStore() {
@@ -34,4 +34,4 @@ class ReduxMixin extends ReduxRuntimeCommonMixin {
   }
 }
 
-module.exports = ReduxMixin;
+export default ReduxMixin;

--- a/packages/spec/integration/graphql/mixin.runtime.js
+++ b/packages/spec/integration/graphql/mixin.runtime.js
@@ -1,6 +1,6 @@
-const { Mixin } = require('hops-mixin');
-const fetch = require('cross-fetch');
-const { HttpLink } = require('apollo-link-http');
+import { Mixin } from 'hops-mixin';
+import fetch from 'cross-fetch';
+import { HttpLink } from 'apollo-link-http';
 
 const customFetch = (serverAddress) => (uri, options) => {
   const urlSuffix =
@@ -12,7 +12,7 @@ const customFetch = (serverAddress) => (uri, options) => {
   return fetch(newUri, options);
 };
 
-module.exports = class GraphQlMixin extends Mixin {
+export default class GraphQlMixin extends Mixin {
   bootstrap(_, res) {
     this.serverAddress = res ? res.locals.serverAddress : '';
   }
@@ -23,4 +23,4 @@ module.exports = class GraphQlMixin extends Mixin {
       fetch: customFetch(this.serverAddress),
     });
   }
-};
+}

--- a/packages/spec/integration/react/mixin.server.js
+++ b/packages/spec/integration/react/mixin.server.js
@@ -1,4 +1,4 @@
-const { Mixin } = require('hops-mixin');
+import { Mixin } from 'hops-mixin';
 
 class ServerDataMixin extends Mixin {
   enhanceServerData(data, req) {
@@ -6,4 +6,4 @@ class ServerDataMixin extends Mixin {
   }
 }
 
-module.exports = ServerDataMixin;
+export default ServerDataMixin;

--- a/packages/styled-components/mixin.browser.js
+++ b/packages/styled-components/mixin.browser.js
@@ -1,6 +1,6 @@
-const { Mixin } = require('hops-mixin');
-const React = require('react');
-const { ThemeProvider } = require('styled-components');
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import { ThemeProvider } from 'styled-components';
 
 class StyledComponentsMixin extends Mixin {
   constructor(config, element, { styled: options = {} } = {}) {
@@ -9,12 +9,8 @@ class StyledComponentsMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
-      ThemeProvider,
-      { theme: this.theme },
-      reactElement
-    );
+    return createElement(ThemeProvider, { theme: this.theme }, reactElement);
   }
 }
 
-module.exports = StyledComponentsMixin;
+export default StyledComponentsMixin;

--- a/packages/styled-components/mixin.server.js
+++ b/packages/styled-components/mixin.server.js
@@ -1,10 +1,10 @@
-const { Mixin } = require('hops-mixin');
-const React = require('react');
-const {
+import { Mixin } from 'hops-mixin';
+import { createElement } from 'react';
+import {
   ServerStyleSheet,
   StyleSheetManager,
   ThemeProvider,
-} = require('styled-components');
+} from 'styled-components';
 
 class StyledComponentsMixin extends Mixin {
   constructor(config, element, { styled: options = {} } = {}) {
@@ -14,10 +14,10 @@ class StyledComponentsMixin extends Mixin {
   }
 
   enhanceElement(reactElement) {
-    return React.createElement(
+    return createElement(
       StyleSheetManager,
       { sheet: this.sheet.instance },
-      React.createElement(ThemeProvider, { theme: this.theme }, reactElement)
+      createElement(ThemeProvider, { theme: this.theme }, reactElement)
     );
   }
 
@@ -32,4 +32,4 @@ class StyledComponentsMixin extends Mixin {
   }
 }
 
-module.exports = StyledComponentsMixin;
+export default StyledComponentsMixin;

--- a/packages/template-graphql/src/home/index.js
+++ b/packages/template-graphql/src/home/index.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { graphql } from 'react-apollo';
+import { useQuery } from '@apollo/react-hooks';
 import { Helmet } from 'react-helmet-async';
 import query from './jobs.gql';
 import styles from './styles.css';
 
-const withJobs = graphql(query);
-
-export const Home = ({ data: { loading, error, jobSearchByQuery } }) => {
+export const Home = ({ data: { loading, jobSearchByQuery } }) => {
   return (
     <div>
       <Helmet>
@@ -30,4 +28,7 @@ export const Home = ({ data: { loading, error, jobSearchByQuery } }) => {
   );
 };
 
-export default withJobs(Home);
+export default () => {
+  const data = useQuery(query);
+  return <Home data={data} />;
+};


### PR DESCRIPTION
With this commit we rewrite all code that is exclusively being used for
runtime code (i.e. code that is bundled through webpack), to the new ESM
syntax. This enables better tree shaking support in modern bundlers.

With this change we can reduce the bundle sizes of our templates by:
- hops-template-react: ~15kb
- hops-template-graphql: ~40kb

I assume in bigger applications the difference might be larger.

BREAKING CHANGE: Some parts of Hops are rewritten to ES-Modules
This could potentially be a breaking change for some consumers when
using deep-imports.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>