### PR TITLE
fix(webpack): disable native Webpack stats in develop-mode

### DIFF
--- a/packages/webpack/mixins/develop/mixin.core.js
+++ b/packages/webpack/mixins/develop/mixin.core.js
@@ -10,7 +10,7 @@ class WebpackDevelopMixin extends Mixin {
       const compiler = createCompiler(webpackDevelopConfig);
 
       middlewares.initial.push(
-        createWebpackDevMiddleware(compiler),
+        createWebpackDevMiddleware(compiler, { stats: false }),
         createWebpackHotMiddleware(compiler, { log: false })
       );
     }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -44,7 +44,7 @@
     "terser-webpack-plugin": "^4.0.0",
     "url-loader": "^4.0.0",
     "webpack": "^4.41.0",
-    "webpack-dev-middleware": "^4.0.2",
+    "webpack-dev-middleware": "^4.1.0",
     "webpack-hot-middleware": "^2.25.0",
     "webpack-sources": "^2.0.0",
     "zen-observable": "^0.8.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13852,7 +13852,7 @@ webpack-bundle-analyzer@^4.1.0:
     sirv "^1.0.7"
     ws "^7.3.1"
 
-webpack-dev-middleware@^4.0.2:
+webpack-dev-middleware@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-4.1.0.tgz#f0c1f12ff4cd855b3b5eec89ee0f69bcc5336364"
   integrity sha512-mpa/FY+DiBu5+r5JUIyTCYWRfkWgyA3/OOE9lwfzV9S70A4vJYLsVRKj5rMFEsezBroy2FmPyQ8oBRVW8QmK1A==


### PR DESCRIPTION
picks #1513, at least the interesting part.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
