### PR TITLE
feat: add web vitals support

### DIFF
--- a/packages/info/README.md
+++ b/packages/info/README.md
@@ -29,11 +29,36 @@ Additionally, you can pass `--color`/`--no-color` flags to manually enable or di
 $ hops start -v --no-color
 ```
 
-## API
+### Configuration
 
-`hops-info` exposes a couple of utility mixin hooks other mixins can implement.
+#### Render Options
 
-### `getLogger()` ([callable](https://github.com/untool/mixinable/blob/master/README.md#defineoverride))
+This preset has only a single runtime option which can be passed to the `render()` options inside the `webVitals` key (see example above).
+
+| Name | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `webVitals.handler` | `ReportHandler` | `undefined` | _no_ | A callback to report web vitals metrics [API](https://www.npmjs.com/package/web-vitals#api) |
+
+##### `handler`
+
+By default this preset adds no report handler for web vitals metrics. You can add your own handler through this option to report the core web vitals to your analytics provider.
+
+Take a look at these resources for implementation details:
+
+- https://web.dev/vitals/
+- https://www.npmjs.com/package/web-vitals
+
+```javascript
+export default render(<MyApp />, {
+  webVitals: { handler: console.log },
+});
+```
+
+### Mixin Hooks API
+
+**Caution**: Please be aware that the mixin hooks are not part of the SemVer API contract. This means that hook methods and signatures can change even in minor releases. Therefore it's up to you to make sure that all hooks that you are using in your own mixins still adhere to the new implementation after an upgrade of a Hops packages.
+
+### `getLogger()` ([callable](https://github.com/untool/mixinable/blob/master/README.md#defineoverride)) **core/server**
 
 This utility hook defined by `hops-info` provides other mixins with a fully configured logger instance. This logger has three standard log methods (`info`, `warning` and `error`) that correspond to the lower three log levels described above. Additionally, it supports arbitrary log methods (e.g. `request`, `hint`, `foo`)
 
@@ -54,7 +79,13 @@ module.exports = class FooMixin extends Mixin {
 };
 ```
 
-### `diagnose(doctor, mode)` ([parallel](https://github.com/untool/mixinable/blob/master/README.md#defineparallel))
+#### `getWebVitalsHandler(): ReportHandler` ([override](https://github.com/untool/mixinable/blob/master/README.md#defineoverride)) **browser**
+
+Hook to return a custom [ReportHandler](https://www.npmjs.com/package/web-vitals#api).
+
+Beware that `handler` passed as render option takes precedence.
+
+### `diagnose(doctor, mode)` ([parallel](https://github.com/untool/mixinable/blob/master/README.md#defineparallel)) **core**
 
 By implementing this method, your core mixin can perform pre-flight checks during application startup/build and create warnings & errors. If you need to do something asynchronous at this point, just return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -22,7 +22,8 @@
     "escape-string-regexp": "^4.0.0",
     "hops-bootstrap": "15.0.0-nightly.0",
     "hops-mixin": "15.0.0-nightly.0",
-    "mixinable": "^5.0.1"
+    "mixinable": "^5.0.1",
+    "web-vitals": "^1.1.1"
   },
   "engines": {
     "node": "12 || 14 || 15"

--- a/packages/info/preset.js
+++ b/packages/info/preset.js
@@ -1,5 +1,9 @@
 const { join } = require('path');
 
 module.exports = {
-  mixins: [join(__dirname, 'logger'), join(__dirname, 'doctor')],
+  mixins: [
+    join(__dirname, 'logger'),
+    join(__dirname, 'doctor'),
+    join(__dirname, 'web-vitals'),
+  ],
 };

--- a/packages/info/web-vitals/mixin.browser.js
+++ b/packages/info/web-vitals/mixin.browser.js
@@ -1,0 +1,34 @@
+import { Mixin, strategies } from 'hops-mixin';
+import { getCLS, getFID, getLCP } from 'web-vitals';
+
+const {
+  sync: { override },
+} = strategies;
+
+class WebVitalsMixin extends Mixin {
+  constructor(config, element, { webVitals: options = {} } = {}) {
+    super(config, element);
+
+    this.options = options;
+  }
+
+  bootstrap() {
+    const handler = this.getWebVitalsHandler();
+
+    if (typeof handler === 'function') {
+      getCLS(handler);
+      getFID(handler);
+      getLCP(handler);
+    }
+  }
+
+  getWebVitalsHandler() {
+    return this.options.handler;
+  }
+}
+
+WebVitalsMixin.strategies = {
+  getWebVitalsHandler: override,
+};
+
+export default WebVitalsMixin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14204,6 +14204,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+web-vitals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.1.tgz#2df535e3355fb7fbe34787b44b736e270e539377"
+  integrity sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"


### PR DESCRIPTION
This adds a new render option `webVitals` to which a `ReportHandler`
can be passed via `webVitals.handler`.
The handler will be called for each of the three core web vitals:
- CLS (cumulative layout shift)
- FID (first input delay)
- LCP (largest contentful paint)

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
