### PR TITLE
fix: add missing CLI-flags to develop command

### DIFF
--- a/packages/react/fast-refresh/mixin.core.js
+++ b/packages/react/fast-refresh/mixin.core.js
@@ -29,7 +29,7 @@ class ReactFastRefreshMixin extends Mixin {
   }
 
   configureCommand(definition) {
-    if (definition.command === 'start') {
+    if (['develop', 'start'].includes(definition.command)) {
       definition.builder.fastRefresh = {
         default: false,
         describe:

--- a/packages/webpack/mixins/develop/mixin.core.js
+++ b/packages/webpack/mixins/develop/mixin.core.js
@@ -22,7 +22,19 @@ class WebpackDevelopMixin extends Mixin {
       this.configureCommand({
         command: 'develop',
         describe: `Serve ${name} in watch mode`,
-        builder: {},
+        builder: {
+          fastDev: {
+            default: false,
+            describe:
+              'Experimental: Enable faster development mode (modern browsers only)',
+            type: 'boolean',
+          },
+          experimentalEsbuild: {
+            default: process.env.USE_EXPERIMENTAL_ESBUILD === 'true',
+            describe: 'Use esbuild for transpilation (experimental)',
+            type: 'boolean',
+          },
+        },
         handler: () =>
           this.clean()
             .then(this.runServer.bind(this, 'develop'))


### PR DESCRIPTION
Wait for #1720 and add `--fast-refresh`, too.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
