### PR TITLE
fix(webpack): print file name and location in webpack warnings

### DIFF
--- a/packages/webpack/lib/plugins/log.js
+++ b/packages/webpack/lib/plugins/log.js
@@ -132,9 +132,12 @@ exports.LoggerPlugin = class LoggerPlugin {
             return acc;
           }, [])
           .forEach((error) => this.logger.error(error));
+
         warnings
           .concat(...children.map((c) => c.warnings))
-          .forEach(({ message: warning }) => this.logger.warn(warning));
+          .forEach(({ message: warning, moduleName, loc }) => {
+            this.logger.warn(warning, chalk.gray(`(${moduleName}:${loc})`));
+          });
       }
 
       this.lastHashes[name] = hash;


### PR DESCRIPTION
Example:
```
hops-demo:warning Should not import the named export 'config' (imported as 'config') from default-exporting module (only default export is available soon) (../../../../node_modules/something/main.js:8:4-10)
hops-demo:warning Critical dependency: the request of a dependency is an expression (./src/main.js:36:0-12)
```

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
