### PR TITLE
feat(msw): allow to specify a handlers file to use during development

### DIFF
--- a/packages/jest-preset/setup-msw.js
+++ b/packages/jest-preset/setup-msw.js
@@ -1,4 +1,4 @@
-import { mockServer } from 'hops-msw/unit';
+import { getMockServer } from 'hops-msw/unit';
 
 let client;
 
@@ -11,7 +11,7 @@ beforeAll(async () => {
     // we don't have hops-react-apollo installed and won't create a client
   }
 
-  mockServer.listen();
+  getMockServer().listen();
 });
 
 afterEach(async () => {
@@ -19,9 +19,9 @@ afterEach(async () => {
     await client.clearStore();
   }
 
-  mockServer.resetHandlers();
+  getMockServer().resetHandlers();
 });
 
 afterAll(() => {
-  mockServer.close();
+  getMockServer().close();
 });

--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -12,11 +12,12 @@ This package (together with `jest-preset-hops`) takes care of setting up the MSW
 
 ```javascript
 import { render, waitFor } from '@testing-library/react';
-import { mockServer, graphql } from 'hops-msw';
+import { getMockServer } from 'hops-msw/unit';
+import { graphql } from 'hops-msw';
 import { withApolloTestProvider } from 'hops-react-apollo';
 
 it('loads graphql data', async () => {
-  mockServer.use(
+  getMockServer().use(
     graphql.query('search', (req, res, ctx) => {
       return res(
         ctx.data({

--- a/packages/msw/index.d.ts
+++ b/packages/msw/index.d.ts
@@ -1,0 +1,6 @@
+import { graphql as mswGraphQL, rest as mswRest } from 'msw';
+
+declare module 'hops-msw/unit' {
+  export const rest: typeof mswRest;
+  export const graphql: typeof mswGraphQL;
+}

--- a/packages/msw/index.js
+++ b/packages/msw/index.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+const { graphql, rest } = require('msw');
+
+module.exports = {
+  graphql,
+  rest,
+};

--- a/packages/msw/mixin.browser.js
+++ b/packages/msw/mixin.browser.js
@@ -31,6 +31,8 @@ const createBrowserMock = (
 
 class MswMixin extends Mixin {
   async bootstrap() {
+    const { mswWaitForBrowserMocks } = this.getServerData();
+
     if (this.config.enableMockServiceWorker !== 'true') {
       return;
     }
@@ -39,19 +41,15 @@ class MswMixin extends Mixin {
     const { setupWorker, graphql, rest } = await import('msw');
     const worker = setupWorker();
 
-    let hasHandlers = false;
-
     try {
       // eslint-disable-next-line node/no-unsupported-features/es-syntax, import/no-unresolved, node/no-missing-import
       const { handlers } = await import('hops-msw/handlers');
-      hasHandlers = true;
       handlers.forEach((handler) => worker.use(handler));
     } catch {
       // ignore if no handlers file has been provided
     }
 
     const registerBrowserMock = (mock) => {
-      hasHandlers = true;
       worker.use(createBrowserMock({ graphql, rest }, mock));
     };
 
@@ -78,7 +76,7 @@ class MswMixin extends Mixin {
     return new Promise((resolve) => {
       window.hopsMswMocksReady = () => resolve();
 
-      if (hasHandlers) {
+      if (!mswWaitForBrowserMocks) {
         window.hopsMswMocksReady();
       }
     });

--- a/packages/msw/mixin.browser.js
+++ b/packages/msw/mixin.browser.js
@@ -38,16 +38,32 @@ class MswMixin extends Mixin {
     // eslint-disable-next-line node/no-unsupported-features/es-syntax
     const { setupWorker, graphql, rest } = await import('msw');
     const worker = setupWorker();
+
+    let hasHandlers = false;
+
+    try {
+      // eslint-disable-next-line node/no-unsupported-features/es-syntax, import/no-unresolved, node/no-missing-import
+      const { handlers } = await import('hops-msw/handlers');
+      hasHandlers = true;
+      handlers.forEach((handler) => worker.use(handler));
+    } catch {
+      // ignore if no handlers file has been provided
+    }
+
     const registerBrowserMock = (mock) => {
+      hasHandlers = true;
       worker.use(createBrowserMock({ graphql, rest }, mock));
     };
 
+    window.hopsMswMocksReady = () => {};
     window.hopsMswMocksReset = () => worker.resetHandlers();
+
     window.hopsMswMocks = window.hopsMswMocks || [];
     window.hopsMswMocks.push = (...mocks) => {
       mocks.forEach((mock) => registerBrowserMock(mock));
       window.hopsMswMocksReady();
     };
+
     window.hopsMswMocks.forEach((mock) => registerBrowserMock(mock));
 
     await worker.start({
@@ -61,7 +77,8 @@ class MswMixin extends Mixin {
 
     return new Promise((resolve) => {
       window.hopsMswMocksReady = () => resolve();
-      if (window.hopsMswMocks.length > 0) {
+
+      if (hasHandlers) {
         window.hopsMswMocksReady();
       }
     });

--- a/packages/msw/mixin.core.js
+++ b/packages/msw/mixin.core.js
@@ -38,7 +38,7 @@ module.exports = class MswMixin extends Mixin {
     }
   }
 
-  configureServer(_, middlewares) {
+  configureServer(app, middlewares) {
     if (process.env.ENABLE_MSW !== 'true') {
       return;
     }
@@ -78,6 +78,10 @@ module.exports = class MswMixin extends Mixin {
         bodyParserJson(),
         (req, res) => {
           const { mocks } = req.body;
+
+          // setting this on `app.locals`, because it is a "global" and
+          // affects all following requests
+          app.locals.mswWaitForBrowserMocks = true;
 
           mocks.forEach(({ type, method, identifier, data }) => {
             switch (type) {
@@ -125,6 +129,8 @@ module.exports = class MswMixin extends Mixin {
       path: '/_msw/reset',
       handler: (_, res) => {
         mockServer.resetHandlers();
+
+        app.locals.mswWaitForBrowserMocks = false;
 
         res.type('text/plain').end('ok');
       },

--- a/packages/msw/mixin.server.js
+++ b/packages/msw/mixin.server.js
@@ -1,0 +1,19 @@
+/* eslint-env browser, node */
+
+import { Mixin } from 'hops-mixin';
+
+class MswMixin extends Mixin {
+  enhanceServerData(serverData, req, res) {
+    // this value has been set on `app.locals`, because it is a "global"
+    // value that should affect all following requests after it has been
+    // set.
+    const { mswWaitForBrowserMocks = false } = res.app.locals;
+
+    return {
+      ...serverData,
+      mswWaitForBrowserMocks,
+    };
+  }
+}
+
+export default MswMixin;

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -2,6 +2,7 @@
   "name": "hops-msw",
   "version": "15.0.0-nightly.8",
   "description": "Mock service worker support for Hops",
+  "main": "index.js",
   "keywords": [
     "hops",
     "mocking",

--- a/packages/msw/preset.js
+++ b/packages/msw/preset.js
@@ -2,6 +2,7 @@ module.exports = {
   mixins: [__dirname],
   mockServiceWorkerUri: '/sw.js',
   enableMockServiceWorker: '[ENABLE_MSW]',
+  mockServiceWorkerHandlersFile: '',
   browserWhitelist: {
     mockServiceWorkerUri: true,
     enableMockServiceWorker: true,
@@ -11,6 +12,9 @@ module.exports = {
     enableMockServiceWorker: {
       type: 'string',
       enum: ['true', ''],
+    },
+    mockServiceWorkerHandlersFile: {
+      type: 'string',
     },
   },
 };

--- a/packages/msw/unit.d.ts
+++ b/packages/msw/unit.d.ts
@@ -1,8 +1,5 @@
 import { SetupServerApi } from 'msw/node';
-import { graphql as mswGraphQL, rest as mswRest } from 'msw';
 
 declare module 'hops-msw/unit' {
-  export const mockServer: SetupServerApi;
-  export const rest: typeof mswRest;
-  export const graphql: typeof mswGraphQL;
+  export const getMockServer: () => SetupServerApi;
 }

--- a/packages/msw/unit.js
+++ b/packages/msw/unit.js
@@ -1,10 +1,15 @@
 // @ts-check
 
 const { setupServer } = require('msw/node');
-const { graphql, rest } = require('msw');
+
+let mockServer;
 
 module.exports = {
-  mockServer: setupServer(),
-  graphql,
-  rest,
+  getMockServer() {
+    if (mockServer) {
+      return mockServer;
+    }
+
+    return (mockServer = setupServer());
+  },
 };

--- a/packages/template-graphql/mocks.js
+++ b/packages/template-graphql/mocks.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line node/no-unpublished-require
+const { graphql } = require('hops-msw');
+
+function jobSearchByQueryData() {
+  return {
+    __typename: 'Query',
+    jobSearchByQuery: {
+      __typename: 'JobSearchResult',
+      collection: [
+        {
+          __typename: 'JobItemResult',
+          jobDetail: {
+            __typename: 'VisibleJob',
+            id: '1',
+            url: 'https://www.xing.com/jobs/1',
+            title: 'some job',
+            companyInfo: {
+              __typename: 'JobCompanyInfo',
+              company: {
+                __typename: 'Company',
+                companyName: 'cool company',
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+module.exports.jobSearchByQueryData = jobSearchByQueryData;
+
+module.exports.handlers = [
+  graphql.query('search', (req, res, ctx) => {
+    return res(ctx.data(jobSearchByQueryData()));
+  }),
+];

--- a/packages/template-graphql/package.json
+++ b/packages/template-graphql/package.json
@@ -4,7 +4,8 @@
   "main": "src/app.jsx",
   "license": "MIT",
   "hops": {
-    "graphqlUri": "https://www.xing.com/xing-one/api"
+    "graphqlUri": "https://www.xing.com/xing-one/api",
+    "mockServiceWorkerHandlersFile": "<rootDir>/mocks.js"
   },
   "scripts": {
     "start": "hops start",

--- a/packages/template-graphql/src/app.jsx
+++ b/packages/template-graphql/src/app.jsx
@@ -1,7 +1,7 @@
 import { Miss, render } from 'hops';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import Home from './home';
+import Home from './home/index.jsx';
 
 const App = () => (
   <Switch>

--- a/packages/template-graphql/src/home/spec/index.spec.jsx
+++ b/packages/template-graphql/src/home/spec/index.spec.jsx
@@ -1,4 +1,5 @@
-import { mockServer, graphql } from 'hops-msw/unit';
+import { getMockServer } from 'hops-msw/unit';
+import { graphql } from 'hops-msw';
 import { withApolloTestProvider } from 'hops-react-apollo';
 import React from 'react';
 import { HelmetProvider } from 'react-helmet-async';
@@ -46,7 +47,7 @@ it('renders loaded state correctly', () => {
 });
 
 it('loads graphql data', async () => {
-  mockServer.use(
+  getMockServer().use(
     graphql.query('search', (req, res, ctx) => {
       return res(
         ctx.data({

--- a/packages/template-graphql/src/home/spec/index.spec.jsx
+++ b/packages/template-graphql/src/home/spec/index.spec.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import renderer, { act } from 'react-test-renderer';
 import HomeWithData, { Home } from '../index.jsx';
+import { jobSearchByQueryData } from '../../../mocks';
 
 HelmetProvider.canUseDOM = false;
 
@@ -49,32 +50,7 @@ it('renders loaded state correctly', () => {
 it('loads graphql data', async () => {
   getMockServer().use(
     graphql.query('search', (req, res, ctx) => {
-      return res(
-        ctx.data({
-          __typename: 'Query',
-          jobSearchByQuery: {
-            __typename: 'JobSearchResult',
-            collection: [
-              {
-                __typename: 'JobItemResult',
-                jobDetail: {
-                  __typename: 'VisibleJob',
-                  id: '1',
-                  url: 'https://www.xing.com/jobs/1',
-                  title: 'some job',
-                  companyInfo: {
-                    __typename: 'JobCompanyInfo',
-                    company: {
-                      __typename: 'Company',
-                      companyName: 'cool company',
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        })
-      );
+      return res(ctx.data(jobSearchByQueryData()));
     })
   );
 


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
