### PR TITLE
fix(debug): provide method extend in the browser

### DIFF
--- a/packages/debug/browser.js
+++ b/packages/debug/browser.js
@@ -6,8 +6,7 @@ const debugRegex = new RegExp(debugCookie.replace('*', '.*'));
 
 module.exports = function debug(name) {
   const isEnabled = debugCookie !== '' && debugRegex.test(name);
-
-  return isEnabled
+  const fn = isEnabled
     ? (format, ...args) => {
         if (typeof format === 'string') {
           console.debug(
@@ -27,4 +26,8 @@ module.exports = function debug(name) {
         }
       }
     : () => {};
+
+  fn.extend = (suffix) => debug(`${name}:${suffix}`);
+
+  return fn;
 };


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
