### PR TITLE
feat(webpack): enable filesystem-based caching

### DIFF
--- a/packages/bootstrap/index.js
+++ b/packages/bootstrap/index.js
@@ -18,4 +18,4 @@ exports.initialize = function initialize(overrides = {}, ...args) {
   return define(strategies, mixins)(config, ...args);
 };
 
-exports.internal = { getConfig, ...require('./lib/utils') };
+exports.internal = { getConfig, getMixins, ...require('./lib/utils') };

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -298,3 +298,4 @@ Available tags for the [`debug`](https://www.npmjs.com/package/debug)-module are
 - `hops:webpack:config:build`
 - `hops:webpack:config:develop`
 - `hops:webpack:config:node`
+- `hops:webpack:dependencies`

--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -6,7 +6,7 @@ const getModules = require('../utils/modules');
 
 const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
 
-module.exports = function getConfig(config, name) {
+module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
   const isProduction = process.env.NODE_ENV === 'production';
 
@@ -92,9 +92,17 @@ module.exports = function getConfig(config, name) {
       devtoolModuleFilenameTemplate: (info) =>
         relative(config.rootDir, info.absoluteResourcePath),
     },
-    // fixme
     cache: {
-      type: 'memory',
+      type: 'filesystem',
+      buildDependencies: {
+        config: [__filename].concat(buildDependencies),
+      },
+    },
+    snapshot: {
+      buildDependencies: {
+        hash: true,
+        timestamp: false,
+      },
     },
     resolve: {
       modules: getModules(config.rootDir),

--- a/packages/webpack/lib/configs/develop.js
+++ b/packages/webpack/lib/configs/develop.js
@@ -7,7 +7,7 @@ const {
 const { join, trimSlashes } = require('pathifist');
 const getModules = require('../utils/modules');
 
-module.exports = function getConfig(config, name) {
+module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
 
   const jsLoaderConfig = {
@@ -91,9 +91,17 @@ module.exports = function getConfig(config, name) {
       devtoolModuleFilenameTemplate: (info) =>
         relative(config.rootDir, info.absoluteResourcePath),
     },
-    // fixme
     cache: {
-      type: 'memory',
+      type: 'filesystem',
+      buildDependencies: {
+        config: [__filename].concat(buildDependencies),
+      },
+    },
+    snapshot: {
+      buildDependencies: {
+        hash: false,
+        timestamp: true,
+      },
     },
     resolve: {
       modules: getModules(config.rootDir),

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -11,7 +11,7 @@ const getModules = require('../utils/modules');
 const { LimitChunkCountPlugin } = optimize;
 const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
 
-module.exports = function getConfig(config, name) {
+module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
   const isProduction = process.env.NODE_ENV === 'production';
 
@@ -118,9 +118,17 @@ module.exports = function getConfig(config, name) {
       devtoolModuleFilenameTemplate: (info) =>
         resolve(info.absoluteResourcePath),
     },
-    // fixme
     cache: {
-      type: 'memory',
+      type: 'filesystem',
+      buildDependencies: {
+        config: [__filename].concat(buildDependencies),
+      },
+    },
+    snapshot: {
+      buildDependencies: {
+        hash: true,
+        timestamp: !isProduction,
+      },
     },
     resolve: {
       modules: getModules(config.rootDir),


### PR DESCRIPTION
#### Production build of `packages/spec/integration/react`…

- with cold webpack cache: ~6.3s
- with warm webpack cache: ~2.3s

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
