### PR TITLE
test(bootstrap): add more test-coverage

### DIFF
--- a/packages/bootstrap/__tests__/environmentalize.test.js
+++ b/packages/bootstrap/__tests__/environmentalize.test.js
@@ -42,3 +42,63 @@ test('Should allow Object whitelisting', () => {
   expect(res._env.FOOBAR).toBe('TEST');
   expect(res._env.SECOND).toBe('BANANA');
 });
+
+test('Should handle Arrays', () => {
+  global._env = {
+    FOOBAR: 'TEST',
+    SECOND: 'PINEAPPLE',
+  };
+
+  const res = environmentalize(
+    {
+      foo: [
+        {
+          bar: '[FOOBAR]',
+          baz: '[SECOND]',
+        },
+      ],
+    },
+    { foo: true }
+  );
+
+  delete global._env;
+  expect(res._env.FOOBAR).toBe('TEST');
+  expect(res._env.SECOND).toBe('PINEAPPLE');
+});
+
+test('Should support fallbacks', () => {
+  global._env = {};
+
+  const res = environmentalize(
+    {
+      foo: {
+        bar: '[FOOBAR=apple]',
+      },
+    },
+    { 'foo.bar': true }
+  );
+
+  delete global._env;
+  expect(res._env.FOOBAR).toBe('apple');
+  expect(res._env.SECOND).toBe(undefined);
+});
+
+test('Should ignore other props', () => {
+  global._env = {
+    FOOBAR: 'onion',
+    SECOND: 'cheese',
+  };
+
+  const res = environmentalize(
+    {
+      foo: {
+        bar: '[FOOBAR]',
+      },
+    },
+    { 'foo.bar': true }
+  );
+
+  delete global._env;
+  expect(res._env.FOOBAR).toBe('onion');
+  expect(res._env.SECOND).toBe(undefined);
+});


### PR DESCRIPTION
This PR improves test coverage and verifies and documents functionality provided by environmentalize

## Current state

missing tests for several features

## Changes introduced here

adds tests to cover features

## Checklist

- [x] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [x] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [x] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
