### PR TITLE
fix: warn on custom cache, add option for possibleTypes

### DIFF
--- a/packages/react-apollo/mixins/mixin.server.js
+++ b/packages/react-apollo/mixins/mixin.server.js
@@ -64,9 +64,20 @@ class GraphQLMixin extends Mixin {
   }
 
   getApolloCache() {
-    const { cache = new InMemoryCache({ possibleTypes }) } = this.options;
+    const { cache } = this.options;
 
-    return cache;
+    if (cache && process.env.NODE_ENV !== 'production') {
+      this.getLogger().warn(
+        'Custom Apollo Cache was used, this will lead to memory leaks, use custom setting `possibleTypes` instead'
+      );
+    }
+
+    return (
+      cache ??
+      new InMemoryCache({
+        possibleTypes: this.options.possibleTypes || possibleTypes,
+      })
+    );
   }
 
   async renderToFragments(element) {


### PR DESCRIPTION
when using a custom cache in the render, memory would grow very
fast.

run:

```
yarn
rm -rf node_modules/.cache/ && yarn build -p
clinic doctor -- node ./node_modules/.bin/hops serve
```

and in a seperate window a few times:

```
autocannon -c 50 http://localhost:8080/jobs/test
```

---

current users are now warned when they pass in a custom cache
instance and we are offering an option to pass in `possibleTypes`
via options.

in hops 16, we can remove custom caches.

Co-authored-by: Jonas Holland <jonas.holland@new-work.se>

This pull request closes issue # (_put the issue number here_)

<!-- This is a template. Feel free to remove the parts you do not need! Start with this line, for example -->

## Current state

<!-- explanation of the current state -->

## Changes introduced here

<!-- explanation of the changes you did in this pull request -->

## Checklist

- [ ] All commit messages adhere to the [appropriate format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) in order to trigger a correct release
- [ ] All code is written in untranspiled ECMAScript (ES 2017) and is formatted using [prettier](https://prettier.io)
- [ ] Necessary unit tests are added in order to ensure correct behavior
- [ ] Documentation has been added

<details>
<summary>Bors merge bot cheat sheet</summary>

We are using [bors-ng](https://github.com/bors-ng/bors-ng) to automate merging of our pull requests. The following table provides a summary of commands that are available to reviewers (members of this repository with push access) and delegates (in case of `bors delegate+` or `bors delegate=[list]`).

| Syntax | Description |
| --- | --- |
| bors merge | Run the test suite and push to master if it passes. Short for "reviewed: looks good." |
| bors merge- | Cancel an r+, r=, merge, or merge= |
| bors try | Run the test suite without pushing to master. |
| bors try- | Cancel a try |
| bors delegate+ | Allow the pull request author to merge their changes. |
| bors delegate=[list] | Allow the listed users to r+ this pull request's changes. |
| bors retry | Run the previous command a second time. |

This is a short collection of opinionated commands. For a full list of the commands read the [bors reference](https://bors.tech/documentation/).

</details>
