### PR TITLE
fix(webpack): externalize server source-map to prevent RangeError

### DIFF
--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -169,7 +169,7 @@ module.exports = function getConfig(config, name, buildDependencies) {
       maxEntrypointSize: 52428800,
       maxAssetSize: 52428800,
     },
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
     watchOptions: { aggregateTimeout: 300, ignored: /node_modules/ },
   };
 };

--- a/packages/webpack/lib/utils/compiler.js
+++ b/packages/webpack/lib/utils/compiler.js
@@ -21,7 +21,7 @@ function startCompilation(webpackConfig, options = {}) {
   const compiler = createCompiler(webpackConfig);
   const output = join(webpackConfig.output.path, webpackConfig.output.filename);
 
-  sourceMapSupport.install({ environment: 'node', hookRequire: true });
+  sourceMapSupport.install({ environment: 'node' });
 
   return new Observable((subscriber) => {
     const callback = (error, stats) => {


### PR DESCRIPTION
For some reason we see intermittent failures with the source-map-support
package (examples: https://github.com/evanw/node-source-map-support/issues/252
and https://github.com/evanw/node-source-map-support/issues/93).
The fix that worked for us seems to be to externalize the source-map.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
