### PR TITLE
fix(msw): remove enableMockServiceWorker configuration option

### DIFF
--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -18,6 +18,8 @@ npm install --save hops-msw
 
 In order to use it for unit-testing, you also need to install the [`jest-preset-hops`](../jest-preset-hops/README.md) package.
 
+**Note:** Please be aware that only one service worker can exist per scope. Therefore `hops-msw` does not work together with `hops-pwa`.
+
 ### Usage
 
 Set the environment variable `ENABLE_MSW` to `true` when running your unit tests.

--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -20,6 +20,8 @@ In order to use it for unit-testing, you also need to install the [`jest-preset-
 
 ### Usage
 
+Set the environment variable `ENABLE_MSW` to `true` when running your unit tests.
+
 **Example:**
 
 ```javascript
@@ -60,8 +62,7 @@ See [here](../spec/integration/redux/__tests__/mocked.js) an example of how to w
 | Name | Type | Default | Required | Description |
 | --- | --- | --- | --- | --- |
 | mockServiceWorkerHandlersFile | `String` | `''` | _no_ | The path to your mock handlers file (which will be used during development) |
-| mockServiceWorkerUri | `String` | `/sw.js` | _no_ | The path on which the mock service worker will be served from |
-| enableMockServiceWorker | `String` | `[ENABLE_MSW]` | _no_ | Whether to enable mock-service-worker (defaults to the environment variable `ENABLE_MSW`) |
+| mockServiceWorkerUri | `String` | `<basePath>/sw.js` | _no_ | The path on which the mock service worker will be served from |
 
 ##### `mockServiceWorkerHandlersFile`
 
@@ -78,7 +79,3 @@ Use this option to register an [array of handlers](https://mswjs.io/docs/getting
 ##### `mockServiceWorkerUri`
 
 Usually this doesn't need to be changed.
-
-##### `enableMockServiceWorker`
-
-Usually this doesn't need to be changed, since its default is to use the environment variable `ENABLE_MSW`.

--- a/packages/msw/mixin.browser.js
+++ b/packages/msw/mixin.browser.js
@@ -34,9 +34,10 @@ const createBrowserMock = (
 
 class MswMixin extends Mixin {
   async bootstrap() {
-    const { mswWaitForBrowserMocks } = this.getServerData();
+    const { mswWaitForBrowserMocks, enableMockServiceWorker } =
+      this.getServerData();
 
-    if (this.config.enableMockServiceWorker !== 'true') {
+    if (enableMockServiceWorker !== true) {
       return;
     }
 

--- a/packages/msw/mixin.core.js
+++ b/packages/msw/mixin.core.js
@@ -63,6 +63,11 @@ module.exports = class MswMixin extends Mixin {
     mockServer.listen();
     process.on('SIGTERM', () => mockServer.close());
 
+    middlewares.initial.push((req, res, next) => {
+      res.locals.enableMockServiceWorker = true;
+      next();
+    });
+
     middlewares.files.push({
       path: this.config.mockServiceWorkerUri,
       handler: (_, res) => {

--- a/packages/msw/mixin.server.js
+++ b/packages/msw/mixin.server.js
@@ -6,17 +6,19 @@ import createDebug from 'hops-debug';
 const debug = createDebug('hops:msw:server');
 
 class MswMixin extends Mixin {
-  enhanceServerData(serverData, req) {
+  enhanceServerData(serverData, req, res) {
     debug(
       'cookie "mswWaitForBrowserMocks":',
       req.cookies.mswWaitForBrowserMocks
     );
 
     const { mswWaitForBrowserMocks = false } = req.cookies;
+    const { enableMockServiceWorker } = res.locals;
 
     return {
       ...serverData,
       mswWaitForBrowserMocks,
+      enableMockServiceWorker,
     };
   }
 }

--- a/packages/msw/preset.js
+++ b/packages/msw/preset.js
@@ -1,18 +1,12 @@
 module.exports = {
   mixins: [__dirname],
   mockServiceWorkerUri: '/sw.js',
-  enableMockServiceWorker: '[ENABLE_MSW]',
   mockServiceWorkerHandlersFile: '',
   browserWhitelist: {
     mockServiceWorkerUri: true,
-    enableMockServiceWorker: true,
   },
   configSchema: {
     mockServiceWorkerUri: { type: 'string' },
-    enableMockServiceWorker: {
-      type: 'string',
-      enum: ['true', ''],
-    },
     mockServiceWorkerHandlersFile: {
       type: 'string',
     },

--- a/packages/msw/preset.js
+++ b/packages/msw/preset.js
@@ -1,6 +1,6 @@
 module.exports = {
   mixins: [__dirname],
-  mockServiceWorkerUri: '/sw.js',
+  mockServiceWorkerUri: '<basePath>/sw.js',
   mockServiceWorkerHandlersFile: '',
   browserWhitelist: {
     mockServiceWorkerUri: true,


### PR DESCRIPTION
<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
