### PR TITLE
Fs logging

### DIFF
--- a/packages/styled-components/mixin.core.js
+++ b/packages/styled-components/mixin.core.js
@@ -5,9 +5,11 @@ class StyledComponentsMixin extends Mixin {
     const { experimentalEsbuild } = this.options;
 
     if (experimentalEsbuild) {
-      console.warn(
-        'The experimental esbuild transpilation does not support styled components yet!'
-      );
+      if (typeof this.getLogger === 'function') {
+        this.getLogger().warn(
+          'The experimental esbuild transpilation does not support styled components yet!'
+        );
+      }
       return;
     }
 

--- a/packages/yargs/mixin.core.js
+++ b/packages/yargs/mixin.core.js
@@ -22,8 +22,12 @@ const overrideHandleError = (functions, error, recoverable) => {
 
 class YargsMixin extends Mixin {
   handleError(error) {
-    // eslint-disable-next-line no-console
-    console.error(error.stack || error);
+    if (typeof this.getLogger === 'function') {
+      // eslint-disable-next-line no-console
+      this.getLogger().error(error.stack || error);
+    } else {
+      console.error(error.stack || error);
+    }
   }
 }
 


### PR DESCRIPTION
This commit enables a filesystem based logging, which can be enabled by
setting the environment variable `HOPS_LOG_LOCATION` to a writable
directory (for example `HOPS_LOG_LOCATION=$(pwd)`).
If the directory is writable by the current user Hops will write all log
messages into a `hops-log.txt` in that directory.
This is useful in cases the stdout/stderr logs are not accessible,
for example when running with docker-compose on a CI server.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
