### PR TITLE
fix(postcss): use module type "commonjs"

### DIFF
--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -79,37 +79,7 @@ For more information on that topic, please have a look at [the documentation of 
 
 #### Preset Options
 
-| Name | Type | Default | Required | Description |
-| --- | --- | --- | --- | --- |
-| `postcss.namedExport` | `Boolean` | `false` | _no_ | Whether CSS Modules do a named exports of class names rather than a default export of the class name object. |
-
-##### `postcss.namedExport`
-
-This option enables you to opt into CSS Modules exporting named exports, instead of doing a default export of the object, that holds all the class names.
-
-To enable it, set the following option in your Hops config.
-
-```json
-"hops": {
-  "postcss": {
-    "namedExport": true
-  }
-}
-```
-
-Then you can do named imports from your your CSS Modules.
-
-```js
-import { btn, btnLabel } from './module.css';
-
-const Btn = ({ children }) => (
-  <button className={btn}>
-    <span className={btnLabel}>{children}</span>
-  </button>
-);
-```
-
-Beware, that this feature requires all class names to be converted to camel-case. This can lead to issues, when e.g. a CSS library leverages the BEM-syntax and two actually different class names yield the same value after being camel-cased. If this happens, the Hops build fails.
+This preset has no preset configuration options.
 
 #### Render Options
 

--- a/packages/postcss/preset.js
+++ b/packages/postcss/preset.js
@@ -1,17 +1,3 @@
 module.exports = {
   mixins: [__dirname],
-  postcss: {
-    namedExport: false,
-  },
-  configSchema: {
-    postcss: {
-      type: 'object',
-      properties: {
-        namedExport: {
-          type: 'boolean',
-        },
-      },
-      additionalProperties: false,
-    },
-  },
 };

--- a/packages/spec/integration/postcss/index.js
+++ b/packages/spec/integration/postcss/index.js
@@ -1,7 +1,13 @@
 import { render } from 'hops';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
+
+// Verify both namespace & default imports work fine
+// while we're still using module type CommonJS
+// for CSS Modules.
 import * as styles from './styles.css';
+import otherStyles from './other-styles.css';
+
 /* eslint-disable import/no-unresolved */
 import './global.css?global';
 import 'animate.css/animate.min.css?global';
@@ -12,7 +18,9 @@ export default render(
     <Helmet>
       <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     </Helmet>
-    <h1 className={`${styles.headline} fancy-headline animate__animated`}>
+    <h1
+      className={`${styles.headline} ${otherStyles.strike} fancy-headline animate__animated`}
+    >
       hello
     </h1>
   </>

--- a/packages/spec/integration/postcss/other-styles.css
+++ b/packages/spec/integration/postcss/other-styles.css
@@ -1,0 +1,3 @@
+.strike {
+  text-decoration: line-through;
+}


### PR DESCRIPTION
This reverts the breaking change introduced with [`5f4ff80`](5f4ff80#diff-f6674fc8d197d1faca718594bf4931825ac8c5b1ba7aa51d523d3e0fd0a50633).

It also renders the previously introduced preset option `namedExport`
obsolete.

Switching to ESM has been a bold move and it turned out, that it not
only has the potential to break existing Hops apps through their own
CSS. But also through third-party packages, that themselves import CSS
Modules in their code. In unfortunate cases they may be using
namespace imports, while they're actually not able to be switched to
named exports, because of reserved keywords in their CSS classnames or
duplicate class names after camelCasification.

In those situations, the third-party package would not be usable.

However, by sticking with CommonJS as a module type for CSS Modules, the
import syntax is not that important. Both ways — default imports and
namespace imports — work fine in conjunction with the Webpack-based
bundling.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
