### PR TITLE
fix(apollo-mock-server): update package graphql-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
             "url": "enc:r6BTklZr+axySHpOBj0JysOusV4S8o7YtSxZ9fi66rL5grn3vMkHUbMdb3OY5+tv",
             "directory": "internal-hops"
           }
-        ]
+        ],
+        "rootManifest": {
+          "resolutions": {
+            "graphql-tag": "^2.12"
+          }
+        }
       },
       {
         "name": "internal-workshop",

--- a/packages/apollo-mock-server/package.json
+++ b/packages/apollo-mock-server/package.json
@@ -27,7 +27,7 @@
     "cross-fetch": "^3.0.4",
     "express": "^4.17.1",
     "graphql": "^15.0.0",
-    "graphql-tag": "^2.11.0",
+    "graphql-tag": "^2.12.3",
     "hops-config": "15.0.0-nightly.1",
     "hops-mixin": "15.0.0-nightly.1",
     "hops-webpack": "15.0.0-nightly.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7176,7 +7176,7 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.3.0"
 
-graphql-tag@^2.11.0, graphql-tag@^2.12.0:
+graphql-tag@^2.11.0, graphql-tag@^2.12.0, graphql-tag@^2.12.3:
   version "2.12.3"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.3.tgz#ac47bf9d51c67c68ada8a33fd527143ed15bb647"
   integrity sha512-5wJMjSvj30yzdciEuk9dPuUBUR56AqDi3xncoYQl1i42pGdSqOJrJsdb/rz5BDoy+qoGvQwABcBeF0xXY3TrKw==


### PR DESCRIPTION
...manually, because the Apollo team published the v2.12.x packages with tag `next`,
so Renovate will not bother to create an update PR for us.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
