### PR TITLE
fix: exit Hops on unrecovrable webpack errors

### DIFF
--- a/packages/webpack/lib/middlewares/render.js
+++ b/packages/webpack/lib/middlewares/render.js
@@ -19,17 +19,25 @@ function createRenderMiddleware(buildConfigArgs, watch, mixin) {
   const enhancedPromise = new EnhancedPromise();
   let middleware;
 
-  compilation.subscribe(({ output }) => {
-    enhancedPromise.reset();
+  compilation.subscribe(
+    ({ output }) => {
+      enhancedPromise.reset();
 
-    if (middleware) {
-      process.emit('RELOAD');
-    } else {
-      middleware = loadRenderMiddleware(output);
+      if (middleware) {
+        process.emit('RELOAD');
+      } else {
+        middleware = loadRenderMiddleware(output);
+      }
+
+      enhancedPromise.resolve(middleware);
+    },
+    (error) => {
+      mixin.handleError(
+        error,
+        typeof error.recoverable === 'boolean' ? error.recoverable : true
+      );
     }
-
-    enhancedPromise.resolve(middleware);
-  });
+  );
 
   return function renderMiddleware(req, res, next) {
     enhancedPromise

--- a/packages/webpack/lib/utils/compiler.js
+++ b/packages/webpack/lib/utils/compiler.js
@@ -78,6 +78,21 @@ function forkCompilation(mixin, buildConfigArgs, options = {}) {
   });
 
   return new Observable((subscriber) => {
+    child.on('error', (error) => {
+      error.recoverable = false;
+      subscriber.error(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      if (code !== 0) {
+        const error = new Error(
+          `Webpack child compiler exited with code: ${code} and signal: ${signal}`
+        );
+        error.recoverable = false;
+        subscriber.error(error);
+      }
+    });
+
     child.on('message', ({ type, data, reason }) => {
       if (type === 'reject') {
         subscriber.error(

--- a/packages/yargs/mixin.core.js
+++ b/packages/yargs/mixin.core.js
@@ -15,7 +15,7 @@ const sequenceWithReturn = (functions, arg, ...args) => {
 const overrideHandleError = (functions, error, recoverable) => {
   override(functions, error, recoverable);
 
-  if (!recoverable) {
+  if (recoverable !== true) {
     process.exit(1);
   }
 };


### PR DESCRIPTION
This commit fixes the global Hops error handler `handleError`, which
should exit the process, when the second arugment is `false`.
Unfortunately when a `truthy` value is passed it doesn't exit, so now
we strictly check for the value `true`.

We also catch errors of the forked webpack compiler and exit the main
process when they are not recoverable.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
