### PR TITLE
fix(msw): rename /_mocks/ endpoint to /_msw/ to avoid clashes

### DIFF
--- a/packages/msw/integration.js
+++ b/packages/msw/integration.js
@@ -72,7 +72,7 @@ const mockDeleteRequest = (pathName, data) => {
 
 /** @type {import('hops-msw/integration').registerServerMocks} */
 const registerServerMocks = async (...mocks) => {
-  await fetch(getMockEndpoint('/_mocks/register'), {
+  await fetch(getMockEndpoint('/_msw/register'), {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -83,7 +83,7 @@ const registerServerMocks = async (...mocks) => {
 
 /** @type {import('hops-msw/integration').resetServerMocks} */
 const resetServerMocks = async () => {
-  await fetch(getMockEndpoint('/_mocks/reset'));
+  await fetch(getMockEndpoint('/_msw/reset'));
 };
 
 module.exports = {

--- a/packages/msw/mixin.core.js
+++ b/packages/msw/mixin.core.js
@@ -79,7 +79,7 @@ module.exports = class MswMixin extends Mixin {
 
     middlewares.initial.push({
       method: 'post',
-      path: '/_mocks/register',
+      path: '/_msw/register',
       handler: [
         bodyParserJson(),
         (req, res) => {
@@ -132,7 +132,7 @@ module.exports = class MswMixin extends Mixin {
 
     middlewares.initial.push({
       method: 'get',
-      path: '/_mocks/reset',
+      path: '/_msw/reset',
       handler: (_, res) => {
         debug('/_msw/reset called');
 


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
