### PR TITLE
fix(bootstrap): adapt validator to breaking changes in ajv

### DIFF
--- a/packages/bootstrap/lib/validator.js
+++ b/packages/bootstrap/lib/validator.js
@@ -84,7 +84,7 @@ exports.validate = (config, properties) => {
     return [];
   } else {
     return ajv.errors.map(
-      ({ dataPath, message }) => `config${dataPath} ${message}`
+      ({ instancePath, message }) => `config${instancePath} ${message}`
     );
   }
 };


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>