### PR TITLE
fix: remove mixin-order escape hatch

### DIFF
--- a/packages/bootstrap/lib/__tests__/utils.test.js
+++ b/packages/bootstrap/lib/__tests__/utils.test.js
@@ -1,13 +1,11 @@
 /* eslint-env node, jest */
 
-const { merge: mergeFactory } = require('../utils');
+const { merge } = require('../utils');
 
 describe('merge', () => {
   it('should merge two objects', () => {
     const a = { a: 1 };
     const b = { b: 2 };
-
-    const merge = mergeFactory(false);
 
     const result = merge(a, b);
 
@@ -26,8 +24,6 @@ describe('merge', () => {
     const c = { a: { c: 3 } };
     const d = { b: { b: 4 } };
 
-    const merge = mergeFactory(false);
-
     const result = merge(a, b, c, d);
 
     expect(result).toEqual({
@@ -45,8 +41,6 @@ describe('merge', () => {
     const a = { mixins: ['a'], other: [1] };
     const b = { mixins: ['b'], other: [2] };
 
-    const merge = mergeFactory(false);
-
     const result = merge(a, b);
 
     expect(result).toEqual({
@@ -62,8 +56,6 @@ describe('merge', () => {
     const a = { mixins: ['a'] };
     const b = { mixins: ['a'] };
 
-    const merge = mergeFactory(false);
-
     const result = merge(a, b);
 
     expect(result).toEqual({
@@ -78,28 +70,10 @@ describe('merge', () => {
     const a = { mixins: ['a', 'b'] };
     const b = { mixins: ['a', 'c'] };
 
-    const merge = mergeFactory(false);
-
     const result = merge(a, b);
 
     expect(result).toEqual({
       mixins: ['b', 'a', 'c'],
-    });
-
-    expect(a).toEqual({ mixins: ['a', 'b'] });
-    expect(b).toEqual({ mixins: ['a', 'c'] });
-  });
-
-  it('should de-duplicate mixins (legacy sort order)', () => {
-    const a = { mixins: ['a', 'b'] };
-    const b = { mixins: ['a', 'c'] };
-
-    const merge = mergeFactory(true);
-
-    const result = merge(a, b);
-
-    expect(result).toEqual({
-      mixins: ['a', 'b', 'c'],
     });
 
     expect(a).toEqual({ mixins: ['a', 'b'] });

--- a/packages/bootstrap/lib/config.js
+++ b/packages/bootstrap/lib/config.js
@@ -10,12 +10,7 @@ const debug = require('debug')('hops:config');
 const { loadConfig } = require('./loader');
 const { resolveMixins } = require('./resolver');
 const { validate } = require('./validator');
-const {
-  environmentalize,
-  placeholdify,
-  merge: mergeFactory,
-  getMixinSortOrder,
-} = require('./utils');
+const { environmentalize, placeholdify, merge } = require('./utils');
 
 exports.getConfig = (overrides = {}) => {
   const pkgFile = findUp('package.json');
@@ -44,7 +39,6 @@ exports.getConfig = (overrides = {}) => {
   };
   const settings = loadConfig(pkgData, rootDir);
 
-  const merge = mergeFactory(getMixinSortOrder(settings, overrides));
   const raw = merge(defaults, settings, overrides);
   const { mixins, mixinTypes, configSchema, ...clean } = raw;
   const processed = environmentalize(placeholdify(clean));

--- a/packages/bootstrap/lib/loader.js
+++ b/packages/bootstrap/lib/loader.js
@@ -5,7 +5,7 @@ const { dirname, join } = require('path');
 const { cosmiconfigSync: cosmiconfig } = require('cosmiconfig');
 const { compatibleMessage } = require('check-error');
 
-const { merge: mergeFactory, getMixinSortOrder } = require('./utils');
+const { merge } = require('./utils');
 const {
   resolve,
   resolvePreset,
@@ -88,7 +88,6 @@ exports.loadConfig = (pkgData, rootDir) => {
   settings.presets = settings.presets.filter(
     (preset) => !(settings.ignoredPresets || []).includes(preset)
   );
-  const merge = mergeFactory(getMixinSortOrder(settings));
   const presets = loader.loadPresets(rootDir, merge, settings.presets);
 
   // eslint-disable-next-line no-unused-vars

--- a/packages/bootstrap/lib/utils.js
+++ b/packages/bootstrap/lib/utils.js
@@ -56,26 +56,10 @@ function merge(target, ...args) {
   }, target);
 }
 
-exports.getMixinSortOrder = (...args) =>
-  args.reduce((enableLegacyMixinSortOrder, config) => {
-    if ('enableLegacyMixinSortOrder' in config) {
-      return config.enableLegacyMixinSortOrder;
-    }
-    return enableLegacyMixinSortOrder;
-  }, false);
-
-exports.merge = (enableLegacyMixinSortOrder = false) => (...args) => {
+exports.merge = (...args) => {
   return merge({}, ...args, (objValue, srcValue, key) => {
     if (Array.isArray(objValue)) {
       if ('mixins' === key) {
-        // #542: remove this in untool v3 if no potential side-effects have been
-        // discovered
-        if (enableLegacyMixinSortOrder) {
-          return [...objValue, ...srcValue].filter(
-            (curr, index, self) => self.indexOf(curr) === index
-          );
-        }
-
         return [
           ...objValue.filter((curr) => !srcValue.includes(curr)),
           ...srcValue,

--- a/packages/webpack/lib/utils/loader.js
+++ b/packages/webpack/lib/utils/loader.js
@@ -38,7 +38,7 @@ exports.getConfig = (overrides = {}) => {
   if (!configs[key]) {
     const utils = require('hops-bootstrap/lib/utils');
     const { environmentalize, placeholdify, merge } = utils;
-    const raw = merge()(${getConfig(type, config, rootDir)}, overrides);
+    const raw = merge(${getConfig(type, config, rootDir)}, overrides);
     configs[key] = environmentalize(placeholdify(raw), ${escapeJS(
       config.browserWhitelist
     )});


### PR DESCRIPTION
There's no way anymore to make Hops resolve mixins in the opposite order
than the configs. Mixins and configs will now always be resolved in the same
order and thus be consistent in the way they overwrite previous presets.

**BREAKING CHANGE**: the config option `enableLegacyMixinSortOrder` has been removed.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
