### PR TITLE
chore(spec): remove superfluous warning checks

### DIFF
--- a/packages/spec/helpers.js
+++ b/packages/spec/helpers.js
@@ -1,25 +1,7 @@
-const isReactLifecycleWarning = (warning) => {
-  const reReactLifecycleWarning = new RegExp(
-    'Warning: componentWill[^\\s]+ has been renamed, and is not recommended for use. ' +
-      'See https://fb.me/react-async-component-lifecycle-hooks for details.'
-  );
-  return Boolean(warning.match(reReactLifecycleWarning));
-};
-
-const isSharedArrayBufferWarning = (warning) =>
-  warning.startsWith(
-    'SharedArrayBuffer will require cross-origin isolation as of M91, around May 2021.'
-  );
-
-const isIntolerableWarning = (type, text) =>
-  type === 'warning' &&
-  !isReactLifecycleWarning(text) &&
-  !isSharedArrayBufferWarning(text);
-
 exports.handleConsoleOutput = (msg) => {
   const type = msg.type();
   const text = msg.text();
-  if (type === 'error' || isIntolerableWarning(type, text)) {
+  if (type === 'error') {
     throw new Error(`${type} in browser console: ${text}`);
   }
 };


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
