### PR TITLE
fix: use NamedModuleIdsPlugin for production

### DIFF
--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -4,7 +4,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const { join, trimSlashes } = require('pathifist');
 const getModules = require('../utils/modules');
 
-const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
+const { NamedModuleIdsPlugin } = ids;
 
 module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
@@ -147,7 +147,7 @@ module.exports = function getConfig(config, name, buildDependencies) {
       concatenateModules: true,
     },
     plugins: [
-      new (isProduction ? HashedModuleIdsPlugin : NamedModuleIdsPlugin)(),
+      new NamedModuleIdsPlugin(),
       // Needed for bootstrap/lib/utils#environmentalize, which falls
       // back to `process.env` if there's no global variable `_env`
       new DefinePlugin({ 'process.env': JSON.stringify({}) }),

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -9,7 +9,7 @@ const { join, trimSlashes } = require('pathifist');
 const getModules = require('../utils/modules');
 
 const { LimitChunkCountPlugin } = optimize;
-const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
+const { NamedModuleIdsPlugin } = ids;
 
 module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
@@ -159,7 +159,7 @@ module.exports = function getConfig(config, name, buildDependencies) {
     },
     plugins: [
       new LimitChunkCountPlugin({ maxChunks: 1 }),
-      new (isProduction ? HashedModuleIdsPlugin : NamedModuleIdsPlugin)(),
+      new NamedModuleIdsPlugin(),
       isProduction ? { apply: () => {} } : new HotModuleReplacementPlugin(),
       new EnvironmentPlugin({ NODE_ENV: 'development' }),
     ],


### PR DESCRIPTION
this fixes an issue with webpack 5, where computed hash values
do not work any more with `importComponents`.

this fix is meant as a temporary fix, which can get removed after
we found the root cause in webpack 5.

This pull request closes issue # (_put the issue number here_)

<!-- This is a template. Feel free to remove the parts you do not need! Start with this line, for example -->

## Current state

<!-- explanation of the current state -->

## Changes introduced here

<!-- explanation of the changes you did in this pull request -->

## Checklist

- [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [ ] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
