### PR TITLE
chore: disable Node.js v15 tests

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,7 +16,7 @@ jobs:
       HOST: 0.0.0.0
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,6 @@
 status = [
   "tests (12.x)",
   "tests (14.x)",
-  "tests (15.x)",
   "canarist/internal-hops",
   "canarist/internal-workshop",
 ]


### PR DESCRIPTION
Transitive dependencies (namely `@npmcli/fs`) dropped support for
Node.js v15, which means Hops can't be used with Hops 15 anymore.
We could potentially downgrade the `terser-webpack-plugin`, but we
decided against that, because we don't want to remove features in Hops
just because it stopped working with an unmaintained non-lts version.


<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
