### PR TITLE
chore(spec): use version range for styled-components types in tests

### DIFF
--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -31,7 +31,7 @@
     "@graphql-tools/schema": "^7.0.0",
     "@graphql-tools/stitch": "^7.0.4",
     "@testing-library/react": "^11.0.0",
-    "@types/styled-components": "5.1.8",
+    "@types/styled-components": "^5.1.8",
     "create-hops-app": "^14.0.0-nightly.9",
     "cross-fetch": "^3.0.4",
     "jest-environment-hops": "^14.0.0-nightly.9",


### PR DESCRIPTION
This should close #1660 and #1661

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
