### PR TITLE
Nested props

### DIFF
--- a/packages/bootstrap/__tests__/environmentalize.test.js
+++ b/packages/bootstrap/__tests__/environmentalize.test.js
@@ -1,0 +1,44 @@
+/* eslint-env node, jest */
+// eslint-disable-next-line node/no-missing-require
+const { environmentalize } = require('..').internal;
+
+test('Should allow env-vars in the configuration which are resolved', () => {
+  global._env = {
+    FOOBAR: 'TEST',
+  };
+
+  const res = environmentalize(
+    {
+      foo: {
+        bar: '[FOOBAR]',
+        baz: '[SECOND]',
+      },
+    },
+    { 'foo.bar': true }
+  );
+
+  delete global._env;
+  expect(res._env.FOOBAR).toBe('TEST');
+  expect(res._env.SECOND).toBe(undefined);
+});
+
+test('Should allow Object whitelisting', () => {
+  global._env = {
+    FOOBAR: 'TEST',
+    SECOND: 'BANANA',
+  };
+
+  const res = environmentalize(
+    {
+      foo: {
+        bar: '[FOOBAR]',
+        baz: '[SECOND]',
+      },
+    },
+    { foo: true }
+  );
+
+  delete global._env;
+  expect(res._env.FOOBAR).toBe('TEST');
+  expect(res._env.SECOND).toBe('BANANA');
+});

--- a/packages/bootstrap/__tests__/index.test.js
+++ b/packages/bootstrap/__tests__/index.test.js
@@ -93,11 +93,15 @@ test('Should allow placeholders in the configuration which are resolved', () => 
 test('Should allow env-vars in the configuration which are resolved', () => {
   process.env.HOPS_TEST_KEY = 'value';
   process.env.ENV_KEY_WITH_DEFAULT2 = 'value';
+  process.env.FOOBAR = 'TEST';
 
   const instance = initialize({
     result1: '[HOPS_TEST_KEY]',
     result2: '[ENV_KEY_WITH_DEFAULT1=default-value]',
     result3: '[ENV_KEY_WITH_DEFAULT2=default-value]',
+    result4: {
+      bar: '[FOOBAR]',
+    },
     mixins: [join(__dirname, 'fixtures', 'config-mixin')],
   });
 
@@ -106,6 +110,7 @@ test('Should allow env-vars in the configuration which are resolved', () => {
   expect(config.result1).toBe('value');
   expect(config.result2).toBe('default-value');
   expect(config.result3).toBe('value');
+  expect(config.result4.bar).toBe('TEST');
 });
 
 test('Should ignore non-string values when checking for placeholders', () => {

--- a/packages/bootstrap/lib/utils.js
+++ b/packages/bootstrap/lib/utils.js
@@ -118,7 +118,7 @@ exports.environmentalize = (_config, whitelist = {}) => {
     if (typeof item === 'string' && regExp.test(item)) {
       return item.replace(regExp, (_, key, fallback) => {
         const replaced = env[key] || fallback || '';
-        if (whitelist[path.join('.')]) {
+        if (whitelist[path.join('.')] || whitelist[path[0]]) {
           _env[key] = replaced;
         }
         return replaceRecursive(replaced);


### PR DESCRIPTION
This pull request closes issue #1156

## Current state

Whitelisting a full object does not work

## Changes introduced here

this PR fixes whitelisting in `browserWhitelist` to enable
whitelisting of full objects.

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [x] Necessary unit tests are added in order to ensure correct behavior
- [] Documentation has been added

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
