### PR TITLE
fix: correctly initialize import component context

### DIFF
--- a/packages/react/import-component/context.js
+++ b/packages/react/import-component/context.js
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-const context = createContext({});
+const context = createContext(undefined);
 
 context.displayName = 'Hops.ImportComponent';
 

--- a/packages/react/import-component/index.js
+++ b/packages/react/import-component/index.js
@@ -71,7 +71,7 @@ export const importComponent = (
     }
 
     return createElement(Importer, {
-      hasModules: Boolean(modules),
+      hasModules: Boolean(modules && modules.length > 0),
       loader,
       render,
       ownProps,


### PR DESCRIPTION
The import component context should be initialized with undefined,
as this is the expected behavior of the Import Component.

Closes #1729
