### PR TITLE
chore: remove superfluous dependency

### DIFF
--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -23,8 +23,7 @@
     "flat": "^5.0.0",
     "hops-debug": "15.0.0-nightly.1",
     "is-plain-obj": "^3.0.0",
-    "mixinable": "^5.0.1",
-    "supports-color": "^8.0.0"
+    "mixinable": "^5.0.1"
   },
   "engines": {
     "node": "12 || 14 || 15"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -42,8 +42,7 @@
     "portfinder": "^1.0.24",
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^7.0.0",
-    "split": "^1.0.1",
-    "supports-color": "^8.0.0"
+    "split": "^1.0.1"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/express#readme"
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -43,7 +43,6 @@
     "source-map-support": "^0.5.13",
     "speed-measure-webpack-plugin": "^1.3.3",
     "strip-ansi": "^6.0.0",
-    "supports-color": "^8.0.0",
     "terser-webpack-plugin": "^4.0.0",
     "url-loader": "^4.0.0",
     "webpack": "^4.43.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13290,13 +13290,6 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-hyperlinks@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
