### PR TITLE
fix(create-hops-app): remove intermediary hack

### DIFF
--- a/packages/create-hops-app/lib/package-manager.js
+++ b/packages/create-hops-app/lib/package-manager.js
@@ -37,10 +37,6 @@ function installPackages(packages, type, options) {
     if (type === 'dev') {
       command.push('--dev');
     }
-    // TODO: remove this after PR #1878 has been released
-    if (process.version.startsWith('v16')) {
-      command.push('--ignore-engines');
-    }
   } else {
     command =
       packages.length === 0


### PR DESCRIPTION
…for introducing support for Node 16

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
