### PR TITLE
refactor(msw): get rid of url-join

### DIFF
--- a/packages/msw/integration.js
+++ b/packages/msw/integration.js
@@ -1,14 +1,13 @@
 // @ts-check
 
 const { fetch } = require('cross-fetch');
-const joinUrl = require('url-join');
 
-const getMockEndpoint = () => {
+const getMockEndpoint = (pathName) => {
   if (typeof process.env.MOCK_HOST !== 'string') {
     throw new Error('Please define MOCK_HOST.');
   }
 
-  return new URL(process.env.MOCK_HOST).toString();
+  return new URL(pathName, process.env.MOCK_HOST).toString();
 };
 
 /** @type {import('hops-msw/integration').mockGraphQLQuery} */
@@ -73,7 +72,7 @@ const mockDeleteRequest = (pathName, data) => {
 
 /** @type {import('hops-msw/integration').registerServerMocks} */
 const registerServerMocks = async (...mocks) => {
-  await fetch(joinUrl(getMockEndpoint(), '/_mocks/register'), {
+  await fetch(getMockEndpoint('/_mocks/register'), {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -84,7 +83,7 @@ const registerServerMocks = async (...mocks) => {
 
 /** @type {import('hops-msw/integration').resetServerMocks} */
 const resetServerMocks = async () => {
-  await fetch(joinUrl(getMockEndpoint(), '/_mocks/reset'));
+  await fetch(getMockEndpoint('/_mocks/reset'));
 };
 
 module.exports = {

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -25,8 +25,7 @@
     "cross-fetch": "^3.1.4",
     "execa": "^5.1.1",
     "hops-mixin": "15.0.0-nightly.6",
-    "msw": "^0.30.0",
-    "url-join": "^4.0.1"
+    "msw": "^0.30.0"
   },
   "homepage": "https://github.com/xing/hops/tree/master/packages/msw#readme"
 }


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
