### PR TITLE
fix(msw): create tmp folder on mkdtempSync failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
           "resolutions": {
             "@babel/core": "7.15.0",
             "colors": "1.4.0",
-            "graphql-tag": "^2.12"
+            "graphql-tag": "^2.12",
+            "event-source-polyfill": "1.0.25"
           }
         }
       }

--- a/packages/msw/mixin.core.js
+++ b/packages/msw/mixin.core.js
@@ -11,12 +11,18 @@ function exists(path) {
 }
 
 const getMockServiceWorkerContent = () => {
-  const { mkdtempSync, readFileSync } = require('fs');
+  const { mkdtempSync, readFileSync, mkdirSync } = require('fs');
   const { tmpdir } = require('os');
   const { join } = require('path');
   const { sync: execa } = require('execa');
+  let dir;
 
-  const dir = mkdtempSync(join(tmpdir(), 'msw-'));
+  try {
+    dir = mkdtempSync(join(tmpdir(), 'msw-'));
+  } catch (error) {
+    mkdirSync(tmpdir());
+    dir = mkdtempSync(join(tmpdir(), 'msw-'));
+  }
 
   execa(process.execPath, [
     require.resolve('msw/cli'),


### PR DESCRIPTION
We found that when executing msw tests within a Docker container, a tmp
folder does not exist. With this change, a tmp folder is created in case
mkdtempSync fails.

Co-authored-by: Robert Kowalski <robert.kowalski@new-work.se>

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
