### PR TITLE
fix: revert deprecation of hops-config import

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,8 +1,8 @@
 # Deprecated APIs
 
-### DEP0001
+### ~~DEP0001~~
 
-`hops-config` is deprecated. Please use `ConfigContext` or the [`withConfig()`](https://github.com/xing/hops#withconfigcomponent) HOC from `hops` instead.
+~~`hops-config` is deprecated. Please use `ConfigContext` or the [`withConfig()`](https://github.com/xing/hops#withconfigcomponent) HOC from `hops` instead.~~
 
 ### DEP0003
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -4,8 +4,6 @@
 
 **Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
 
-This is a package that exposes your applications configuration and is mostly here for legacy reasons. It has thus been [deprecated](../../DEPRECATIONS.md#dep0001) as of version 12 of Hops and will be removed with the next major release.
-
 Please use [`withConfig`](../../DOCUMENTATION.md#withconfigcomponent) or [`useConfig`](../../DOCUMENTATION.md#useconfig-config) to access the configuration inside your application's React components.
 
 Inside [mixins](../bootstrap#mixins) you can access the config through `this.config`.

--- a/packages/config/browser.js
+++ b/packages/config/browser.js
@@ -1,9 +1,3 @@
-import deprecateFactory from 'depd';
 import { internal } from 'hops-bootstrap';
-const deprecate = deprecateFactory('hops-config');
-
-deprecate(
-  '[DEP0001] hops-config is deprecated. Please use ConfigContext or the withConfig() HOC from hops instead.'
-);
 
 export default internal.getConfig();


### PR DESCRIPTION
As discussed, we revert the deprecation for now until we have a better
alternative.
In the meantime we'll try to improve the performance of loading the
config via import/require.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
