### PR TITLE
feat(express): make helmet headers configurable

### DIFF
--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -35,6 +35,7 @@ You may use either `hops serve -p` or its equivalent `NODE_ENV=production hops s
 | `port` | `String` | `[PORT]` | _no_ | Specify the Port that Hops should listen on |
 | `distDir` | `String` | `'<rootDir>/dist'` | _no_ | The folder from which to serve static assets |
 | `gracePeriod` | `number` | `30000` | _no_ | Time to wait (in ms) until killing the server |
+| `helmetConfig` | `Object` | `{}` | _no_ | Headers to set or overwrite in helmet |
 
 ##### `https`
 
@@ -90,6 +91,10 @@ The amount of time (in milliseconds) to wait after receiving a [`SIGTERM`](https
   "gracePeriod": 60000
 }
 ```
+
+##### `helmetConfig`
+
+The config to set security http headers via [helmet](https://helmetjs.github.io/).
 
 #### Render Options
 

--- a/packages/express/mixins/mixin.core.js
+++ b/packages/express/mixins/mixin.core.js
@@ -37,9 +37,9 @@ class ExpressMixin extends Mixin {
     const express = require('express');
     const mime = require('mime');
     const cookieParser = require('cookie-parser');
-    const { distDir } = this.config;
+    const { distDir, helmetConfig = {} } = this.config;
     middlewares.preinitial.push(
-      helmet({ contentSecurityPolicy: false }),
+      helmet({ contentSecurityPolicy: false, ...helmetConfig }),
       cookieParser()
     );
     middlewares.files.push(

--- a/packages/express/preset.js
+++ b/packages/express/preset.js
@@ -26,5 +26,8 @@ module.exports = {
     port: { oneOf: [{ type: 'string' }, { type: 'number' }] },
     distDir: { type: 'string', minLength: 1, absolutePath: true },
     gracePeriod: { type: 'number' },
+    helmetConfig: {
+      type: 'object',
+    },
   },
 };


### PR DESCRIPTION
this PR makes the sent security headers by hops via helmet
configurable, so that projects that use directly hops as a
"front-facing-server" can set their custom headers.

This pull request closes issue # (_put the issue number here_)

<!-- This is a template. Feel free to remove the parts you do not need! Start with this line, for example -->

## Current state

<!-- explanation of the current state -->

## Changes introduced here

<!-- explanation of the changes you did in this pull request -->

## Checklist

- [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [ ] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
