### PR TITLE
chore: skip tests on certain branches

### DIFF
--- a/.github/canarist-service.yml
+++ b/.github/canarist-service.yml
@@ -1,0 +1,4 @@
+ignore-branches:
+  - master
+  - v14.x
+  - v13.x

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - 'staging.tmp'
       - 'trying.tmp'
+      - 'master'
+      - 'v14.x'
+      - 'v13.x'
 
 jobs:
   tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ These steps are to be done on the master branch:
 - Add the new release label to the check-label config ([example](https://github.com/xing/hops/pull/1682/commits/1fc5688406594e769621e3836809d21a0da18604))
 - Update the release-bot config for the new branches ([example](https://github.com/xing/hops/pull/1682/commits/07187953765851052f5aef32647d5a96f400cabe))
 - Update base branches in renovate config ([example](https://github.com/xing/hops/pull/1682/commits/dad6ee42a1d80dcccb47c587c61ebeb02ea2a819))
+<!-- TODO: add new commit here that includes the update of the "branches-ignore"-property in node-ci.yml -->
 - Update the branches in CI workflows ([example](https://github.com/xing/hops/pull/1682/commits/f9fb27bee52d511c879b9cf2efd484317706832a))
 - Update documentation links ([example](https://github.com/xing/hops/pull/1682/commits/67b14b9ce66db3281e9e5ab2f53172afabd5f7bc))
 


### PR DESCRIPTION
..., namely the main- & the release branches

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
