### PR TITLE
docs: let all links to "main readme" point to readme version selection

### DIFF
--- a/packages/apollo-mock-server/README.md
+++ b/packages/apollo-mock-server/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-apollo-mock-server.svg)](https://www.npmjs.com/package/hops-apollo-mock-server)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) in order to start and configure an Apollo Server that can be used for GraphQL mocking to enable faster local development.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-config.svg)](https://www.npmjs.com/package/hops-config)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 Please use [`withConfig`](../../DOCUMENTATION.md#withconfigcomponent) or [`useConfig`](../../DOCUMENTATION.md#useconfig-config) to access the configuration inside your application's React components.
 

--- a/packages/create-hops-app/README.md
+++ b/packages/create-hops-app/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/create-hops-app.svg)](https://www.npmjs.com/package/create-hops-app)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This package provides a binary (`create-hops-app`) that can be used to create Hops applications.
 

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-debug.svg)](https://www.npmjs.com/package/hops-debug)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This package proxies the [`debug`](https://www.npmjs.com/package/debug) package from npm and makes it available for server- and client-code.
 

--- a/packages/development-proxy/README.md
+++ b/packages/development-proxy/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-development-proxy.svg)](https://www.npmjs.com/package/hops-development-proxy)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 [Hops preset](../../DOCUMENTATION.md#presets) that adds an API-proxy for development.
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-express.svg)](https://www.npmjs.com/package/hops-express)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is one of the core presets for Hops and provides the development and production server configuration and mixin infrastructure in order to build a Hops application.
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-graphql.svg)](https://www.npmjs.com/package/hops-graphql)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to set up an `<ApolloProvider />` and enable server-side and client-side support for GraphQL via the Apollo framework. Additionally it also brings an Apollo Server that can be used for mocking to enable faster local development.
 

--- a/packages/hops/README.md
+++ b/packages/hops/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops.svg)](https://www.npmjs.com/package/hops)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 Hops is everything you need to develop and deploy a production grade universal web application with [React](https://facebook.github.io/react/). It provides both a **universal runtime** as well as the necessary **build tooling**.
 
@@ -30,4 +30,4 @@ npm start
 
 This will start Hops in development mode. Visit [http://localhost:8080](http://localhost:8080) to see your app in the browser and make some changes to the code in your editor to see it live-reloading.
 
-Check out the [main Hops Readme](../../DOCUMENTATION.md) for more detailed explanations and documentation.
+Check out the [main Hops Readme](https://github.com/xing/hops#docs) for more detailed explanations and documentation.

--- a/packages/jest-environment/README.md
+++ b/packages/jest-environment/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/jest-environment-hops.svg)](https://www.npmjs.com/package/jest-environment-hops)
 
-Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.
+Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.
 
 > **This package is part of Hops's internal tooling. Hence, it doesn't provide an API contract. Breaking changes may be introduced even with patch releases. Use at your own risk.**
 

--- a/packages/jest-preset/README.md
+++ b/packages/jest-preset/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/jest-preset-hops.svg)](https://www.npmjs.com/package/jest-preset-hops)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 A [Jest preset](https://facebook.github.io/jest/docs/configuration.html#preset-string) that makes it easier for Hops powered apps to use Jest.
 

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-lambda.svg)](https://www.npmjs.com/package/hops-lambda)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that takes care of deploying your application to [AWS Lambda](https://aws.amazon.com/lambda/).
 

--- a/packages/mixin/README.md
+++ b/packages/mixin/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-mixin.svg)](https://www.npmjs.com/package/hops-mixin)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 Contains the building blocks needed to build your own hops mixins. Mixins allow you to alter and extend Hops' functionality.
 

--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-msw.svg)](https://www.npmjs.com/package/hops-msw)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to set up a [Mock Service Worker](https://www.npmjs.com/package/msw) for your Hops app. It allows to mock REST and GraphQL APIs in unit and integration tests.
 

--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-postcss.svg)](https://www.npmjs.com/package/hops-postcss)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that, when installed, will enable css loaders for [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env) with support for [CSS Modules](https://github.com/css-modules/css-modules).
 

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-pwa.svg)](https://www.npmjs.com/package/hops-pwa)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to enable [progressive web app](https://developers.google.com/web/progressive-web-apps/) features like a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) and [service worker](https://developers.google.com/web/fundamentals/primers/service-workers/) usage in Hops.
 

--- a/packages/react-apollo/README.md
+++ b/packages/react-apollo/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-react-apollo.svg)](https://www.npmjs.com/package/hops-react-apollo)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to set up an `<ApolloProvider />` and enable client-side support for GraphQL via the Apollo framework.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-react.svg)](https://www.npmjs.com/package/hops-react)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that enables React, JSX, React-Helmet Async and React-Router support in Hops applications. It also supports [the JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-redux.svg)](https://www.npmjs.com/package/hops-redux)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to add redux support to your Hops project.
 

--- a/packages/styled-components/README.md
+++ b/packages/styled-components/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-styled-components.svg)](https://www.npmjs.com/package/hops-styled-components)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to set up a `<ThemeProvider />` and enable server-side rendering support for [styled-components](https://www.styled-components.com/) in Hops.
 

--- a/packages/template-graphql/README.md
+++ b/packages/template-graphql/README.md
@@ -2,9 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/hops-template-graphql.svg)](https://www.npmjs.com/package/hops-template-graphql)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
-This is a small example application showing [hops](../../DOCUMENTATION.md) in action. It demonstrates how to use hops with React, GraphQL and Jest.
+This is a small example application showing [hops](https://github.com/xing/hops#docs) in action. It demonstrates how to use hops with React, GraphQL and Jest.
 
 It has the following folder structure:
 

--- a/packages/template-react/README.md
+++ b/packages/template-react/README.md
@@ -2,9 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/hops-template-react.svg)](https://www.npmjs.com/package/hops-template-react)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
-This is a small example application showing [hops](../../DOCUMENTATION.md) in action. It demonstrates how to use hops with React.
+This is a small example application showing [hops](https://github.com/xing/hops#docs) in action. It demonstrates how to use hops with React.
 
 It has the following folder structure:
 

--- a/packages/template-redux/README.md
+++ b/packages/template-redux/README.md
@@ -2,9 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/hops-template-redux.svg)](https://www.npmjs.com/package/hops-template-redux)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
-This is a small example application showing [hops](../../DOCUMENTATION.md) in action. It demonstrates how to use hops with React, Redux and Jest.
+This is a small example application showing [hops](https://github.com/xing/hops#docs) in action. It demonstrates how to use hops with React, Redux and Jest.
 
 It has the following folder structure:
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/hops-typescript.svg)](https://www.npmjs.com/package/hops-typescript)
 
-**Please see the [main Hops Readme](../../DOCUMENTATION.md) for general information and a Getting Started Guide.**
+**Please see the [main Hops Readme](https://github.com/xing/hops#docs) for general information and a Getting Started Guide.**
 
 This is a [preset for Hops](../../DOCUMENTATION.md#presets) that can be used to enable [TypeScript](https://www.typescriptlang.org/) support for Hops projects.
 


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
