### PR TITLE
chore: add comand to roll back release commit

### DIFF
--- a/.github/release-bot.yml
+++ b/.github/release-bot.yml
@@ -12,3 +12,5 @@ labels:
 release-pr-branch-pattern: 'release-bot/next-%s'
 
 prepare-release-command: 'yarn release:prepare'
+
+rollback-release-command: 'yarn release:rollback'

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "template-graphql": "yarn workspace hops-template-graphql run",
     "template-react": "yarn workspace hops-template-react run",
     "template-redux": "yarn workspace hops-template-redux run",
+    "is-release-bot-commit": "node -e \"process.exit(child_process.execSync('git show -s --format=\\'%an\\' HEAD').toString().trim() == 'Hops release bot' ? 0 : 1)\"",
     "prerelease": "node -e \"process.exit(process.env.GH_TOKEN === undefined)\"",
     "release": "lerna publish",
     "release:prepare": "lerna version --no-push --yes",
+    "release:rollback": "yarn is-release-bot-commit && git reset --hard HEAD^",
     "release:create-nightly": "yarn release premajor --conventional-prerelease --preid nightly",
     "release:rc": "yarn release --conventional-prerelease --preid rc",
     "release:graduate": "yarn release --conventional-graduate"


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
