### PR TITLE
Require strictly aligned Hops packages

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -259,6 +259,14 @@ Starts a production ready Express.js server.
 In order to deploy your application, you need to make sure to also include the `./node_modules/.cache/hops-webpack` directory in your deployment, because that is where the build output of the server middleware will be stored.\
 You can also change that location by specifying a different [`serverDir`](#default-settings).
 
+### Hops version alignment
+
+Hops requires all its packages to be de-duplicated, which means their versions need to be aligned. Imagine you're building a Hops app with Apollo. So you install the following two Hops packages: `hops` and `hops-react-apollo`. This won't lead to any issues, because the latest version of these packages in the registry will be the same.
+
+Now imagine your Hops app matures and you're more or less regularly updating the Hops packages. If thereby the versions of the two installed Hops packages accidentally start to diverge — e.g. `hops@x.1.1` and `hops-react-apollo@x.1.3` — you'll get duplicated Hops packages in your `node_modules`-folder.
+
+Hops will then start to error and tell which packages need to be de-duplicated. You'll then have to resolve the duplication(s) before you're able to proceed.
+
 ## Configuration
 
 ### Settings

--- a/packages/info/doctor/mixin.core.js
+++ b/packages/info/doctor/mixin.core.js
@@ -34,9 +34,14 @@ class DoctorMixin extends Mixin {
     );
   }
 
-  diagnose({ validateConfig, detectDuplicatePackages }) {
+  diagnose({ validateConfig, detectDuplicatePackages, pushError }) {
     validateConfig();
-    detectDuplicatePackages('hops-*');
+    if (detectDuplicatePackages('hops-*')) {
+      pushError(
+        'hops-duplicates',
+        `Please align the versions of the Hops's packages before proceeding.`
+      );
+    }
   }
 
   bootstrap() {

--- a/packages/info/doctor/validators/duplicates.js
+++ b/packages/info/doctor/validators/duplicates.js
@@ -15,6 +15,7 @@ module.exports = class DetectDuplicatePackagesMixin {
         (name) => `package "${name}" may not be installed more than once`
       )
     );
+    return duplicates.length > 0;
   }
 
   logResults(logger) {


### PR DESCRIPTION
**BREAKING CHANGE**: Hops now requires strictly de-duplicated packages

⚠️ We'll have to pin the versions on the soon to be created `v14.x`-branch and then do the release. :warning:

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
