### PR TITLE
fix(info): remove deprecated handling of warning messages

### DIFF
--- a/packages/info/doctor/mixin.core.js
+++ b/packages/info/doctor/mixin.core.js
@@ -1,6 +1,5 @@
 const { async } = require('mixinable');
 const { Mixin } = require('hops-mixin');
-const deprecate = require('depd')('hops-doctor');
 const { internal: bootstrap } = require('hops-bootstrap');
 const { createDoctor } = require('.');
 
@@ -43,18 +42,13 @@ class DoctorMixin extends Mixin {
     const { doctor } = this;
 
     return Promise.resolve().then(() => {
-      doctor.getMode().then((mode) =>
-        this.diagnose(doctor, mode).then((results) => {
-          const messages = results.filter(Boolean);
-          if (messages.length) {
-            deprecate(
-              'Returning messages from the diagnose-hook is deprecated. Please use "pushWarning" and "pushError" instead.'
-            );
-          }
-          doctor.collectResults(...[].concat(...messages));
-          doctor.logResults(this.getLogger());
-        })
-      );
+      doctor
+        .getMode()
+        .then((mode) =>
+          this.diagnose(doctor, mode).then(() =>
+            doctor.logResults(this.getLogger())
+          )
+        );
     });
   }
 

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -13,7 +13,6 @@
   "homepage": "https://github.com/xing/hops#readme",
   "dependencies": {
     "chalk": "^4.0.0",
-    "depd": "^2.0.0",
     "duplitect": "^3.0.0",
     "enhanced-resolve": "^5.0.0",
     "eprom": "^1.0.0",

--- a/packages/lambda/mixin.core.js
+++ b/packages/lambda/mixin.core.js
@@ -88,8 +88,7 @@ class LambdaMixin extends Mixin {
     this.options = { ...this.options, ...argv };
   }
 
-  diagnose() {
-    const warnings = [];
+  diagnose({ pushWarning }) {
     const { version: targetNodeVersion } = semver.coerce(
       !this.config.node || this.config.node === 'current'
         ? process.version
@@ -97,7 +96,7 @@ class LambdaMixin extends Mixin {
     );
 
     if (!semver.intersects(targetNodeVersion, nodeVersionRange)) {
-      warnings.push(
+      pushWarning(
         [
           `AWS Lambda only supports the Node.js version range "${nodeVersionRange}".`,
           'Please specify or use a Node.js version intersecting this range',
@@ -113,18 +112,16 @@ class LambdaMixin extends Mixin {
         trimSlashes(this.config.assetPath).indexOf(this.awsConfig.stageName) !==
           0)
     ) {
-      warnings.push(
+      pushWarning(
         `When no custom domain is configured, the stageName (${this.awsConfig.stageName}) should be the first path segment in basePath (${this.awsConfig.basePath}) and assetPath (${this.config.assetPath}).`
       );
     }
 
     if (this.awsConfig.domainName && !this.awsConfig.certificateArn) {
-      warnings.push(
+      pushWarning(
         'Setting a custom domain name also requires to specify the ACM certificate ARN.'
       );
     }
-
-    return warnings;
   }
 }
 

--- a/packages/react-apollo/mixin.core.js
+++ b/packages/react-apollo/mixin.core.js
@@ -65,13 +65,13 @@ class GraphQLMixin extends Mixin {
     this.options = { ...this.options, ...argv };
   }
 
-  diagnose({ detectDuplicatePackages }) {
+  diagnose({ detectDuplicatePackages, pushWarning }) {
     detectDuplicatePackages('graphql');
     if (!existsSync(this.config.fragmentsFile)) {
-      return [
-        `Could not find a graphql introspection query result at "${this.config.fragmentsFile}".`,
-        'You might need to execute "hops graphql introspect"',
-      ];
+      pushWarning(
+        `Could not find a graphql introspection query result at "${this.config.fragmentsFile}".`
+      );
+      pushWarning('You might need to execute "hops graphql introspect"');
     }
   }
 }


### PR DESCRIPTION
As of now, `hops-info` only handles warnings and errors, that have been passed
into the respective `pushWarning` or `pushError` functions, which again come as
arguments into the `diagnose`-hook.

Strings — or arrays of strings —, returned from the `diagnose`-hook,
aren't handled anymore.

**BREAKING CHANGE**: hops-info does not handle warnings returned from the `diagnose`-hook anymore.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
