### PR TITLE
fix(react): replace invalid characters in chunk name

### DIFF
--- a/packages/react/import-component/babel.js
+++ b/packages/react/import-component/babel.js
@@ -81,7 +81,12 @@ module.exports = ({ types: t }) => ({
           const hasher = crypto.createHash('md4');
           hasher.update(nodePath.relative(this.opts.rootDir, state.filename));
           hasher.update(importedComponent);
-          const hash = hasher.digest('base64').slice(0, 4);
+          const hash = hasher
+            .digest('base64')
+            .replace('/', '-')
+            .replace('+', '_')
+            .replace('=', '')
+            .slice(0, 4);
 
           t.addComment(
             argPath.node,


### PR DESCRIPTION
We're using base64 to generate short chunk names, unfortunately this
means that we need to replace some characters which are invalid
characters in file names.
We replace `/` with `-`, `+` with `_` and `=` with an empty string.
Replacing `=` with an empty string shouldn't occur in real life,
because we're only using the first four characters.

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
