### PR TITLE
fix: set correct "main" fields for templates

### DIFF
--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hops-template-graphql",
   "version": "15.0.0-nightly.0",
-  "main": "src/app.js",
+  "main": "src/app.jsx",
   "license": "MIT",
   "hops": {
     "graphqlUri": "https://www.xing.com/xing-one/api"

--- a/packages/template-react/package.json
+++ b/packages/template-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hops-template-react",
   "version": "15.0.0-nightly.0",
-  "main": "src/app.js",
+  "main": "src/app.jsx",
   "license": "MIT",
   "scripts": {
     "start": "hops start",

--- a/packages/template-redux/package.json
+++ b/packages/template-redux/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hops-template-redux",
   "version": "15.0.0-nightly.0",
-  "main": "src/app.js",
+  "main": "src/app.jsx",
   "license": "MIT",
   "scripts": {
     "start": "hops start",


### PR DESCRIPTION
A recent change renamed the entry files for the templates from `.js` to
`.jsx` which caused the entry files to not be found anymore.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
