### PR TITLE
chore: restore old range strategy for dev-dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:base"],
   "prCreation": "not-pending",
   "dependencyDashboard": true,
   "lockFileMaintenance": {
@@ -37,7 +37,7 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "replace"
     },
     {
       "matchBaseBranches": ["master"],


### PR DESCRIPTION
…which is: relying on the lockfile maintenance.

When I updated the config to switch to the new configuration properties, I
failed to re-create the setting for dev-dependencies¹, which led to a
lot of PRs being opened by Renovate.

With this change the majority of dependency updates should be done
implicitly again via the lockfile maintenance. Only major updates will
lead to a dedicted PR which replaces the version string with the newer
one.

----
¹: https://github.com/xing/hops/blob/dad6ee42a1d80dcccb47c587c61ebeb02ea2a819/renovate.json#L40-L42

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
