### PR TITLE
Fix `importComponent`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         ],
         "rootManifest": {
           "resolutions": {
+            "@babel/core": "7.15.0",
             "colors": "1.4.0",
             "graphql-tag": "^2.12"
           }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
           },
           {
             "url": "enc:r6BTklZr+axySHpOBj0JysOusV4S8o7YtSxZ9fi66rL5grn3vMkHUbMdb3OY5+tv",
-            "directory": "internal-hops"
+            "directory": "internal-hops",
+            "branch": "wait-for-compilation"
           }
         ],
         "rootManifest": {

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "@commitlint/cli": "^13.0.0",
     "@commitlint/config-conventional": "^13.0.0",
     "@commitlint/config-lerna-scopes": "^13.0.0",
-    "canarist": "^2.3.1",
+    "canarist": "^2.3.2",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/jest-environment/helpers.js
+++ b/packages/jest-environment/helpers.js
@@ -45,8 +45,11 @@ const build = ({ cwd, env = {}, argv = [] }) =>
 const startServer = ({ cwd, command, env = {}, argv = [] }) => {
   const teardownPromise = new EProm();
   const urlPromise = new EProm();
+
   let stdout = '';
   let stderr = '';
+  const success1 = "bundling 'develop' finished";
+  const success2 = "bundling 'node' finished";
 
   const hopsBin = resolveFrom(cwd, 'hops/bin');
   const args = [hopsBin, command].concat(argv);
@@ -61,6 +64,7 @@ const startServer = ({ cwd, command, env = {}, argv = [] }) => {
     return teardownPromise;
   };
 
+  let serverUrl = '';
   started.stdout.on('data', (data) => {
     const line = data.toString('utf-8');
     debug('stdout >', line);
@@ -68,8 +72,12 @@ const startServer = ({ cwd, command, env = {}, argv = [] }) => {
 
     const [, url] = line.match(/listening at (.*)/i) || [];
     if (url) {
+      serverUrl = url;
       debug('found match:', url);
-      urlPromise.resolve(url);
+    }
+
+    if (stdout.includes(success1) && stdout.includes(success2) && serverUrl) {
+      urlPromise.resolve(serverUrl);
     }
   });
 

--- a/packages/jest-environment/helpers.js
+++ b/packages/jest-environment/helpers.js
@@ -86,6 +86,12 @@ const startServer = ({ cwd, command, env = {}, argv = [] }) => {
     ) {
       hasFinishedPromise.resolve();
     }
+
+    if (line.match(/bundling [^ ]+ failed/)) {
+      setTimeout(() => {
+        hasFinishedPromise.reject({ stdout, stderr });
+      }, 5000);
+    }
   });
 
   started.stderr.on('data', (data) => {

--- a/packages/jest-environment/index.js
+++ b/packages/jest-environment/index.js
@@ -112,7 +112,11 @@ class FixtureEnvironment extends NodeEnvironment {
           );
         }
         const { env, argv } = getHopsCommandModifications(args);
-        const { getUrl, stopServer: killServer } = startServer({
+        const {
+          getUrl,
+          stopServer: killServer,
+          hasFinished,
+        } = startServer({
           cwd: that.cwd,
           command: 'start',
           env,
@@ -124,7 +128,7 @@ class FixtureEnvironment extends NodeEnvironment {
           delete that.killServer;
           return killServer();
         };
-        return { getUrl, stopServer };
+        return { getUrl, stopServer, hasFinished };
       },
     };
   }

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-syntax-jsx": "^7.8.3",
     "@babel/plugin-transform-flow-strip-types": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",

--- a/packages/jest-preset/transforms/esbuild.js
+++ b/packages/jest-preset/transforms/esbuild.js
@@ -1,17 +1,27 @@
 // eslint-disable-next-line node/no-extraneous-require
 const { createTransformer } = require('esbuild-jest');
+const { transformSync } = require('@babel/core');
 
 const transformer = createTransformer({
   sourcemap: true,
 });
 
+const regex = /importComponent/g;
+
 module.exports = {
   process(content, filename, config, opts) {
-    content = content.replace(
-      /importComponent\s*\(\s*\(\)\s+=>\s+import\(\s*'([^']+)'\s*\)\s*\)/g,
-      "importComponent({ component: require('$1') })"
-    );
+    if (!regex.test(content)) {
+      return transformer.process(content, filename, config, opts);
+    }
 
-    return transformer.process(content, filename, config, opts);
+    const result = transformSync(content, {
+      plugins: [
+        require.resolve('../helpers/babel-plugin-import-component'),
+        require.resolve('@babel/plugin-syntax-jsx'),
+      ],
+      filename,
+    });
+
+    return transformer.process(result.code, filename, config, opts);
   },
 };

--- a/packages/react/import-component/babel.js
+++ b/packages/react/import-component/babel.js
@@ -1,8 +1,49 @@
 'use strict';
 
+const nodePath = require('path');
+const crypto = require('crypto');
+
+/**
+ * This plugin transforms the following function call:
+ * ```javascript
+ * importComponent(() => import('./component'));
+ * ```
+ *
+ * Into the following:
+ *
+ * ```javascript
+ * importComponent({
+ *  load: () => import('./component'),
+ *  moduleId: require.resolveWeak('./component'),
+ *  chunkName: () => 'hash'
+ * })
+ * ```
+ */
+
+const regex = /webpackChunkName:\s*(?:(['"])([^'"]*)\1|([^\s]*))/;
+
+function extractChunkName(t, leadingComments) {
+  if (!leadingComments || !Array.isArray(leadingComments)) {
+    return;
+  }
+
+  const comment = leadingComments.find((comment) =>
+    comment.value.includes('webpackChunkName')
+  );
+
+  if (!comment) {
+    return;
+  }
+
+  const results = comment.value.match(regex);
+  const cleanChunkName = results[2] || results[3];
+
+  return cleanChunkName;
+}
+
 module.exports = ({ types: t }) => ({
   visitor: {
-    ImportDeclaration(path) {
+    ImportDeclaration(path, state) {
       const modules = ['hops-react', this.opts.module];
       const source = path.node.source.value;
       if (!modules.includes(source)) return;
@@ -31,10 +72,24 @@ module.exports = ({ types: t }) => ({
         t.assertCallExpression(argument.get('body'));
         t.assertImport(argument.get('body.callee'));
 
-        const { node } = argument.get('body.arguments.0');
-        const importedComponent = node.value;
-        const leadingComments = node.leadingComments;
+        const argPath = argument.get('body.arguments.0');
+        const importedComponent = argPath.node.value;
         const resourcePathNode = t.stringLiteral(importedComponent);
+
+        let chunkName = extractChunkName(t, argPath.node.leadingComments);
+        if (!chunkName) {
+          const hasher = crypto.createHash('md4');
+          hasher.update(nodePath.relative(this.opts.rootDir, state.filename));
+          hasher.update(importedComponent);
+          const hash = hasher.digest('base64').slice(0, 4);
+
+          t.addComment(
+            argPath.node,
+            'leading',
+            ` webpackChunkName: '${hash}' `
+          );
+          chunkName = hash;
+        }
 
         argument.replaceWith(
           t.objectExpression([
@@ -43,7 +98,11 @@ module.exports = ({ types: t }) => ({
               t.arrowFunctionExpression(
                 [],
                 t.callExpression(t.identifier('import'), [
-                  t.addComments(resourcePathNode, 'leading', leadingComments),
+                  t.addComments(
+                    resourcePathNode,
+                    'leading',
+                    argPath.node.leadingComments
+                  ),
                 ])
               )
             ),
@@ -56,6 +115,10 @@ module.exports = ({ types: t }) => ({
                 ),
                 [resourcePathNode]
               )
+            ),
+            t.objectProperty(
+              t.identifier('chunkName'),
+              t.arrowFunctionExpression([], t.stringLiteral(chunkName))
             ),
           ])
         );

--- a/packages/react/import-component/index.js
+++ b/packages/react/import-component/index.js
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import ImportComponentContext from './context';
 
 export const importComponent = (
-  { load, moduleId },
+  { load, moduleId, chunkName },
   resolve = (module) => module.default
 ) => {
   class Importer extends Component {
-    constructor({ hasModules }) {
+    constructor() {
       super();
-      if (hasModules || __webpack_modules__[moduleId]) {
+      if (__webpack_modules__[moduleId]) {
         this.state = { Component: resolve(__webpack_require__(moduleId)) };
       } else {
         this.state = { loading: true };
@@ -57,21 +57,19 @@ export const importComponent = (
   }
 
   Importer.propTypes = {
-    hasModules: PropTypes.bool,
     ownProps: PropTypes.object.isRequired,
     loader: PropTypes.func,
     render: PropTypes.func,
   };
 
   function Import({ loader, render, ...ownProps }) {
-    const modules = useContext(ImportComponentContext);
+    const chunks = useContext(ImportComponentContext);
 
-    if (modules) {
-      modules.push(moduleId);
+    if (chunks) {
+      chunks.push(chunkName());
     }
 
     return createElement(Importer, {
-      hasModules: Boolean(modules && modules.length > 0),
       loader,
       render,
       ownProps,

--- a/packages/react/import-component/mixin.core.js
+++ b/packages/react/import-component/mixin.core.js
@@ -5,7 +5,10 @@ class ImportComponentCoreMixin extends Mixin {
     const { experimentalEsbuild } = this.options;
 
     if (experimentalEsbuild) {
-      jsLoaderConfig.use.push(require.resolve('./import-component-loader.js'));
+      jsLoaderConfig.use.push({
+        loader: require.resolve('./import-component-loader.js'),
+        options: { module: 'hops', rootDir: this.config.rootDir },
+      });
     } else {
       jsLoaderConfig.options.plugins.push([
         require.resolve('../lib/babel'),

--- a/packages/react/import-component/mixin.core.js
+++ b/packages/react/import-component/mixin.core.js
@@ -9,7 +9,7 @@ class ImportComponentCoreMixin extends Mixin {
     } else {
       jsLoaderConfig.options.plugins.push([
         require.resolve('../lib/babel'),
-        { module: 'hops' },
+        { module: 'hops', rootDir: this.config.rootDir },
       ]);
     }
   }

--- a/packages/react/import-component/mixin.runtime.js
+++ b/packages/react/import-component/mixin.runtime.js
@@ -5,12 +5,12 @@ import { Provider } from './context';
 class ImportComponentMixin extends Mixin {
   bootstrap(_req, res) {
     if (res) {
-      res.locals.modules = this.modules = [];
+      res.locals.chunks = this.chunks = [];
     }
   }
 
   enhanceElement(element) {
-    return createElement(Provider, { value: this.modules }, element);
+    return createElement(Provider, { value: this.chunks }, element);
   }
 }
 

--- a/packages/react/lib/assets.js
+++ b/packages/react/lib/assets.js
@@ -1,15 +1,19 @@
 'use strict';
 
 import { extname } from 'path';
+import { ensureLeadingSlash } from 'pathifist';
 
-export default (stats, modules) => {
-  const { entryFiles, vendorFiles, moduleFileMap } = stats;
-  const moduleFiles = modules.reduce(
-    (result, module) => [...result, ...moduleFileMap[module]],
-    []
-  );
+export default (stats, chunks) => {
+  const { entryFiles, vendorFiles } = stats;
+  const chunkFiles = chunks.reduce((result, chunk) => {
+    const chunkGroup = stats.namedChunkGroups[chunk];
+    const assets = chunkGroup.assets.map((asset) =>
+      ensureLeadingSlash(asset.name)
+    );
+    return [...result, ...assets];
+  }, []);
 
-  return [...vendorFiles, ...moduleFiles, ...entryFiles]
+  return [...vendorFiles, ...chunkFiles, ...entryFiles]
     .filter(
       (asset, index, self) =>
         self.indexOf(asset) === index &&

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-syntax-jsx": "^7.8.3",
     "@babel/plugin-transform-flow-strip-types": "^7.9.0",
     "@babel/preset-react": "^7.9.4",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",

--- a/packages/react/render/mixin.server.js
+++ b/packages/react/render/mixin.server.js
@@ -27,8 +27,8 @@ class ReactMixin extends Mixin {
     return renderToFragments(element);
   }
 
-  renderTemplate(fragments, { modules }) {
-    const assets = getAssets(this.stats, modules);
+  renderTemplate(fragments, { chunks }) {
+    const assets = getAssets(this.stats, chunks);
     const resourceHints = getResourceHints(this.stats);
     const globals = { _env: this.config._env };
 
@@ -70,9 +70,9 @@ class ReactMixin extends Mixin {
           } else {
             res.status(router.status || 200);
 
-            // note: res.locals.modules is set by the ImportComponentMixin
+            // note: res.locals.chunks is set by the ImportComponentMixin
             return this.renderTemplate(fragments, {
-              modules: res.locals.modules,
+              chunks: res.locals.chunks,
             }).then((page) => res.send(page));
           }
         }

--- a/packages/spec/integration/development-proxy/__tests__/object-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/object-config.js
@@ -25,8 +25,12 @@ describe('development proxy object config', () => {
     };
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('proxies with proxy config set as object', async () => {

--- a/packages/spec/integration/development-proxy/__tests__/string-config.js
+++ b/packages/spec/integration/development-proxy/__tests__/string-config.js
@@ -19,8 +19,12 @@ describe('development proxy string config', () => {
     packageJson.hops.proxy = `http://localhost:${PORT}/proxy`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('proxies with proxy config set as string', async () => {

--- a/packages/spec/integration/esbuild-typescript/__tests__/develop.js
+++ b/packages/spec/integration/esbuild-typescript/__tests__/develop.js
@@ -4,8 +4,15 @@ describe('typescript development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev', '--experimental-esbuild');
+    const { getUrl, hasFinished } = HopsCLI.start(
+      '--fast-dev',
+      '--experimental-esbuild'
+    );
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('renders a simple jsx site', async () => {

--- a/packages/spec/integration/esbuild/__tests__/develop.js
+++ b/packages/spec/integration/esbuild/__tests__/develop.js
@@ -4,8 +4,15 @@ describe('esbuild - develop', () => {
   let url, page, getInnerText;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev', '--experimental-esbuild');
+    const { getUrl, hasFinished } = HopsCLI.start(
+      '--fast-dev',
+      '--experimental-esbuild'
+    );
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
     const pptr = await createPage();
     page = pptr.page;
     getInnerText = pptr.getInnerText;

--- a/packages/spec/integration/fast-refresh/__tests__/develop.js
+++ b/packages/spec/integration/fast-refresh/__tests__/develop.js
@@ -16,8 +16,15 @@ describe('react fast refresh', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev', '--fast-refresh');
+    const { getUrl, hasFinished } = HopsCLI.start(
+      '--fast-dev',
+      '--fast-refresh'
+    );
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('renders caption only once', async () => {

--- a/packages/spec/integration/graphql-apollo3/__tests__/develop.js
+++ b/packages/spec/integration/graphql-apollo3/__tests__/develop.js
@@ -8,8 +8,12 @@ describe('graphql development client', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   describe('/invalid-response (HTML)', () => {

--- a/packages/spec/integration/graphql-mock-server/__tests__/develop.js
+++ b/packages/spec/integration/graphql-mock-server/__tests__/develop.js
@@ -4,8 +4,13 @@ describe('graphql mock server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'graphql-mock-server' finished",
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('renders a mocked quote', async () => {

--- a/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
+++ b/packages/spec/integration/graphql-no-ssr/__tests__/develop.js
@@ -4,8 +4,13 @@ describe('graphql mock server without SSR', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'graphql-mock-server' finished",
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('requests data on the client & not on the server', async () => {

--- a/packages/spec/integration/hot-module-reload/__tests__/develop.js
+++ b/packages/spec/integration/hot-module-reload/__tests__/develop.js
@@ -19,8 +19,12 @@ describe.skip('hot module reload', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('reflects changes automatically', async () => {

--- a/packages/spec/integration/postcss/__tests__/develop.js
+++ b/packages/spec/integration/postcss/__tests__/develop.js
@@ -4,8 +4,12 @@ describe('react-postcss', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('styles when served in development mode', async () => {

--- a/packages/spec/integration/pwa/__tests__/build.js
+++ b/packages/spec/integration/pwa/__tests__/build.js
@@ -34,7 +34,7 @@ describe('pwa production build', () => {
     // all responses should now come from the service worker
     expect(
       Array.from(requests.values()).map((r) => r.response().fromServiceWorker())
-    ).toEqual([true, true, true]);
+    ).toEqual([true, true]);
 
     await page.close();
   });

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -117,9 +117,9 @@ describe('react development server', () => {
     const preloadAs = await getProperty('as', 'link[rel="preload"]');
     const prefetchHref = await getProperty('href', 'link[rel="prefetch"]');
 
-    expect(preloadHref).toMatch(/\/fixture-react-[0-9].js$/);
+    expect(preloadHref).toMatch(/\/fixture-react-[^.]+.js$/);
     expect(preloadAs).toBe('script');
-    expect(prefetchHref).toMatch(/\/fixture-react-[0-9].js$/);
+    expect(prefetchHref).toMatch(/\/fixture-react-[^.]+.js$/);
 
     await page.close();
   });

--- a/packages/spec/integration/react/__tests__/develop.js
+++ b/packages/spec/integration/react/__tests__/develop.js
@@ -6,8 +6,12 @@ describe('react development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('renders home', async () => {

--- a/packages/spec/integration/redux-without-ssr/__tests__/develop.js
+++ b/packages/spec/integration/redux-without-ssr/__tests__/develop.js
@@ -4,8 +4,12 @@ describe('redux development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('increments the counter on page load', async () => {

--- a/packages/spec/integration/redux/__tests__/develop.js
+++ b/packages/spec/integration/redux/__tests__/develop.js
@@ -5,13 +5,17 @@ describe('redux development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start(
+    const { getUrl, hasFinished } = HopsCLI.start(
       {
         PORT: '8950',
       },
       '--fast-dev'
     );
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('has default state', async () => {

--- a/packages/spec/integration/redux/__tests__/mocked.js
+++ b/packages/spec/integration/redux/__tests__/mocked.js
@@ -97,7 +97,7 @@ describe('development server with msw mocks', () => {
 
       page.on('console', (msg) => handleConsoleOutput(msg));
 
-      registerServerMocks(
+      await registerServerMocks(
         page,
         baseUrl,
         mockGetRequest(new URL('/api', baseUrl).toString(), { value: 5 })

--- a/packages/spec/integration/redux/__tests__/mocked.js
+++ b/packages/spec/integration/redux/__tests__/mocked.js
@@ -70,7 +70,7 @@ describe('development server with msw mocks', () => {
   let baseUrl;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start(
+    const { getUrl, hasFinished } = HopsCLI.start(
       {
         ENABLE_MSW: 'true',
         PORT: '8949',
@@ -78,6 +78,10 @@ describe('development server with msw mocks', () => {
       '--fast-dev'
     );
     baseUrl = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   describe('Adding up to 12', () => {

--- a/packages/spec/integration/styled-components/__tests__/develop.js
+++ b/packages/spec/integration/styled-components/__tests__/develop.js
@@ -4,8 +4,12 @@ describe('styled-components development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('allows to use styled components', async () => {

--- a/packages/spec/integration/typescript-styled-components/__tests__/develop.js
+++ b/packages/spec/integration/typescript-styled-components/__tests__/develop.js
@@ -4,8 +4,12 @@ describe('typescript-styled-components development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('allows to use the css-props', async () => {

--- a/packages/spec/integration/typescript/__tests__/develop.js
+++ b/packages/spec/integration/typescript/__tests__/develop.js
@@ -4,8 +4,12 @@ describe('typescript development server', () => {
   let url;
 
   beforeAll(async () => {
-    const { getUrl } = HopsCLI.start('--fast-dev');
+    const { getUrl, hasFinished } = HopsCLI.start('--fast-dev');
     url = await getUrl();
+    await hasFinished([
+      "bundling 'develop' finished",
+      "bundling 'node' finished",
+    ]);
   });
 
   it('renders a simple jsx site', async () => {

--- a/packages/webpack/lib/configs/build.js
+++ b/packages/webpack/lib/configs/build.js
@@ -1,10 +1,8 @@
 const { dirname, relative } = require('path');
-const { EnvironmentPlugin, DefinePlugin, ids } = require('webpack');
+const { EnvironmentPlugin, DefinePlugin } = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const { join, trimSlashes } = require('pathifist');
 const getModules = require('../utils/modules');
-
-const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
 
 module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
@@ -131,9 +129,6 @@ module.exports = function getConfig(config, name, buildDependencies) {
     },
     externals: [],
     optimization: {
-      splitChunks: {
-        chunks: 'all',
-      },
       minimizer: [
         new TerserPlugin({
           extractComments: false,
@@ -142,12 +137,8 @@ module.exports = function getConfig(config, name, buildDependencies) {
           },
         }),
       ],
-      chunkIds: 'natural',
-      usedExports: false,
-      concatenateModules: true,
     },
     plugins: [
-      new (isProduction ? HashedModuleIdsPlugin : NamedModuleIdsPlugin)(),
       // Needed for bootstrap/lib/utils#environmentalize, which falls
       // back to `process.env` if there's no global variable `_env`
       new DefinePlugin({ 'process.env': JSON.stringify({}) }),

--- a/packages/webpack/lib/configs/develop.js
+++ b/packages/webpack/lib/configs/develop.js
@@ -129,11 +129,7 @@ module.exports = function getConfig(config, name, buildDependencies) {
       rules: [{ oneOf: allLoaderConfigs }],
     },
     externals: [],
-    optimization: {
-      splitChunks: { chunks: 'all' },
-      moduleIds: 'named',
-      chunkIds: 'natural',
-    },
+    optimization: {},
     plugins: [
       // Needed for bootstrap/lib/utils#environmentalize, which falls
       // back to `process.env` if there's no global variable `_env`

--- a/packages/webpack/lib/configs/node.js
+++ b/packages/webpack/lib/configs/node.js
@@ -3,13 +3,11 @@ const {
   EnvironmentPlugin,
   HotModuleReplacementPlugin,
   optimize,
-  ids,
 } = require('webpack');
 const { join, trimSlashes } = require('pathifist');
 const getModules = require('../utils/modules');
 
 const { LimitChunkCountPlugin } = optimize;
-const { HashedModuleIdsPlugin, NamedModuleIdsPlugin } = ids;
 
 module.exports = function getConfig(config, name, buildDependencies) {
   const getAssetPath = (...arg) => trimSlashes(join(config.assetPath, ...arg));
@@ -155,12 +153,9 @@ module.exports = function getConfig(config, name, buildDependencies) {
     externals: [],
     optimization: {
       minimizer: [],
-      chunkIds: 'natural',
-      usedExports: false,
     },
     plugins: [
       new LimitChunkCountPlugin({ maxChunks: 1 }),
-      new (isProduction ? HashedModuleIdsPlugin : NamedModuleIdsPlugin)(),
       isProduction ? { apply: () => {} } : new HotModuleReplacementPlugin(),
       new EnvironmentPlugin({ NODE_ENV: 'development' }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,7 +527,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.16.7":
+"@babel/plugin-syntax-jsx@^7.16.7", "@babel/plugin-syntax-jsx@^7.8.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
   integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4260,15 +4260,15 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-canarist@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/canarist/-/canarist-2.3.1.tgz#8b1359a2e6b8a923b2d9c9ad25e27d940a2a0e8c"
-  integrity sha512-fsg/eADtK/6qiq0l+7ngfhsLPK5A6Jli7RzuyULjgAxhzhsBTyPZfRzoMEKFptJvsfU12AM1wKe6hhHMmaZmcw==
+canarist@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/canarist/-/canarist-2.3.2.tgz#755fe4591e9b6f3850a04d45e6b685e32243a781"
+  integrity sha512-swO6SWkVv2LhP6NI8r+MQuKz1q8YHE21MtnawfpOUQhyFlYJh42807oSErJpevq9wsLew5ejGHJTDOELSm11xQ==
   dependencies:
-    cosmiconfig "^7.0.0"
-    debug "^4.1.1"
-    fast-glob "^3.2.2"
-    git-url-parse "^11.1.2"
+    cosmiconfig "^7.0.1"
+    debug "^4.3.3"
+    fast-glob "^3.2.11"
+    git-url-parse "^11.6.0"
     lodash.mergewith "^4.6.2"
     minimist "^1.2.5"
     rimraf "^3.0.2"
@@ -4868,7 +4868,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
@@ -5209,10 +5209,10 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -6147,10 +6147,10 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.1.1, fast-glob@^3.2.2:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+fast-glob@^3.1.1, fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6609,10 +6609,10 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^6.0.0"
 
-git-url-parse@^11.1.2, git-url-parse@^11.4.4:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.5.0.tgz#acaaf65239cb1536185b19165a24bbc754b3f764"
-  integrity sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==
+git-url-parse@^11.4.4, git-url-parse@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
 


### PR DESCRIPTION
Ref: https://github.com/xing/hops/pull/1632, https://github.com/xing/hops/pull/1976

Todo:
- [x] What happens if we import the same file from different files? I suspect our babel plugin will generate different chunk names which should in fact not be different. So maybe our hash should not include the filepath of the importing component but only the filepath of the imported component.
  - seems to create separate entries in the `namedChunkGroups` which point to the same asset.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
