### PR TITLE
chore: fix Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "extends": ["config:base"],
-  "pinVersions": false,
   "prCreation": "not-pending",
-  "masterIssue": true,
+  "dependencyDashboard": true,
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -29,28 +28,27 @@
   ],
   "packageRules": [
     {
-      "depTypeList": ["dependencies", "peerDependencies"],
+      "matchDepTypes": ["dependencies", "peerDependencies"],
       "semanticCommitType": "fix"
     },
     {
-      "depTypeList": ["peerDependencies"],
+      "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"
     },
     {
-      "depTypeList": ["devDependencies"],
-      "updateTypes": ["major", "minor"],
+      "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"
     },
     {
-      "baseBranchList": ["master"],
+      "matchBaseBranches": ["master"],
       "labels": [":package: master"]
     },
     {
-      "baseBranchList": ["release-bot/next-v14.x"],
+      "matchBaseBranches": ["release-bot/next-v14.x"],
       "labels": [":package: v14"]
     },
     {
-      "baseBranchList": ["release-bot/next-v13.x"],
+      "matchBaseBranches": ["release-bot/next-v13.x"],
       "labels": [":package: v13"],
       "major": {
         "enabled": false


### PR DESCRIPTION
refs #1783

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
