### PR TITLE
chore(spec): improve create-hops-app test

### DIFF
--- a/packages/create-hops-app/lib/package-manager.js
+++ b/packages/create-hops-app/lib/package-manager.js
@@ -37,6 +37,10 @@ function installPackages(packages, type, options) {
     if (type === 'dev') {
       command.push('--dev');
     }
+    // TODO: remove this after PR #1878 has been released
+    if (process.version.startsWith('v16')) {
+      command.push('--ignore-engines');
+    }
   } else {
     command =
       packages.length === 0

--- a/packages/spec/integration/create-hops-app/__tests__/index.spec.js
+++ b/packages/spec/integration/create-hops-app/__tests__/index.spec.js
@@ -5,7 +5,7 @@
 const path = require('path');
 const { prerelease } = require('semver');
 const { existsSync, readFileSync } = require('fs');
-const { execSync } = require('child_process');
+const execa = require('execa');
 const { version, bin } = require(require.resolve(
   'create-hops-app/package.json'
 ));
@@ -21,27 +21,43 @@ describe('create-hops-app', () => {
     process.chdir(cwd);
   });
 
-  it('initializes a Hops app with yarn', () => {
+  it('initializes a Hops app with yarn', async () => {
     const name = 'my-app-yarn';
-    const args = [name, `--template ${template}@${version}`].join(' ');
+    const args = [name, `--template ${template}@${version}`];
 
-    execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
+    const { all: output } = await execa(createHopsAppBin, args, {
+      all: true,
+    });
 
     const lockFile = path.join(cwd, name, 'yarn.lock');
 
-    expect(existsSync(lockFile)).toBeTruthy();
+    // Leaving the realm of `expect` here in order to be able to
+    // print the output of the command in case of failure.
+    if (!existsSync(lockFile)) {
+      console.log(output);
+
+      throw new Error(`Could not find file ${name}/yarn.lock`);
+    }
+
     expect(readFileSync(lockFile, 'utf-8')).toContain('hops-react');
   });
 
-  it('initializes a Hops app with npm', () => {
+  it('initializes a Hops app with npm', async () => {
     const name = 'my-app-npm';
-    const args = [name, `--template ${template}@${version}`, `--npm`].join(' ');
+    const args = [name, `--template ${template}@${version}`, `--npm`];
 
-    execSync(`${createHopsAppBin} ${args}`, { stdio: 'ignore' });
+    const { all: output } = await execa(createHopsAppBin, args, { all: true });
 
     const lockFile = path.join(cwd, name, 'package-lock.json');
 
-    expect(existsSync(lockFile)).toBeTruthy();
+    // Leaving the realm of `expect` here in order to be able to
+    // print the output of the command in case of failure.
+    if (!existsSync(lockFile)) {
+      console.log(output);
+
+      throw new Error(`Could not find file ${name}/yarn.lock`);
+    }
+
     expect(readFileSync(lockFile, 'utf-8')).toContain('hops-react');
   });
 

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -39,6 +39,7 @@
     "cross-fetch": "^3.1.4",
     "esbuild-jest": "^0.5.0",
     "esbuild-loader": "^2.13.1",
+    "execa": "^5.1.1",
     "jest-environment-hops": "15.0.0-nightly.5",
     "raw-body": "^2.4.1",
     "react-apollo": "^3.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5956,7 +5956,7 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^5.0.0:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
…and add intermediary support for Node v16

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
