### PR TITLE
fix: link to correct `jest-preset-hops` package

### DIFF
--- a/packages/spec/integration/doctor/package.json
+++ b/packages/spec/integration/doctor/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "hops": "*",
-    "hops-preset-jest": "*",
+    "jest-preset-hops": "*",
     "react": "*"
   }
 }

--- a/packages/spec/integration/hops/package.json
+++ b/packages/spec/integration/hops/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "hops": "*",
-    "hops-preset-jest": "*",
+    "jest-preset-hops": "*",
     "react": "*",
     "react-helmet-async": "*",
     "react-router-dom": "*",

--- a/packages/spec/integration/jest-preset/package.json
+++ b/packages/spec/integration/jest-preset/package.json
@@ -16,6 +16,6 @@
     ]
   },
   "dependencies": {
-    "hops-preset-jest": "*"
+    "jest-preset-hops": "*"
   }
 }


### PR DESCRIPTION
Because [hops-preset-jest](https://www.npmjs.com/package/hops-preset-jest) doesn't exist in the Hops repo but is a malicious package on NPM now.

The internal package that was meant is called `jest-preset-hops`, not `hops-preset-jest`.